### PR TITLE
feat: add state snapshotting for event-sourced aggregates

### DIFF
--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -297,13 +297,13 @@ Update spec frontmatter: `status: implemented`
 **Run autonomously — no gate.**
 
 1. Read the spec's `docs` frontmatter field for explicitly mapped documentation pages.
-2. Grep `packages/docs/content/docs/` for references to the spec's exports (discover additional pages).
+2. Grep `docs/content/docs/` for references to the spec's exports (discover additional pages).
 3. For each affected documentation page:
    - Update code examples that use changed API signatures
    - Update explanatory text if behavioral requirements changed
    - Add deprecation notices if applicable
-4. If this is a new spec (new module), create stub documentation pages in the appropriate category under `packages/docs/content/docs/` and update the category's `meta.json`.
-5. Flag auto-generated API reference pages (in `packages/docs/src/content/docs/api/`) for regeneration if exports changed — do NOT manually edit them.
+4. If this is a new spec (new module), create stub documentation pages in the appropriate category under `docs/content/docs/` and update the category's `meta.json`.
+5. Flag auto-generated API reference pages (in `docs/src/content/docs/api/`) for regeneration if exports changed — do NOT manually edit them.
 6. Report briefly and continue to the Final Report:
    ```
    📖 Step 6 complete: Documentation updated

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -55,14 +55,14 @@ docs:
   - aggregates/defining-aggregates.mdx
 ```
 
-These paths are relative to `packages/docs/content/docs/`.
+These paths are relative to `docs/content/docs/`.
 
 ### Strategy 2: Grep for export references (secondary)
 
 Search for references to the spec's exported symbols in documentation:
 
 ```bash
-grep -rl "ExportName1\|ExportName2" packages/docs/content/docs/ --include="*.mdx"
+grep -rl "ExportName1\|ExportName2" docs/content/docs/ --include="*.mdx"
 ```
 
 This catches pages not listed in the `docs` frontmatter — for example, a `concepts/` or `design-decisions/` page that references `defineAggregate`.
@@ -71,10 +71,10 @@ Add any discovered pages NOT already in the `docs` list to the working set, but 
 
 ### Strategy 3: Check auto-generated API reference
 
-Search `packages/docs/src/content/docs/api/` for files matching the spec's exports:
+Search `docs/src/content/docs/api/` for files matching the spec's exports:
 
 ```bash
-ls packages/docs/src/content/docs/api/*/
+ls docs/src/content/docs/api/*/
 ```
 
 **Do NOT edit auto-generated API reference files.** Only flag them in the report if the API surface changed (new exports added, existing signatures changed).
@@ -169,7 +169,7 @@ If the module doesn't fit any category, flag it in the report for manual placeme
 
 ### 5b: Create the MDX Page
 
-Create a new file at `packages/docs/content/docs/<category>/<name>.mdx`:
+Create a new file at `docs/content/docs/<category>/<name>.mdx`:
 
 ```mdx
 ---
@@ -192,7 +192,7 @@ description: <One-line description of what this module does>
 
 ### 5c: Update `meta.json`
 
-Add the new page to the appropriate category's `meta.json` file at `packages/docs/content/docs/<category>/meta.json`.
+Add the new page to the appropriate category's `meta.json` file at `docs/content/docs/<category>/meta.json`.
 
 Read the existing `meta.json`, add the new page name (without extension) to the `pages` array in a logical position (usually at the end, unless there's a clear ordering).
 
@@ -200,7 +200,7 @@ Read the existing `meta.json`, add the new page name (without extension) to the 
 
 If the spec added new exports, removed exports, or changed existing signatures:
 
-1. List the affected auto-generated API pages in `packages/docs/src/content/docs/api/`
+1. List the affected auto-generated API pages in `docs/src/content/docs/api/`
 2. Note these in the report as needing regeneration
 3. **Do NOT manually edit these files** — they are auto-generated
 
@@ -210,11 +210,11 @@ If the spec added new exports, removed exports, or changed existing signatures:
 📖 Step 6 complete: Documentation updated
 
   Pages updated: <N>
-    - packages/docs/content/docs/<path>.mdx (<summary of changes>)
-    - packages/docs/content/docs/<path>.mdx (<summary of changes>)
+    - docs/content/docs/<path>.mdx (<summary of changes>)
+    - docs/content/docs/<path>.mdx (<summary of changes>)
 
   Pages created: <N>
-    - packages/docs/content/docs/<category>/<name>.mdx (new stub)
+    - docs/content/docs/<category>/<name>.mdx (new stub)
 
   API reference: <status>
     - <N> auto-generated pages may need regeneration (exports changed: <list>)
@@ -222,7 +222,7 @@ If the spec added new exports, removed exports, or changed existing signatures:
     - No API surface changes — auto-generated docs are up to date
 
   Flagged for review: <N>
-    - packages/docs/content/docs/<path>.mdx (prose may need updating — <reason>)
+    - docs/content/docs/<path>.mdx (prose may need updating — <reason>)
 
   No changes needed: <N> pages checked, all up to date
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ noddde is a TypeScript framework for building business applications using Domain
 - `packages/core/` — Types, interfaces, and definition functions (`@noddde/core`) — zero runtime dependencies
 - `packages/engine/` — Runtime: Domain orchestration + in-memory implementations (`@noddde/engine`) — depends on `@noddde/core`
 - `packages/samples/` — 3 sample domains (auction, banking, order-fulfillment)
-- `packages/docs/` — Fumadocs documentation site
+- `docs/` — Fumadocs documentation site
 - `specs/` — Spec-driven development specs (see below)
 
 ## Architecture Map
@@ -41,6 +41,7 @@ noddde is a TypeScript framework for building business applications using Domain
 | `infrastructure/index.ts`         | `Infrastructure` (empty base), `CQRSInfrastructure` (commandBus + eventBus + queryBus)   |
 | **persistence/**                  |                                                                                          |
 | `persistence/index.ts`            | `StateStoredAggregatePersistence`, `EventSourcedAggregatePersistence`, `SagaPersistence` |
+| `persistence/snapshot.ts`         | `Snapshot`, `SnapshotStore`, `SnapshotStrategy`, `PartialEventLoad`, `everyNEvents`      |
 
 ### Engine Source Files (`packages/engine/src/`)
 
@@ -53,6 +54,7 @@ noddde is a TypeScript framework for building business applications using Domain
 | `implementations/in-memory-query-bus.ts`             | `InMemoryQueryBus`                                                                    |
 | `implementations/in-memory-aggregate-persistence.ts` | `InMemoryEventSourcedAggregatePersistence`, `InMemoryStateStoredAggregatePersistence` |
 | `implementations/in-memory-saga-persistence.ts`      | `InMemorySagaPersistence`                                                             |
+| `implementations/in-memory-snapshot-store.ts`        | `InMemorySnapshotStore`                                                               |
 
 ### Key Patterns
 

--- a/docs/content/docs/running/domain-configuration.mdx
+++ b/docs/content/docs/running/domain-configuration.mdx
@@ -71,6 +71,8 @@ type DomainConfiguration<TInfrastructure extends Infrastructure> = {
     aggregateConcurrency?:
       | { strategy?: "optimistic"; maxRetries?: number }
       | { strategy: "pessimistic"; locker: AggregateLocker; lockTimeoutMs?: number };
+    snapshotStore?: () => SnapshotStore | Promise<SnapshotStore>;
+    snapshotStrategy?: SnapshotStrategy;
     sagaPersistence?: () => SagaPersistence | Promise<SagaPersistence>;
     provideInfrastructure?: () => TInfrastructure | Promise<TInfrastructure>;
     cqrsInfrastructure?: (infra: TInfrastructure) => CQRSInfrastructure | Promise<CQRSInfrastructure>;
@@ -217,6 +219,8 @@ The four providers are:
 - **`cqrsInfrastructure`** -- The three CQRS buses (CommandBus, EventBus, QueryBus)
 - **`aggregatePersistence`** -- The persistence strategy for aggregate state
 - **`aggregateConcurrency`** -- Concurrency strategy: optimistic (version check + retry, throws `ConcurrencyError`) or pessimistic (exclusive lock before load, throws `LockTimeoutError` on timeout). See [Concurrency Strategies](/docs/running/persistence#concurrency-control).
+- **`snapshotStore`** -- Factory function returning a `SnapshotStore` for caching event-sourced aggregate state. See [State Snapshotting](/docs/running/persistence#state-snapshotting-event-sourced-optimization).
+- **`snapshotStrategy`** -- A `SnapshotStrategy` function that decides when to take snapshots (e.g., `everyNEvents(100)`).
 - **`unitOfWorkFactory`** -- The factory for atomic command dispatch boundaries
 
 For a full treatment of each provider, how they are initialized, and how to swap them for testing, see the [Infrastructure](/docs/running/infrastructure) page.

--- a/docs/content/docs/running/orm-adapters.mdx
+++ b/docs/content/docs/running/orm-adapters.mdx
@@ -15,7 +15,7 @@ noddde provides three ORM adapter packages that implement all persistence interf
 
 ### Dialect Support Matrix
 
-Persistence (event store, state store, saga store) and [concurrency control](/docs/running/persistence#concurrency-control) work with **every dialect** supported by your ORM. The only dialect restriction applies to **pessimistic locking**, which requires database-level advisory locks:
+Persistence (event store, state store, saga store, snapshot store) and [concurrency control](/docs/running/persistence#concurrency-control) work with **every dialect** supported by your ORM. The only dialect restriction applies to **pessimistic locking**, which requires database-level advisory locks:
 
 | Dialect    | Persistence | No concurrency / Optimistic | Pessimistic locking  |
 | ---------- | ----------- | --------------------------- | -------------------- |
@@ -30,19 +30,26 @@ For SQLite or any dialect without advisory lock support, use `InMemoryAggregateL
 Each package exports a single factory function that returns all persistence implementations wired to share a transaction context:
 
 ```ts
-import { events, aggregateStates, sagaStates } from "@noddde/drizzle/pg";
+import {
+  events,
+  aggregateStates,
+  sagaStates,
+  snapshots,
+} from "@noddde/drizzle/pg";
 const infra = createDrizzlePersistence(db, {
   events,
   aggregateStates,
   sagaStates,
+  snapshots,
 });
 // or: createPrismaPersistence(prisma)
 // or: createTypeORMPersistence(dataSource)
 
 // Returns:
-// infra.eventSourcedPersistence  -- EventSourcedAggregatePersistence
+// infra.eventSourcedPersistence  -- EventSourcedAggregatePersistence & PartialEventLoad
 // infra.stateStoredPersistence   -- StateStoredAggregatePersistence
 // infra.sagaPersistence          -- SagaPersistence
+// infra.snapshotStore            -- SnapshotStore (Drizzle: only when snapshots schema provided)
 // infra.unitOfWorkFactory        -- UnitOfWorkFactory (real DB transactions)
 ```
 
@@ -62,13 +69,28 @@ The package exports convenience table definitions for each Drizzle dialect. Impo
 
 ```ts
 // SQLite
-import { events, aggregateStates, sagaStates } from "@noddde/drizzle/sqlite";
+import {
+  events,
+  aggregateStates,
+  sagaStates,
+  snapshots,
+} from "@noddde/drizzle/sqlite";
 
 // PostgreSQL (uses serial PK, jsonb for payloads)
-import { events, aggregateStates, sagaStates } from "@noddde/drizzle/pg";
+import {
+  events,
+  aggregateStates,
+  sagaStates,
+  snapshots,
+} from "@noddde/drizzle/pg";
 
 // MySQL (uses int auto-increment, varchar(255), json)
-import { events, aggregateStates, sagaStates } from "@noddde/drizzle/mysql";
+import {
+  events,
+  aggregateStates,
+  sagaStates,
+  snapshots,
+} from "@noddde/drizzle/mysql";
 ```
 
 You can also define your own tables matching the expected column structure -- the adapter does not require using the provided schemas.
@@ -79,13 +101,20 @@ You can also define your own tables matching the expected column structure -- th
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { createDrizzlePersistence } from "@noddde/drizzle";
-import { events, aggregateStates, sagaStates } from "@noddde/drizzle/sqlite";
+import {
+  events,
+  aggregateStates,
+  sagaStates,
+  snapshots,
+} from "@noddde/drizzle/sqlite";
+import { everyNEvents } from "@noddde/core";
 
 const db = drizzle(new Database("app.db"));
 const infra = createDrizzlePersistence(db, {
   events,
   aggregateStates,
   sagaStates,
+  snapshots,
 });
 
 const domain = await configureDomain({
@@ -94,6 +123,8 @@ const domain = await configureDomain({
   infrastructure: {
     aggregatePersistence: () => infra.eventSourcedPersistence,
     sagaPersistence: () => infra.sagaPersistence,
+    snapshotStore: () => infra.snapshotStore,
+    snapshotStrategy: everyNEvents(100),
     unitOfWorkFactory: () => infra.unitOfWorkFactory,
   },
 });
@@ -150,6 +181,16 @@ model NodddeSagaState {
   @@id([sagaName, sagaId])
   @@map("noddde_saga_states")
 }
+
+model NodddeSnapshot {
+  aggregateName String @map("aggregate_name")
+  aggregateId   String @map("aggregate_id")
+  state         String
+  version       Int    @default(0)
+
+  @@id([aggregateName, aggregateId])
+  @@map("noddde_snapshots")
+}
 ```
 
 Then run `prisma generate` and your preferred migration command.
@@ -159,6 +200,7 @@ Then run `prisma generate` and your preferred migration command.
 ```ts
 import { PrismaClient } from "@prisma/client";
 import { createPrismaPersistence } from "@noddde/prisma";
+import { everyNEvents } from "@noddde/core";
 
 const prisma = new PrismaClient();
 const infra = createPrismaPersistence(prisma);
@@ -169,6 +211,8 @@ const domain = await configureDomain({
   infrastructure: {
     aggregatePersistence: () => infra.eventSourcedPersistence,
     sagaPersistence: () => infra.sagaPersistence,
+    snapshotStore: () => infra.snapshotStore,
+    snapshotStrategy: everyNEvents(100),
     unitOfWorkFactory: () => infra.unitOfWorkFactory,
   },
 });
@@ -197,6 +241,7 @@ import {
   NodddeEventEntity,
   NodddeAggregateStateEntity,
   NodddeSagaStateEntity,
+  NodddeSnapshotEntity,
 } from "@noddde/typeorm";
 
 const dataSource = new DataSource({
@@ -206,6 +251,7 @@ const dataSource = new DataSource({
     NodddeEventEntity,
     NodddeAggregateStateEntity,
     NodddeSagaStateEntity,
+    NodddeSnapshotEntity,
   ],
   synchronize: true, // use migrations in production
 });
@@ -218,6 +264,7 @@ For production, use TypeORM migrations instead of `synchronize: true`.
 
 ```ts
 import { createTypeORMPersistence } from "@noddde/typeorm";
+import { everyNEvents } from "@noddde/core";
 
 const infra = createTypeORMPersistence(dataSource);
 
@@ -227,6 +274,8 @@ const domain = await configureDomain({
   infrastructure: {
     aggregatePersistence: () => infra.eventSourcedPersistence,
     sagaPersistence: () => infra.sagaPersistence,
+    snapshotStore: () => infra.snapshotStore,
+    snapshotStrategy: everyNEvents(100),
     unitOfWorkFactory: () => infra.unitOfWorkFactory,
   },
 });
@@ -285,11 +334,12 @@ Advisory locks are session-level, spanning beyond the database transaction. This
 
 All three adapters use the same logical schema:
 
-| Table                     | Purpose         | Key                                          | Columns                                                                                                                                                                                   |
-| ------------------------- | --------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `noddde_events`           | Event streams   | Auto-increment `id`                          | `aggregate_name`, `aggregate_id`, `sequence_number`, `event_name`, `payload` (JSON), `metadata` (JSON, nullable). Unique constraint on `(aggregate_name, aggregate_id, sequence_number)`. |
-| `noddde_aggregate_states` | State snapshots | Composite (`aggregate_name`, `aggregate_id`) | `state` (JSON), `version` (integer, default 0)                                                                                                                                            |
-| `noddde_saga_states`      | Saga state      | Composite (`saga_name`, `saga_id`)           | `state` (JSON)                                                                                                                                                                            |
+| Table                     | Purpose                 | Key                                          | Columns                                                                                                                                                                                   |
+| ------------------------- | ----------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `noddde_events`           | Event streams           | Auto-increment `id`                          | `aggregate_name`, `aggregate_id`, `sequence_number`, `event_name`, `payload` (JSON), `metadata` (JSON, nullable). Unique constraint on `(aggregate_name, aggregate_id, sequence_number)`. |
+| `noddde_aggregate_states` | State snapshots         | Composite (`aggregate_name`, `aggregate_id`) | `state` (JSON), `version` (integer, default 0)                                                                                                                                            |
+| `noddde_saga_states`      | Saga state              | Composite (`saga_name`, `saga_id`)           | `state` (JSON)                                                                                                                                                                            |
+| `noddde_snapshots`        | Event-sourced snapshots | Composite (`aggregate_name`, `aggregate_id`) | `state` (JSON), `version` (integer, default 0)                                                                                                                                            |
 
 States and event payloads are serialized as JSON strings, making the schema database-agnostic.
 

--- a/docs/content/docs/running/persistence.mdx
+++ b/docs/content/docs/running/persistence.mdx
@@ -52,6 +52,98 @@ interface StateStoredAggregatePersistence {
 - **`save`** overwrites the current state snapshot. The `expectedVersion` must match the stored version -- if it does not, a `ConcurrencyError` is thrown.
 - **`load`** returns the last saved state and version as `{ state, version }`, or `null` for new aggregates (version 0).
 
+### State Snapshotting (Event-Sourced Optimization)
+
+For long-lived aggregates with large event streams, replaying every event on each command dispatch becomes expensive. **State snapshotting** periodically caches the aggregate state at a known event stream version. On subsequent loads, the engine starts from the snapshot and replays only the events that occurred after it.
+
+Snapshots are not the source of truth — the event stream is. Deleting all snapshots is safe; the engine falls back to full replay.
+
+```ts
+interface Snapshot {
+  state: any;
+  version: number; // event stream version at snapshot time
+}
+
+interface SnapshotStore {
+  load(aggregateName: string, aggregateId: string): Promise<Snapshot | null>;
+  save(
+    aggregateName: string,
+    aggregateId: string,
+    snapshot: Snapshot,
+  ): Promise<void>;
+}
+```
+
+- **`load`** returns the latest snapshot, or `null` if none exists (triggers full replay).
+- **`save`** overwrites any previously stored snapshot for the same aggregate instance. Only the latest snapshot is kept.
+
+#### Snapshot Strategy
+
+A `SnapshotStrategy` is a pure function that decides whether to take a snapshot after each command. The built-in `everyNEvents` factory covers the common case:
+
+```ts
+import { everyNEvents } from "@noddde/core";
+
+// Snapshot every 100 events
+const strategy = everyNEvents(100);
+```
+
+You can also write custom strategies:
+
+```ts
+import type { SnapshotStrategy } from "@noddde/core";
+
+const customStrategy: SnapshotStrategy = ({ version, eventsSinceSnapshot }) => {
+  // Snapshot every 50 events, but always after the first event
+  return version === 1 || eventsSinceSnapshot >= 50;
+};
+```
+
+#### Configuring Snapshots
+
+Add `snapshotStore` and `snapshotStrategy` to the infrastructure section of your domain configuration:
+
+```ts
+import {
+  configureDomain,
+  InMemoryEventSourcedAggregatePersistence,
+  InMemorySnapshotStore,
+} from "@noddde/engine";
+import { everyNEvents } from "@noddde/core";
+
+const domain = await configureDomain<MyInfrastructure>({
+  writeModel: { aggregates: { BankAccount } },
+  readModel: { projections: {} },
+  infrastructure: {
+    aggregatePersistence: () => new InMemoryEventSourcedAggregatePersistence(),
+    snapshotStore: () => new InMemorySnapshotStore(),
+    snapshotStrategy: everyNEvents(100),
+  },
+});
+```
+
+Both `snapshotStore` and `snapshotStrategy` are optional. If either is omitted, no automatic snapshotting occurs.
+
+#### Partial Event Loading
+
+When a snapshot exists, the engine only needs events that occurred after it. If the persistence implementation also implements `PartialEventLoad`, the engine uses `loadAfterVersion()` to avoid loading the full event stream:
+
+```ts
+interface PartialEventLoad {
+  loadAfterVersion(
+    aggregateName: string,
+    aggregateId: string,
+    afterVersion: number,
+  ): Promise<Event[]>;
+}
+```
+
+The built-in `InMemoryEventSourcedAggregatePersistence` implements `PartialEventLoad`. If the persistence does not implement it, the engine falls back to `load()` + `Array.slice()` — correct, but less efficient for large streams.
+
+#### How Snapshot Saving Works
+
+Snapshots are saved **after** the unit of work commits, as a best-effort operation. A failed snapshot save does not roll back a successfully committed command — the engine silently catches the error. The next command that triggers the strategy will attempt to save again.
+
 ### Saga Persistence
 
 Sagas are always state-stored. The `SagaPersistence` interface mirrors the state-stored aggregate interface:
@@ -189,7 +281,17 @@ import { InMemoryEventSourcedAggregatePersistence } from "@noddde/engine";
 const persistence = new InMemoryEventSourcedAggregatePersistence();
 ```
 
-Stores event streams in memory, keyed by `(aggregateName, aggregateId)`.
+Stores event streams in memory, keyed by `(aggregateName, aggregateId)`. Also implements `PartialEventLoad` for optimized snapshot-based loading.
+
+### InMemorySnapshotStore
+
+```ts
+import { InMemorySnapshotStore } from "@noddde/engine";
+
+const snapshotStore = new InMemorySnapshotStore();
+```
+
+Stores aggregate state snapshots in memory, keyed by `(aggregateName, aggregateId)`. Each `save` overwrites the previous snapshot. Returns `null` for unknown aggregates.
 
 ### InMemoryStateStoredAggregatePersistence
 
@@ -225,15 +327,15 @@ The strategy is a configuration choice, not a modeling choice.
 
 ## Decision Matrix
 
-| Factor             | Event Sourcing    | State Storage          |
-| ------------------ | ----------------- | ---------------------- |
-| Audit trail        | Full history      | Current state only     |
-| Storage growth     | Grows with events | Constant per aggregate |
-| Load performance   | Slower (replay)   | Faster (direct read)   |
-| Projection rebuild | Possible          | Not possible           |
-| Temporal queries   | Supported         | Not supported          |
-| Complexity         | Higher            | Lower                  |
-| Debugging          | Excellent         | Standard               |
+| Factor             | Event Sourcing                                                                            | State Storage          |
+| ------------------ | ----------------------------------------------------------------------------------------- | ---------------------- |
+| Audit trail        | Full history                                                                              | Current state only     |
+| Storage growth     | Grows with events                                                                         | Constant per aggregate |
+| Load performance   | Slower (replay, mitigated by [snapshots](#state-snapshotting-event-sourced-optimization)) | Faster (direct read)   |
+| Projection rebuild | Possible                                                                                  | Not possible           |
+| Temporal queries   | Supported                                                                                 | Not supported          |
+| Complexity         | Higher                                                                                    | Lower                  |
+| Debugging          | Excellent                                                                                 | Standard               |
 
 ### When to Choose Event Sourcing
 
@@ -333,6 +435,7 @@ noddde provides three ORM adapter packages that cover persistence and [unit of w
 | `InMemoryEventSourcedAggregatePersistence` | `@noddde/drizzle`, `@noddde/prisma`, or `@noddde/typeorm` |
 | `InMemoryStateStoredAggregatePersistence`  | `@noddde/drizzle`, `@noddde/prisma`, or `@noddde/typeorm` |
 | `InMemorySagaPersistence`                  | `@noddde/drizzle`, `@noddde/prisma`, or `@noddde/typeorm` |
+| `InMemorySnapshotStore`                    | `@noddde/drizzle`, `@noddde/prisma`, or `@noddde/typeorm` |
 
 Each adapter provides a single factory function that creates all persistence implementations wired to share a database transaction context. Your aggregate and projection code remains unchanged -- only the infrastructure factories in `configureDomain` need to be updated.
 

--- a/packages/adapters/drizzle/src/__tests__/drizzle.test.ts
+++ b/packages/adapters/drizzle/src/__tests__/drizzle.test.ts
@@ -2,8 +2,14 @@ import { describe, it, expect } from "vitest";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { ConcurrencyError } from "@noddde/core";
+import type { PartialEventLoad } from "@noddde/core";
 import { createDrizzlePersistence } from "../index";
-import { events, aggregateStates, sagaStates } from "../sqlite/schema";
+import {
+  events,
+  aggregateStates,
+  sagaStates,
+  snapshots,
+} from "../sqlite/schema";
 
 function createTestDb() {
   const sqlite = new Database(":memory:");
@@ -31,6 +37,13 @@ function createTestDb() {
       saga_id TEXT NOT NULL,
       state TEXT NOT NULL,
       PRIMARY KEY (saga_name, saga_id)
+    );
+    CREATE TABLE noddde_snapshots (
+      aggregate_name TEXT NOT NULL,
+      aggregate_id TEXT NOT NULL,
+      state TEXT NOT NULL,
+      version INTEGER NOT NULL,
+      PRIMARY KEY (aggregate_name, aggregate_id)
     );
   `);
   return drizzle(sqlite);
@@ -360,5 +373,169 @@ describe("Drizzle Multi-Dialect Persistence", () => {
     await expect(uow.rollback()).rejects.toThrow(
       "UnitOfWork already completed",
     );
+  });
+
+  it("snapshot store: save and load roundtrip", async () => {
+    const db = createTestDb();
+    const infra = createDrizzlePersistence(db, {
+      events,
+      aggregateStates,
+      sagaStates,
+      snapshots,
+    });
+
+    expect(infra.snapshotStore).toBeDefined();
+    const store = infra.snapshotStore!;
+
+    await store.save("Order", "order-1", {
+      state: { status: "confirmed", total: 100 },
+      version: 5,
+    });
+
+    const loaded = await store.load("Order", "order-1");
+    expect(loaded).toEqual({
+      state: { status: "confirmed", total: 100 },
+      version: 5,
+    });
+  });
+
+  it("snapshot store: returns null for unknown aggregate", async () => {
+    const db = createTestDb();
+    const infra = createDrizzlePersistence(db, {
+      events,
+      aggregateStates,
+      sagaStates,
+      snapshots,
+    });
+
+    const loaded = await infra.snapshotStore!.load("Order", "nonexistent");
+    expect(loaded).toBeNull();
+  });
+
+  it("snapshot store: overwrites on repeated saves", async () => {
+    const db = createTestDb();
+    const infra = createDrizzlePersistence(db, {
+      events,
+      aggregateStates,
+      sagaStates,
+      snapshots,
+    });
+    const store = infra.snapshotStore!;
+
+    await store.save("Order", "order-1", {
+      state: { status: "placed" },
+      version: 1,
+    });
+    await store.save("Order", "order-1", {
+      state: { status: "confirmed" },
+      version: 3,
+    });
+
+    const loaded = await store.load("Order", "order-1");
+    expect(loaded).toEqual({
+      state: { status: "confirmed" },
+      version: 3,
+    });
+  });
+
+  it("snapshotStore is not present when schema.snapshots is not provided", () => {
+    const db = createTestDb();
+    const infra = createDrizzlePersistence(db, {
+      events,
+      aggregateStates,
+      sagaStates,
+    });
+
+    expect(infra.snapshotStore).toBeUndefined();
+  });
+
+  it("loadAfterVersion: returns events after given version", async () => {
+    const db = createTestDb();
+    const infra = createDrizzlePersistence(db, {
+      events,
+      aggregateStates,
+      sagaStates,
+      snapshots,
+    });
+    const persistence =
+      infra.eventSourcedPersistence as typeof infra.eventSourcedPersistence &
+        PartialEventLoad;
+
+    await persistence.save(
+      "Order",
+      "order-1",
+      [
+        { name: "OrderPlaced", payload: { total: 100 } },
+        { name: "OrderConfirmed", payload: {} },
+        { name: "OrderShipped", payload: { trackingId: "T1" } },
+      ],
+      0,
+    );
+
+    const afterV1 = await persistence.loadAfterVersion("Order", "order-1", 1);
+    expect(afterV1).toHaveLength(2);
+    expect(afterV1[0]!.name).toBe("OrderConfirmed");
+    expect(afterV1[1]!.name).toBe("OrderShipped");
+
+    const afterV2 = await persistence.loadAfterVersion("Order", "order-1", 2);
+    expect(afterV2).toHaveLength(1);
+    expect(afterV2[0]!.name).toBe("OrderShipped");
+  });
+
+  it("loadAfterVersion: returns empty array when afterVersion >= stream length", async () => {
+    const db = createTestDb();
+    const infra = createDrizzlePersistence(db, {
+      events,
+      aggregateStates,
+      sagaStates,
+      snapshots,
+    });
+    const persistence =
+      infra.eventSourcedPersistence as typeof infra.eventSourcedPersistence &
+        PartialEventLoad;
+
+    await persistence.save(
+      "Order",
+      "order-1",
+      [
+        { name: "OrderPlaced", payload: {} },
+        { name: "OrderConfirmed", payload: {} },
+      ],
+      0,
+    );
+
+    const afterV2 = await persistence.loadAfterVersion("Order", "order-1", 2);
+    expect(afterV2).toEqual([]);
+
+    const afterV10 = await persistence.loadAfterVersion("Order", "order-1", 10);
+    expect(afterV10).toEqual([]);
+  });
+
+  it("loadAfterVersion: returns all events when afterVersion is 0", async () => {
+    const db = createTestDb();
+    const infra = createDrizzlePersistence(db, {
+      events,
+      aggregateStates,
+      sagaStates,
+      snapshots,
+    });
+    const persistence =
+      infra.eventSourcedPersistence as typeof infra.eventSourcedPersistence &
+        PartialEventLoad;
+
+    await persistence.save(
+      "Order",
+      "order-1",
+      [
+        { name: "OrderPlaced", payload: {} },
+        { name: "OrderConfirmed", payload: {} },
+      ],
+      0,
+    );
+
+    const all = await persistence.loadAfterVersion("Order", "order-1", 0);
+    expect(all).toHaveLength(2);
+    expect(all[0]!.name).toBe("OrderPlaced");
+    expect(all[1]!.name).toBe("OrderConfirmed");
   });
 });

--- a/packages/adapters/drizzle/src/index.ts
+++ b/packages/adapters/drizzle/src/index.ts
@@ -5,13 +5,17 @@ import type {
   EventSourcedAggregatePersistence,
   StateStoredAggregatePersistence,
   SagaPersistence,
+  SnapshotStore,
 } from "@noddde/core";
 import {
   DrizzleEventSourcedAggregatePersistence,
   DrizzleStateStoredAggregatePersistence,
   DrizzleSagaPersistence,
+  DrizzleSnapshotStore,
 } from "./persistence";
 import { createDrizzleUnitOfWorkFactory } from "./unit-of-work";
+
+export { DrizzleSnapshotStore } from "./persistence";
 
 /**
  * Schema tables the developer passes to the factory.
@@ -31,6 +35,8 @@ export interface DrizzleNodddeSchema {
   aggregateStates: any;
   /** Saga states table with columns: sagaName, sagaId, state */
   sagaStates: any;
+  /** Snapshots table with columns: aggregateName, aggregateId, state, version. Optional — only needed if using snapshot store. */
+  snapshots?: any;
 }
 
 /**
@@ -57,6 +63,8 @@ export interface DrizzlePersistenceInfrastructure {
   sagaPersistence: SagaPersistence;
   /** Factory for creating Drizzle-backed UnitOfWork instances. */
   unitOfWorkFactory: UnitOfWorkFactory;
+  /** Snapshot store for event-sourced aggregates. Present only when schema.snapshots is provided. */
+  snapshotStore?: SnapshotStore;
 }
 
 /**
@@ -100,7 +108,7 @@ export function createDrizzlePersistence(
 ): DrizzlePersistenceInfrastructure {
   const txStore: DrizzleTransactionStore = { current: null };
 
-  return {
+  const result: DrizzlePersistenceInfrastructure = {
     eventSourcedPersistence: new DrizzleEventSourcedAggregatePersistence(
       db,
       txStore,
@@ -114,4 +122,10 @@ export function createDrizzlePersistence(
     sagaPersistence: new DrizzleSagaPersistence(db, txStore, schema),
     unitOfWorkFactory: createDrizzleUnitOfWorkFactory(db, txStore),
   };
+
+  if (schema.snapshots) {
+    result.snapshotStore = new DrizzleSnapshotStore(db, txStore, schema);
+  }
+
+  return result;
 }

--- a/packages/adapters/drizzle/src/mysql/schema.ts
+++ b/packages/adapters/drizzle/src/mysql/schema.ts
@@ -53,3 +53,15 @@ export const sagaStates = mysqlTable("noddde_saga_states", {
   sagaId: varchar("saga_id", { length: 255 }).notNull(),
   state: text("state").notNull(),
 });
+
+/**
+ * MySQL table definition for aggregate state snapshots.
+ * Stores the latest snapshot per aggregate instance for
+ * optimized event-sourced aggregate loading.
+ */
+export const snapshots = mysqlTable("noddde_snapshots", {
+  aggregateName: varchar("aggregate_name", { length: 255 }).notNull(),
+  aggregateId: varchar("aggregate_id", { length: 255 }).notNull(),
+  state: text("state").notNull(),
+  version: int("version").notNull(),
+});

--- a/packages/adapters/drizzle/src/persistence.ts
+++ b/packages/adapters/drizzle/src/persistence.ts
@@ -1,9 +1,12 @@
 /* eslint-disable no-unused-vars */
-import { eq, and, asc } from "drizzle-orm";
+import { eq, and, asc, gt } from "drizzle-orm";
 import {
   ConcurrencyError,
   type Event,
   type EventSourcedAggregatePersistence,
+  type PartialEventLoad,
+  type Snapshot,
+  type SnapshotStore,
   type StateStoredAggregatePersistence,
   type SagaPersistence,
 } from "@noddde/core";
@@ -16,7 +19,7 @@ import type { DrizzleTransactionStore, DrizzleNodddeSchema } from "./index";
  * schema tables as constructor parameters.
  */
 export class DrizzleEventSourcedAggregatePersistence
-  implements EventSourcedAggregatePersistence
+  implements EventSourcedAggregatePersistence, PartialEventLoad
 {
   constructor(
     private readonly db: any,
@@ -81,6 +84,44 @@ export class DrizzleEventSourcedAggregatePersistence
         and(
           eq(eventsTable.aggregateName, aggregateName),
           eq(eventsTable.aggregateId, aggregateId),
+        ),
+      )
+      .orderBy(asc(eventsTable.sequenceNumber));
+
+    return rows.map((row: any) => {
+      const event: Event = {
+        name: row.eventName,
+        payload: row.payload,
+      };
+      if (row.metadata != null) {
+        const meta =
+          typeof row.metadata === "string"
+            ? JSON.parse(row.metadata)
+            : row.metadata;
+        if (meta != null) {
+          event.metadata = meta;
+        }
+      }
+      return event;
+    });
+  }
+
+  async loadAfterVersion(
+    aggregateName: string,
+    aggregateId: string,
+    afterVersion: number,
+  ): Promise<Event[]> {
+    const executor = this.getExecutor();
+    const eventsTable = this.schema.events;
+
+    const rows = await executor
+      .select()
+      .from(eventsTable)
+      .where(
+        and(
+          eq(eventsTable.aggregateName, aggregateName),
+          eq(eventsTable.aggregateId, aggregateId),
+          gt(eventsTable.sequenceNumber, afterVersion),
         ),
       )
       .orderBy(asc(eventsTable.sequenceNumber));
@@ -260,5 +301,91 @@ export class DrizzleSagaPersistence implements SagaPersistence {
 
     if (rows.length === 0) return undefined;
     return JSON.parse(rows[0]!.state);
+  }
+}
+
+/**
+ * Drizzle-backed snapshot store for event-sourced aggregates.
+ * Stores and retrieves state snapshots to avoid full event stream
+ * replay. Dialect-agnostic — accepts schema tables as constructor parameters.
+ */
+export class DrizzleSnapshotStore implements SnapshotStore {
+  constructor(
+    private readonly db: any,
+    private readonly txStore: DrizzleTransactionStore,
+    private readonly schema: DrizzleNodddeSchema,
+  ) {}
+
+  private getExecutor() {
+    return this.txStore.current ?? this.db;
+  }
+
+  async load(
+    aggregateName: string,
+    aggregateId: string,
+  ): Promise<Snapshot | null> {
+    const executor = this.getExecutor();
+    const table = this.schema.snapshots;
+    if (!table) return null;
+
+    const rows = await executor
+      .select()
+      .from(table)
+      .where(
+        and(
+          eq(table.aggregateName, aggregateName),
+          eq(table.aggregateId, aggregateId),
+        ),
+      );
+
+    if (rows.length === 0) return null;
+    const row = rows[0]!;
+    const state =
+      typeof row.state === "string" ? JSON.parse(row.state) : row.state;
+    return { state, version: row.version };
+  }
+
+  async save(
+    aggregateName: string,
+    aggregateId: string,
+    snapshot: Snapshot,
+  ): Promise<void> {
+    const executor = this.getExecutor();
+    const table = this.schema.snapshots;
+    if (!table) return;
+
+    const serialized =
+      typeof snapshot.state === "string"
+        ? snapshot.state
+        : JSON.stringify(snapshot.state);
+
+    const existing = await executor
+      .select()
+      .from(table)
+      .where(
+        and(
+          eq(table.aggregateName, aggregateName),
+          eq(table.aggregateId, aggregateId),
+        ),
+      );
+
+    if (existing.length > 0) {
+      await executor
+        .update(table)
+        .set({ state: serialized, version: snapshot.version })
+        .where(
+          and(
+            eq(table.aggregateName, aggregateName),
+            eq(table.aggregateId, aggregateId),
+          ),
+        );
+    } else {
+      await executor.insert(table).values({
+        aggregateName,
+        aggregateId,
+        state: serialized,
+        version: snapshot.version,
+      });
+    }
   }
 }

--- a/packages/adapters/drizzle/src/pg/schema.ts
+++ b/packages/adapters/drizzle/src/pg/schema.ts
@@ -54,3 +54,16 @@ export const sagaStates = pgTable("noddde_saga_states", {
   sagaId: text("saga_id").notNull(),
   state: jsonb("state").notNull(),
 });
+
+/**
+ * PostgreSQL table definition for aggregate state snapshots.
+ * Stores the latest snapshot per aggregate instance for
+ * optimized event-sourced aggregate loading.
+ * Uses `jsonb` for native JSON storage with indexing support.
+ */
+export const snapshots = pgTable("noddde_snapshots", {
+  aggregateName: text("aggregate_name").notNull(),
+  aggregateId: text("aggregate_id").notNull(),
+  state: jsonb("state").notNull(),
+  version: integer("version").notNull(),
+});

--- a/packages/adapters/drizzle/src/sqlite/schema.ts
+++ b/packages/adapters/drizzle/src/sqlite/schema.ts
@@ -49,3 +49,15 @@ export const sagaStates = sqliteTable("noddde_saga_states", {
   sagaId: text("saga_id").notNull(),
   state: text("state").notNull(),
 });
+
+/**
+ * SQLite table definition for aggregate state snapshots.
+ * Stores the latest snapshot per aggregate instance for
+ * optimized event-sourced aggregate loading.
+ */
+export const snapshots = sqliteTable("noddde_snapshots", {
+  aggregateName: text("aggregate_name").notNull(),
+  aggregateId: text("aggregate_id").notNull(),
+  state: text("state").notNull(),
+  version: integer("version").notNull(),
+});

--- a/packages/adapters/prisma/prisma/schema.prisma
+++ b/packages/adapters/prisma/prisma/schema.prisma
@@ -41,3 +41,14 @@ model NodddeSagaState {
   @@id([sagaName, sagaId])
   @@map("noddde_saga_states")
 }
+
+/// Snapshots table for event-sourced aggregate state snapshotting.
+model NodddeSnapshot {
+  aggregateName String @map("aggregate_name")
+  aggregateId   String @map("aggregate_id")
+  state         String
+  version       Int
+
+  @@id([aggregateName, aggregateId])
+  @@map("noddde_snapshots")
+}

--- a/packages/adapters/prisma/src/__tests__/prisma.test.ts
+++ b/packages/adapters/prisma/src/__tests__/prisma.test.ts
@@ -4,6 +4,10 @@ import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import { ConcurrencyError } from "@noddde/core";
+import type {
+  PartialEventLoad,
+  EventSourcedAggregatePersistence,
+} from "@noddde/core";
 import { createPrismaPersistence, PrismaAdvisoryLocker } from "../index";
 
 const TEST_DB = path.resolve(__dirname, "../../prisma/test.db");
@@ -277,6 +281,117 @@ describe("PrismaUnitOfWork", () => {
 
     const events = await infra.eventSourcedPersistence.load("Account", "acc-1");
     expect(events).toEqual([]);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Snapshot Store
+// ═══════════════════════════════════════════════════════════════════
+
+describe("PrismaSnapshotStore", () => {
+  beforeEach(setupDb);
+  afterEach(teardownDb);
+
+  it("should save and load a snapshot", async () => {
+    await infra.snapshotStore.save("Account", "acc-1", {
+      state: { balance: 500 },
+      version: 5,
+    });
+    const snapshot = await infra.snapshotStore.load("Account", "acc-1");
+    expect(snapshot).toEqual({ state: { balance: 500 }, version: 5 });
+  });
+
+  it("should return null for unknown aggregate", async () => {
+    const snapshot = await infra.snapshotStore.load("Account", "nonexistent");
+    expect(snapshot).toBeNull();
+  });
+
+  it("should overwrite snapshot on repeated saves", async () => {
+    await infra.snapshotStore.save("Account", "acc-1", {
+      state: { balance: 100 },
+      version: 2,
+    });
+    await infra.snapshotStore.save("Account", "acc-1", {
+      state: { balance: 500 },
+      version: 5,
+    });
+    const snapshot = await infra.snapshotStore.load("Account", "acc-1");
+    expect(snapshot).toEqual({ state: { balance: 500 }, version: 5 });
+  });
+
+  it("should isolate snapshots by aggregate name", async () => {
+    await infra.snapshotStore.save("Account", "1", {
+      state: { balance: 100 },
+      version: 2,
+    });
+    await infra.snapshotStore.save("Order", "1", {
+      state: { total: 200 },
+      version: 3,
+    });
+    const account = await infra.snapshotStore.load("Account", "1");
+    const order = await infra.snapshotStore.load("Order", "1");
+    expect(account).toEqual({ state: { balance: 100 }, version: 2 });
+    expect(order).toEqual({ state: { total: 200 }, version: 3 });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// PartialEventLoad (loadAfterVersion)
+// ═══════════════════════════════════════════════════════════════════
+
+describe("PrismaEventSourcedAggregatePersistence - PartialEventLoad", () => {
+  beforeEach(setupDb);
+  afterEach(teardownDb);
+
+  it("should load events after a given version", async () => {
+    await infra.eventSourcedPersistence.save(
+      "Account",
+      "acc-1",
+      [
+        { name: "AccountCreated", payload: { owner: "Alice" } },
+        { name: "DepositMade", payload: { amount: 100 } },
+        { name: "DepositMade", payload: { amount: 200 } },
+      ],
+      0,
+    );
+    const persistence =
+      infra.eventSourcedPersistence as EventSourcedAggregatePersistence &
+        PartialEventLoad;
+    const events = await persistence.loadAfterVersion("Account", "acc-1", 1);
+    expect(events).toHaveLength(2);
+    expect(events[0]!.name).toBe("DepositMade");
+    expect(events[0]!.payload).toEqual({ amount: 100 });
+  });
+
+  it("should return empty array when afterVersion >= stream length", async () => {
+    await infra.eventSourcedPersistence.save(
+      "Account",
+      "acc-1",
+      [{ name: "AccountCreated", payload: { owner: "Alice" } }],
+      0,
+    );
+    const persistence =
+      infra.eventSourcedPersistence as EventSourcedAggregatePersistence &
+        PartialEventLoad;
+    const events = await persistence.loadAfterVersion("Account", "acc-1", 99);
+    expect(events).toEqual([]);
+  });
+
+  it("should return all events when afterVersion is 0", async () => {
+    await infra.eventSourcedPersistence.save(
+      "Account",
+      "acc-1",
+      [
+        { name: "AccountCreated", payload: { owner: "Alice" } },
+        { name: "DepositMade", payload: { amount: 50 } },
+      ],
+      0,
+    );
+    const persistence =
+      infra.eventSourcedPersistence as EventSourcedAggregatePersistence &
+        PartialEventLoad;
+    const events = await persistence.loadAfterVersion("Account", "acc-1", 0);
+    expect(events).toHaveLength(2);
   });
 });
 

--- a/packages/adapters/prisma/src/index.ts
+++ b/packages/adapters/prisma/src/index.ts
@@ -2,6 +2,7 @@ export {
   PrismaEventSourcedAggregatePersistence,
   PrismaStateStoredAggregatePersistence,
   PrismaSagaPersistence,
+  PrismaSnapshotStore,
 } from "./persistence";
 export { PrismaAdvisoryLocker } from "./advisory-locker";
 export {
@@ -11,7 +12,7 @@ export {
 export type { PrismaTransactionStore } from "./unit-of-work";
 
 import type { PrismaClient } from "@prisma/client";
-import type { UnitOfWorkFactory } from "@noddde/core";
+import type { UnitOfWorkFactory, SnapshotStore } from "@noddde/core";
 import type {
   EventSourcedAggregatePersistence,
   StateStoredAggregatePersistence,
@@ -21,6 +22,7 @@ import {
   PrismaEventSourcedAggregatePersistence,
   PrismaStateStoredAggregatePersistence,
   PrismaSagaPersistence,
+  PrismaSnapshotStore,
 } from "./persistence";
 import { createPrismaUnitOfWorkFactory } from "./unit-of-work";
 import type { PrismaTransactionStore } from "./unit-of-work";
@@ -32,6 +34,7 @@ export interface PrismaPersistenceInfrastructure {
   eventSourcedPersistence: EventSourcedAggregatePersistence;
   stateStoredPersistence: StateStoredAggregatePersistence;
   sagaPersistence: SagaPersistence;
+  snapshotStore: SnapshotStore;
   unitOfWorkFactory: UnitOfWorkFactory;
 }
 
@@ -75,6 +78,7 @@ export function createPrismaPersistence(
       txStore,
     ),
     sagaPersistence: new PrismaSagaPersistence(prisma, txStore),
+    snapshotStore: new PrismaSnapshotStore(prisma, txStore),
     unitOfWorkFactory: createPrismaUnitOfWorkFactory(prisma, txStore),
   };
 }

--- a/packages/adapters/prisma/src/persistence.ts
+++ b/packages/adapters/prisma/src/persistence.ts
@@ -5,6 +5,9 @@ import type {
   EventSourcedAggregatePersistence,
   StateStoredAggregatePersistence,
   SagaPersistence,
+  PartialEventLoad,
+  Snapshot,
+  SnapshotStore,
 } from "@noddde/core";
 import { ConcurrencyError } from "@noddde/core";
 import type { PrismaTransactionStore } from "./unit-of-work";
@@ -17,7 +20,7 @@ type PrismaExecutor =
  * Prisma-backed event-sourced aggregate persistence.
  */
 export class PrismaEventSourcedAggregatePersistence
-  implements EventSourcedAggregatePersistence
+  implements EventSourcedAggregatePersistence, PartialEventLoad
 {
   constructor(
     private readonly prisma: PrismaClient,
@@ -71,6 +74,29 @@ export class PrismaEventSourcedAggregatePersistence
 
     const rows = await executor.nodddeEvent.findMany({
       where: { aggregateName, aggregateId },
+      orderBy: { sequenceNumber: "asc" },
+    });
+
+    return rows.map((row: any) => ({
+      name: row.eventName,
+      payload: JSON.parse(row.payload),
+      ...(row.metadata ? { metadata: JSON.parse(row.metadata) } : {}),
+    }));
+  }
+
+  async loadAfterVersion(
+    aggregateName: string,
+    aggregateId: string,
+    afterVersion: number,
+  ): Promise<Event[]> {
+    const executor = this.getExecutor() as any;
+
+    const rows = await executor.nodddeEvent.findMany({
+      where: {
+        aggregateName,
+        aggregateId,
+        sequenceNumber: { gt: afterVersion },
+      },
       orderBy: { sequenceNumber: "asc" },
     });
 
@@ -207,5 +233,68 @@ export class PrismaSagaPersistence implements SagaPersistence {
 
     if (!row) return undefined;
     return JSON.parse(row.state);
+  }
+}
+
+/**
+ * Prisma-backed snapshot store for event-sourced aggregate state snapshotting.
+ */
+export class PrismaSnapshotStore implements SnapshotStore {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly txStore: PrismaTransactionStore,
+  ) {}
+
+  private getExecutor(): PrismaExecutor {
+    return (this.txStore.current ?? this.prisma) as PrismaExecutor;
+  }
+
+  async load(
+    aggregateName: string,
+    aggregateId: string,
+  ): Promise<Snapshot | null> {
+    const executor = this.getExecutor() as any;
+
+    const row = await executor.nodddeSnapshot.findUnique({
+      where: {
+        aggregateName_aggregateId: { aggregateName, aggregateId },
+      },
+    });
+
+    if (!row) return null;
+    return { state: JSON.parse(row.state), version: row.version };
+  }
+
+  async save(
+    aggregateName: string,
+    aggregateId: string,
+    snapshot: Snapshot,
+  ): Promise<void> {
+    const executor = this.getExecutor() as any;
+    const serialized = JSON.stringify(snapshot.state);
+
+    const existing = await executor.nodddeSnapshot.findUnique({
+      where: {
+        aggregateName_aggregateId: { aggregateName, aggregateId },
+      },
+    });
+
+    if (existing) {
+      await executor.nodddeSnapshot.update({
+        where: {
+          aggregateName_aggregateId: { aggregateName, aggregateId },
+        },
+        data: { state: serialized, version: snapshot.version },
+      });
+    } else {
+      await executor.nodddeSnapshot.create({
+        data: {
+          aggregateName,
+          aggregateId,
+          state: serialized,
+          version: snapshot.version,
+        },
+      });
+    }
   }
 }

--- a/packages/adapters/typeorm/src/__tests__/typeorm.test.ts
+++ b/packages/adapters/typeorm/src/__tests__/typeorm.test.ts
@@ -7,7 +7,9 @@ import {
   NodddeEventEntity,
   NodddeAggregateStateEntity,
   NodddeSagaStateEntity,
+  NodddeSnapshotEntity,
 } from "../entities";
+import { TypeORMEventSourcedAggregatePersistence } from "../persistence";
 
 let dataSource: DataSource;
 let infra: ReturnType<typeof createTypeORMPersistence>;
@@ -20,6 +22,7 @@ async function setupDb() {
       NodddeEventEntity,
       NodddeAggregateStateEntity,
       NodddeSagaStateEntity,
+      NodddeSnapshotEntity,
     ],
     synchronize: true,
   });
@@ -287,6 +290,131 @@ describe("TypeORMUnitOfWork", () => {
     await uow.rollback();
 
     const events = await infra.eventSourcedPersistence.load("Account", "acc-1");
+    expect(events).toEqual([]);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Snapshot Store
+// ═══════════════════════════════════════════════════════════════════
+
+describe("TypeORMSnapshotStore", () => {
+  beforeEach(setupDb);
+  afterEach(teardownDb);
+
+  it("should save and load a snapshot", async () => {
+    await infra.snapshotStore.save("Account", "acc-1", {
+      state: { balance: 500 },
+      version: 10,
+    });
+    const snapshot = await infra.snapshotStore.load("Account", "acc-1");
+    expect(snapshot).toEqual({ state: { balance: 500 }, version: 10 });
+  });
+
+  it("should return null for unknown aggregate", async () => {
+    const snapshot = await infra.snapshotStore.load("Account", "nonexistent");
+    expect(snapshot).toBeNull();
+  });
+
+  it("should overwrite snapshot on repeated saves", async () => {
+    await infra.snapshotStore.save("Account", "acc-1", {
+      state: { balance: 100 },
+      version: 5,
+    });
+    await infra.snapshotStore.save("Account", "acc-1", {
+      state: { balance: 300 },
+      version: 15,
+    });
+    const snapshot = await infra.snapshotStore.load("Account", "acc-1");
+    expect(snapshot).toEqual({ state: { balance: 300 }, version: 15 });
+  });
+
+  it("should isolate snapshots by aggregate name and id", async () => {
+    await infra.snapshotStore.save("Order", "1", {
+      state: { total: 200 },
+      version: 3,
+    });
+    await infra.snapshotStore.save("Account", "1", {
+      state: { balance: 100 },
+      version: 7,
+    });
+
+    const orderSnapshot = await infra.snapshotStore.load("Order", "1");
+    const accountSnapshot = await infra.snapshotStore.load("Account", "1");
+    expect(orderSnapshot).toEqual({ state: { total: 200 }, version: 3 });
+    expect(accountSnapshot).toEqual({ state: { balance: 100 }, version: 7 });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Partial Event Load (loadAfterVersion)
+// ═══════════════════════════════════════════════════════════════════
+
+describe("TypeORMEventSourcedAggregatePersistence (loadAfterVersion)", () => {
+  beforeEach(setupDb);
+  afterEach(teardownDb);
+
+  it("should load events after a given version", async () => {
+    await infra.eventSourcedPersistence.save(
+      "Account",
+      "acc-1",
+      [
+        { name: "AccountCreated", payload: { owner: "Alice" } },
+        { name: "DepositMade", payload: { amount: 100 } },
+        { name: "DepositMade", payload: { amount: 50 } },
+      ],
+      0,
+    );
+
+    const persistence =
+      infra.eventSourcedPersistence as TypeORMEventSourcedAggregatePersistence;
+    const events = await persistence.loadAfterVersion("Account", "acc-1", 1);
+    expect(events).toHaveLength(2);
+    expect(events[0]!.name).toBe("DepositMade");
+    expect(events[0]!.payload).toEqual({ amount: 100 });
+    expect(events[1]!.name).toBe("DepositMade");
+    expect(events[1]!.payload).toEqual({ amount: 50 });
+  });
+
+  it("should return all events when afterVersion is 0", async () => {
+    await infra.eventSourcedPersistence.save(
+      "Account",
+      "acc-1",
+      [
+        { name: "AccountCreated", payload: { owner: "Alice" } },
+        { name: "DepositMade", payload: { amount: 100 } },
+      ],
+      0,
+    );
+
+    const persistence =
+      infra.eventSourcedPersistence as TypeORMEventSourcedAggregatePersistence;
+    const events = await persistence.loadAfterVersion("Account", "acc-1", 0);
+    expect(events).toHaveLength(2);
+  });
+
+  it("should return empty array when afterVersion >= stream length", async () => {
+    await infra.eventSourcedPersistence.save(
+      "Account",
+      "acc-1",
+      [{ name: "AccountCreated", payload: { owner: "Alice" } }],
+      0,
+    );
+
+    const persistence =
+      infra.eventSourcedPersistence as TypeORMEventSourcedAggregatePersistence;
+    const events = await persistence.loadAfterVersion("Account", "acc-1", 10);
+    expect(events).toEqual([]);
+  });
+
+  it("should return empty array for unknown aggregate", async () => {
+    const persistence =
+      infra.eventSourcedPersistence as TypeORMEventSourcedAggregatePersistence;
+    const events = await persistence.loadAfterVersion(
+      "Account",
+      "nonexistent",
+      0,
+    );
     expect(events).toEqual([]);
   });
 });

--- a/packages/adapters/typeorm/src/entities.ts
+++ b/packages/adapters/typeorm/src/entities.ts
@@ -66,3 +66,21 @@ export class NodddeSagaStateEntity {
   @Column({ type: "text" })
   state!: string;
 }
+
+/**
+ * TypeORM entity for aggregate state snapshots.
+ */
+@Entity("noddde_snapshots")
+export class NodddeSnapshotEntity {
+  @PrimaryColumn({ name: "aggregate_name" })
+  aggregateName!: string;
+
+  @PrimaryColumn({ name: "aggregate_id" })
+  aggregateId!: string;
+
+  @Column({ type: "text" })
+  state!: string;
+
+  @Column({ type: "int" })
+  version!: number;
+}

--- a/packages/adapters/typeorm/src/index.ts
+++ b/packages/adapters/typeorm/src/index.ts
@@ -2,11 +2,13 @@ export {
   NodddeEventEntity,
   NodddeAggregateStateEntity,
   NodddeSagaStateEntity,
+  NodddeSnapshotEntity,
 } from "./entities";
 export {
   TypeORMEventSourcedAggregatePersistence,
   TypeORMStateStoredAggregatePersistence,
   TypeORMSagaPersistence,
+  TypeORMSnapshotStore,
 } from "./persistence";
 export { TypeORMAdvisoryLocker } from "./advisory-locker";
 export {
@@ -21,11 +23,13 @@ import type {
   EventSourcedAggregatePersistence,
   StateStoredAggregatePersistence,
   SagaPersistence,
+  SnapshotStore,
 } from "@noddde/core";
 import {
   TypeORMEventSourcedAggregatePersistence,
   TypeORMStateStoredAggregatePersistence,
   TypeORMSagaPersistence,
+  TypeORMSnapshotStore,
 } from "./persistence";
 import { createTypeORMUnitOfWorkFactory } from "./unit-of-work";
 import type { TypeORMTransactionStore } from "./unit-of-work";
@@ -37,6 +41,7 @@ export interface TypeORMPersistenceInfrastructure {
   eventSourcedPersistence: EventSourcedAggregatePersistence;
   stateStoredPersistence: StateStoredAggregatePersistence;
   sagaPersistence: SagaPersistence;
+  snapshotStore: SnapshotStore;
   unitOfWorkFactory: UnitOfWorkFactory;
 }
 
@@ -54,12 +59,13 @@ export interface TypeORMPersistenceInfrastructure {
  *   NodddeEventEntity,
  *   NodddeAggregateStateEntity,
  *   NodddeSagaStateEntity,
+ *   NodddeSnapshotEntity,
  * } from "@noddde/typeorm";
  *
  * const dataSource = new DataSource({
  *   type: "sqlite",
  *   database: ":memory:",
- *   entities: [NodddeEventEntity, NodddeAggregateStateEntity, NodddeSagaStateEntity],
+ *   entities: [NodddeEventEntity, NodddeAggregateStateEntity, NodddeSagaStateEntity, NodddeSnapshotEntity],
  *   synchronize: true,
  * });
  * await dataSource.initialize();
@@ -92,6 +98,7 @@ export function createTypeORMPersistence(
       txStore,
     ),
     sagaPersistence: new TypeORMSagaPersistence(dataSource, txStore),
+    snapshotStore: new TypeORMSnapshotStore(dataSource, txStore),
     unitOfWorkFactory: createTypeORMUnitOfWorkFactory(dataSource, txStore),
   };
 }

--- a/packages/adapters/typeorm/src/persistence.ts
+++ b/packages/adapters/typeorm/src/persistence.ts
@@ -1,9 +1,13 @@
 /* eslint-disable no-unused-vars */
 import type { DataSource, EntityManager } from "typeorm";
+import { MoreThan } from "typeorm";
 import type {
   Event,
   EventMetadata,
   EventSourcedAggregatePersistence,
+  PartialEventLoad,
+  Snapshot,
+  SnapshotStore,
   StateStoredAggregatePersistence,
   SagaPersistence,
 } from "@noddde/core";
@@ -12,6 +16,7 @@ import {
   NodddeEventEntity,
   NodddeAggregateStateEntity,
   NodddeSagaStateEntity,
+  NodddeSnapshotEntity,
 } from "./entities";
 import type { TypeORMTransactionStore } from "./unit-of-work";
 
@@ -19,7 +24,7 @@ import type { TypeORMTransactionStore } from "./unit-of-work";
  * TypeORM-backed event-sourced aggregate persistence.
  */
 export class TypeORMEventSourcedAggregatePersistence
-  implements EventSourcedAggregatePersistence
+  implements EventSourcedAggregatePersistence, PartialEventLoad
 {
   constructor(
     private readonly dataSource: DataSource,
@@ -74,6 +79,32 @@ export class TypeORMEventSourcedAggregatePersistence
 
     const rows = await repo.find({
       where: { aggregateName, aggregateId },
+      order: { sequenceNumber: "ASC" },
+    });
+
+    return rows.map((row) => ({
+      name: row.eventName,
+      payload: JSON.parse(row.payload),
+      ...(row.metadata
+        ? { metadata: JSON.parse(row.metadata) as EventMetadata }
+        : {}),
+    }));
+  }
+
+  async loadAfterVersion(
+    aggregateName: string,
+    aggregateId: string,
+    afterVersion: number,
+  ): Promise<Event[]> {
+    const manager = this.getManager();
+    const repo = manager.getRepository(NodddeEventEntity);
+
+    const rows = await repo.find({
+      where: {
+        aggregateName,
+        aggregateId,
+        sequenceNumber: MoreThan(afterVersion),
+      },
       order: { sequenceNumber: "ASC" },
     });
 
@@ -209,5 +240,61 @@ export class TypeORMSagaPersistence implements SagaPersistence {
 
     if (!row) return undefined;
     return JSON.parse(row.state);
+  }
+}
+
+/**
+ * TypeORM-backed snapshot store for aggregate state snapshots.
+ */
+export class TypeORMSnapshotStore implements SnapshotStore {
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly txStore: TypeORMTransactionStore,
+  ) {}
+
+  private getManager(): EntityManager {
+    return this.txStore.current ?? this.dataSource.manager;
+  }
+
+  async load(
+    aggregateName: string,
+    aggregateId: string,
+  ): Promise<Snapshot | null> {
+    const manager = this.getManager();
+    const repo = manager.getRepository(NodddeSnapshotEntity);
+
+    const row = await repo.findOne({
+      where: { aggregateName, aggregateId },
+    });
+
+    if (!row) return null;
+    return { state: JSON.parse(row.state), version: row.version };
+  }
+
+  async save(
+    aggregateName: string,
+    aggregateId: string,
+    snapshot: Snapshot,
+  ): Promise<void> {
+    const manager = this.getManager();
+    const repo = manager.getRepository(NodddeSnapshotEntity);
+    const serialized = JSON.stringify(snapshot.state);
+
+    const existing = await repo.findOne({
+      where: { aggregateName, aggregateId },
+    });
+
+    if (existing) {
+      existing.state = serialized;
+      existing.version = snapshot.version;
+      await repo.save(existing);
+    } else {
+      const entity = new NodddeSnapshotEntity();
+      entity.aggregateName = aggregateName;
+      entity.aggregateId = aggregateId;
+      entity.state = serialized;
+      entity.version = snapshot.version;
+      await repo.save(entity);
+    }
   }
 }

--- a/packages/core/src/__tests__/persistence/snapshot.test.ts
+++ b/packages/core/src/__tests__/persistence/snapshot.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { everyNEvents } from "@noddde/core";
+
+describe("everyNEvents", () => {
+  it("should return false when eventsSinceSnapshot is below n", () => {
+    const strategy = everyNEvents(10);
+
+    expect(
+      strategy({ version: 5, lastSnapshotVersion: 0, eventsSinceSnapshot: 5 }),
+    ).toBe(false);
+    expect(
+      strategy({ version: 9, lastSnapshotVersion: 0, eventsSinceSnapshot: 9 }),
+    ).toBe(false);
+    expect(
+      strategy({
+        version: 15,
+        lastSnapshotVersion: 10,
+        eventsSinceSnapshot: 5,
+      }),
+    ).toBe(false);
+  });
+
+  it("should return true when eventsSinceSnapshot >= n", () => {
+    const strategy = everyNEvents(10);
+
+    expect(
+      strategy({
+        version: 10,
+        lastSnapshotVersion: 0,
+        eventsSinceSnapshot: 10,
+      }),
+    ).toBe(true);
+    expect(
+      strategy({
+        version: 15,
+        lastSnapshotVersion: 0,
+        eventsSinceSnapshot: 15,
+      }),
+    ).toBe(true);
+    expect(
+      strategy({
+        version: 20,
+        lastSnapshotVersion: 10,
+        eventsSinceSnapshot: 10,
+      }),
+    ).toBe(true);
+  });
+
+  it("should always return true with n=1", () => {
+    const strategy = everyNEvents(1);
+
+    expect(
+      strategy({ version: 1, lastSnapshotVersion: 0, eventsSinceSnapshot: 1 }),
+    ).toBe(true);
+    expect(
+      strategy({
+        version: 100,
+        lastSnapshotVersion: 99,
+        eventsSinceSnapshot: 1,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/core/src/persistence/index.ts
+++ b/packages/core/src/persistence/index.ts
@@ -5,6 +5,13 @@ export { ConcurrencyError } from "./concurrency-error";
 export type { AggregateLocker } from "./aggregate-locker";
 export { LockTimeoutError } from "./lock-timeout-error";
 export { fnv1a64 } from "./hash";
+export { everyNEvents } from "./snapshot";
+export type {
+  Snapshot,
+  SnapshotStore,
+  SnapshotStrategy,
+  PartialEventLoad,
+} from "./snapshot";
 
 /**
  * Persistence strategy that stores the current aggregate state directly.

--- a/packages/core/src/persistence/snapshot.ts
+++ b/packages/core/src/persistence/snapshot.ts
@@ -1,0 +1,115 @@
+/* eslint-disable no-unused-vars */
+import type { Event } from "../edd";
+
+/**
+ * A snapshot of an aggregate's state at a specific event stream version.
+ * Snapshots are an optimization for event-sourced aggregates — they allow
+ * the domain engine to avoid replaying the full event stream on every command.
+ *
+ * Snapshots are not the source of truth — the event stream is. Deleting all
+ * snapshots does not lose data; the engine falls back to full replay.
+ */
+export interface Snapshot {
+  /** The aggregate state at the time of the snapshot. */
+  state: any;
+  /** The event stream version (number of events) at which this snapshot was taken. */
+  version: number;
+}
+
+/**
+ * Storage interface for aggregate state snapshots.
+ * Snapshots are an optimization for event-sourced aggregates — they allow
+ * the domain engine to avoid replaying the full event stream on every command.
+ *
+ * Implementations must support save-then-load round-trips and return `null`
+ * for unknown aggregates. Only the latest snapshot per aggregate instance
+ * is retained.
+ *
+ * @see {@link Snapshot} for the snapshot data structure.
+ */
+export interface SnapshotStore {
+  /**
+   * Loads the latest snapshot for an aggregate instance.
+   * Returns `null` if no snapshot exists.
+   *
+   * @param aggregateName - The aggregate type name (used as a namespace).
+   * @param aggregateId - The unique identifier of the aggregate instance.
+   */
+  load(aggregateName: string, aggregateId: string): Promise<Snapshot | null>;
+
+  /**
+   * Saves a snapshot of an aggregate's state at a given version.
+   * Overwrites any previously stored snapshot for the same instance.
+   *
+   * @param aggregateName - The aggregate type name (used as a namespace).
+   * @param aggregateId - The unique identifier of the aggregate instance.
+   * @param snapshot - The snapshot to save.
+   */
+  save(
+    aggregateName: string,
+    aggregateId: string,
+    snapshot: Snapshot,
+  ): Promise<void>;
+}
+
+/**
+ * Strategy function that decides whether to take a snapshot after
+ * processing a command. Called by the domain engine after each
+ * successful event-sourced command dispatch.
+ *
+ * @param context - Information about the current event stream state.
+ * @returns `true` to take a snapshot, `false` to skip.
+ */
+export type SnapshotStrategy = (context: {
+  /** Current event stream version (total number of events after this command). */
+  version: number;
+  /** Version at which the last snapshot was taken (0 if no snapshot exists). */
+  lastSnapshotVersion: number;
+  /** Number of events since the last snapshot (`version - lastSnapshotVersion`). */
+  eventsSinceSnapshot: number;
+}) => boolean;
+
+/**
+ * Optional interface that event-sourced persistence implementations
+ * can adopt to efficiently load only events after a given version.
+ *
+ * When the domain engine has a snapshot, it uses this method (if available)
+ * to avoid loading the full event stream. If the persistence does not
+ * implement this interface, the engine falls back to `load()` + `Array.slice()`.
+ */
+export interface PartialEventLoad {
+  /**
+   * Loads events that occurred after the given version.
+   * `afterVersion` is the number of events to skip from the beginning
+   * of the stream. Returns events at positions `afterVersion, afterVersion+1, ...`.
+   *
+   * - `afterVersion = 0` returns all events (equivalent to `load()`).
+   * - `afterVersion >= streamLength` returns an empty array.
+   *
+   * @param aggregateName - The aggregate type name (used as a namespace).
+   * @param aggregateId - The unique identifier of the aggregate instance.
+   * @param afterVersion - The number of events to skip from the beginning.
+   */
+  loadAfterVersion(
+    aggregateName: string,
+    aggregateId: string,
+    afterVersion: number,
+  ): Promise<Event[]>;
+}
+
+/**
+ * Creates a snapshot strategy that triggers every N events since the
+ * last snapshot (or since the beginning if no snapshot exists).
+ *
+ * @param n - The number of events between snapshots. Must be >= 1.
+ * @returns A {@link SnapshotStrategy} function.
+ *
+ * @example
+ * ```ts
+ * // Snapshot every 100 events
+ * const strategy = everyNEvents(100);
+ * ```
+ */
+export function everyNEvents(n: number): SnapshotStrategy {
+  return ({ eventsSinceSnapshot }) => eventsSinceSnapshot >= n;
+}

--- a/packages/engine/src/__tests__/engine/implementations/in-memory-aggregate-persistence.test.ts
+++ b/packages/engine/src/__tests__/engine/implementations/in-memory-aggregate-persistence.test.ts
@@ -98,6 +98,75 @@ describe("InMemoryEventSourcedAggregatePersistence", () => {
     const loaded = await persistence.load("BankAccount", "acc-1");
     expect(loaded).toHaveLength(1);
   });
+
+  it("loadAfterVersion returns events after the given version", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+
+    await persistence.save(
+      "BankAccount",
+      "acc-1",
+      [
+        { name: "AccountCreated", payload: { id: "acc-1" } },
+        { name: "DepositMade", payload: { amount: 50 } },
+        { name: "DepositMade", payload: { amount: 75 } },
+      ],
+      0,
+    );
+
+    const events = await persistence.loadAfterVersion(
+      "BankAccount",
+      "acc-1",
+      1,
+    );
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({ name: "DepositMade", payload: { amount: 50 } });
+    expect(events[1]).toEqual({
+      name: "DepositMade",
+      payload: { amount: 75 },
+    });
+  });
+
+  it("loadAfterVersion returns all events when afterVersion is 0", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+
+    await persistence.save(
+      "BankAccount",
+      "acc-1",
+      [
+        { name: "AccountCreated", payload: { id: "acc-1" } },
+        { name: "DepositMade", payload: { amount: 50 } },
+      ],
+      0,
+    );
+
+    const events = await persistence.loadAfterVersion(
+      "BankAccount",
+      "acc-1",
+      0,
+    );
+
+    expect(events).toHaveLength(2);
+  });
+
+  it("loadAfterVersion returns empty array when afterVersion >= stream length", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+
+    await persistence.save(
+      "BankAccount",
+      "acc-1",
+      [{ name: "AccountCreated", payload: { id: "acc-1" } }],
+      0,
+    );
+
+    const events = await persistence.loadAfterVersion(
+      "BankAccount",
+      "acc-1",
+      5,
+    );
+
+    expect(events).toEqual([]);
+  });
 });
 
 describe("InMemoryStateStoredAggregatePersistence", () => {

--- a/packages/engine/src/__tests__/engine/implementations/in-memory-snapshot-store.test.ts
+++ b/packages/engine/src/__tests__/engine/implementations/in-memory-snapshot-store.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { InMemorySnapshotStore } from "@noddde/engine";
+
+describe("InMemorySnapshotStore", () => {
+  it("should store and retrieve a snapshot", async () => {
+    const store = new InMemorySnapshotStore();
+    const snapshot = { state: { balance: 250, owner: "Alice" }, version: 5 };
+
+    await store.save("BankAccount", "acc-1", snapshot);
+    const loaded = await store.load("BankAccount", "acc-1");
+
+    expect(loaded).toEqual(snapshot);
+  });
+
+  it("should return null when no snapshot exists", async () => {
+    const store = new InMemorySnapshotStore();
+    const loaded = await store.load("BankAccount", "nonexistent");
+
+    expect(loaded).toBeNull();
+  });
+
+  it("should overwrite the snapshot on subsequent saves", async () => {
+    const store = new InMemorySnapshotStore();
+
+    await store.save("BankAccount", "acc-1", {
+      state: { balance: 100 },
+      version: 3,
+    });
+    await store.save("BankAccount", "acc-1", {
+      state: { balance: 200 },
+      version: 7,
+    });
+
+    const loaded = await store.load("BankAccount", "acc-1");
+    expect(loaded).toEqual({ state: { balance: 200 }, version: 7 });
+  });
+
+  it("should isolate snapshots between different aggregate names", async () => {
+    const store = new InMemorySnapshotStore();
+
+    await store.save("Order", "1", { state: { total: 50 }, version: 2 });
+    await store.save("Account", "1", { state: { balance: 999 }, version: 5 });
+
+    const orderSnapshot = await store.load("Order", "1");
+    const accountSnapshot = await store.load("Account", "1");
+
+    expect(orderSnapshot).toEqual({ state: { total: 50 }, version: 2 });
+    expect(accountSnapshot).toEqual({ state: { balance: 999 }, version: 5 });
+  });
+
+  it("should isolate snapshots between different aggregate IDs", async () => {
+    const store = new InMemorySnapshotStore();
+
+    await store.save("BankAccount", "acc-1", {
+      state: { balance: 100 },
+      version: 3,
+    });
+    await store.save("BankAccount", "acc-2", {
+      state: { balance: 500 },
+      version: 8,
+    });
+
+    const acc1 = await store.load("BankAccount", "acc-1");
+    const acc2 = await store.load("BankAccount", "acc-2");
+
+    expect(acc1).toEqual({ state: { balance: 100 }, version: 3 });
+    expect(acc2).toEqual({ state: { balance: 500 }, version: 8 });
+  });
+});

--- a/packages/engine/src/__tests__/integration/command-dispatch-lifecycle.test.ts
+++ b/packages/engine/src/__tests__/integration/command-dispatch-lifecycle.test.ts
@@ -8,8 +8,10 @@ import {
   InMemoryCommandBus,
   InMemoryEventSourcedAggregatePersistence,
   InMemoryQueryBus,
+  InMemorySnapshotStore,
   InMemoryStateStoredAggregatePersistence,
 } from "@noddde/engine";
+import { everyNEvents } from "@noddde/core";
 
 // ---- Shared counter aggregate ----
 
@@ -344,5 +346,143 @@ describe("Async command handler", () => {
     const events = await persistence.load("AsyncAggregate", "async-1");
     expect(events).toHaveLength(1);
     expect(events[0]!.payload.result).toBe("HELLO");
+  });
+});
+
+describe("Snapshot-aware command dispatch", () => {
+  it("should save a snapshot when the strategy triggers and use it for subsequent loads", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+    const snapshotStore = new InMemorySnapshotStore();
+    const eventBus = new EventEmitterEventBus();
+
+    const domain = await configureDomain({
+      writeModel: { aggregates: { Counter } },
+      readModel: { projections: {} },
+      infrastructure: {
+        aggregatePersistence: () => persistence,
+        snapshotStore: () => snapshotStore,
+        snapshotStrategy: everyNEvents(3),
+        cqrsInfrastructure: () => ({
+          commandBus: new InMemoryCommandBus(),
+          eventBus,
+          queryBus: new InMemoryQueryBus(),
+        }),
+      },
+    });
+
+    // Dispatch 3 commands — snapshot should trigger after the 3rd
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "counter-1",
+      payload: { amount: 1 },
+    });
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "counter-1",
+      payload: { amount: 2 },
+    });
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "counter-1",
+      payload: { amount: 3 },
+    });
+
+    // Verify snapshot was saved at version 3 with state { count: 6 }
+    const snapshot = await snapshotStore.load("Counter", "counter-1");
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.version).toBe(3);
+    expect(snapshot!.state).toEqual({ count: 6 });
+
+    // Spy on loadAfterVersion to verify it's used for subsequent commands
+    const loadAfterVersionSpy = vi.spyOn(persistence, "loadAfterVersion");
+
+    // Dispatch a 4th command — should use the snapshot
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "counter-1",
+      payload: { amount: 4 },
+    });
+
+    // Verify loadAfterVersion was called with snapshot version
+    expect(loadAfterVersionSpy).toHaveBeenCalledWith("Counter", "counter-1", 3);
+
+    // Verify the event stream has all 4 events
+    const events = await persistence.load("Counter", "counter-1");
+    expect(events).toHaveLength(4);
+  });
+
+  it("should produce correct state across snapshot boundaries", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+    const snapshotStore = new InMemorySnapshotStore();
+
+    const domain = await configureDomain({
+      writeModel: { aggregates: { Counter } },
+      readModel: { projections: {} },
+      infrastructure: {
+        aggregatePersistence: () => persistence,
+        snapshotStore: () => snapshotStore,
+        snapshotStrategy: everyNEvents(2),
+        cqrsInfrastructure: () => ({
+          commandBus: new InMemoryCommandBus(),
+          eventBus: new EventEmitterEventBus(),
+          queryBus: new InMemoryQueryBus(),
+        }),
+      },
+    });
+
+    // Dispatch 5 commands: snapshots at version 2 and 4
+    for (let i = 1; i <= 5; i++) {
+      await domain.dispatchCommand({
+        name: "Increment",
+        targetAggregateId: "counter-1",
+        payload: { amount: i },
+      });
+    }
+
+    // Verify final event stream (1+2+3+4+5 = 15 total)
+    const events = await persistence.load("Counter", "counter-1");
+    expect(events).toHaveLength(5);
+
+    // Verify the latest snapshot exists
+    const snapshot = await snapshotStore.load("Counter", "counter-1");
+    expect(snapshot).not.toBeNull();
+    // Snapshot should be at version 4 (last threshold crossing)
+    // with state { count: 1+2+3+4 = 10 }
+    expect(snapshot!.version).toBe(4);
+    expect(snapshot!.state).toEqual({ count: 10 });
+  });
+});
+
+describe("Command dispatch without snapshot (regression check)", () => {
+  it("should work identically without snapshot store configured", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+
+    const domain = await configureDomain({
+      writeModel: { aggregates: { Counter } },
+      readModel: { projections: {} },
+      infrastructure: {
+        aggregatePersistence: () => persistence,
+        // No snapshotStore, no snapshotStrategy
+        cqrsInfrastructure: () => ({
+          commandBus: new InMemoryCommandBus(),
+          eventBus: new EventEmitterEventBus(),
+          queryBus: new InMemoryQueryBus(),
+        }),
+      },
+    });
+
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "counter-1",
+      payload: { amount: 5 },
+    });
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "counter-1",
+      payload: { amount: 3 },
+    });
+
+    const events = await persistence.load("Counter", "counter-1");
+    expect(events).toHaveLength(2);
   });
 });

--- a/packages/engine/src/domain.ts
+++ b/packages/engine/src/domain.ts
@@ -11,6 +11,7 @@ import type {
   EventMetadata,
   EventSourcedAggregatePersistence,
   Infrastructure,
+  PartialEventLoad,
   PersistenceConfiguration,
   Projection,
   Query,
@@ -18,6 +19,9 @@ import type {
   QueryResult,
   Saga,
   SagaPersistence,
+  Snapshot,
+  SnapshotStore,
+  SnapshotStrategy,
   StandaloneCommandHandler,
   StateStoredAggregatePersistence,
   UnitOfWork,
@@ -189,6 +193,22 @@ export type DomainConfiguration<
      */
     sagaPersistence?: () => SagaPersistence | Promise<SagaPersistence>;
     /**
+     * Factory for the snapshot store. When configured alongside
+     * `snapshotStrategy`, the domain engine saves periodic aggregate state
+     * snapshots to avoid replaying the full event stream on every command.
+     *
+     * Only meaningful for event-sourced persistence.
+     */
+    snapshotStore?: () => SnapshotStore | Promise<SnapshotStore>;
+    /**
+     * Strategy that decides when to take a snapshot after processing a
+     * command. Called after each successful event-sourced command dispatch.
+     * Requires `snapshotStore` to be configured.
+     *
+     * @see {@link everyNEvents} for a built-in strategy factory.
+     */
+    snapshotStrategy?: SnapshotStrategy;
+    /**
      * Factory for custom infrastructure dependencies (repositories,
      * clocks, API clients, etc.).
      */
@@ -246,6 +266,8 @@ export class Domain<
   private _infrastructure!: TInfrastructure & CQRSInfrastructure;
   private _persistence!: PersistenceConfiguration;
   private _sagaPersistence?: SagaPersistence;
+  private _snapshotStore?: SnapshotStore;
+  private _snapshotStrategy?: SnapshotStrategy;
   private _unitOfWorkFactory!: UnitOfWorkFactory;
   private _concurrencyStrategy!: ConcurrencyStrategy;
   private readonly _uowStorage = new AsyncLocalStorage<UnitOfWork>();
@@ -314,6 +336,12 @@ export class Domain<
     this._persistence = configuration.infrastructure.aggregatePersistence
       ? await configuration.infrastructure.aggregatePersistence()
       : new InMemoryEventSourcedAggregatePersistence();
+
+    // Step 4.5: Resolve snapshot store and strategy
+    if (configuration.infrastructure.snapshotStore) {
+      this._snapshotStore = await configuration.infrastructure.snapshotStore();
+    }
+    this._snapshotStrategy = configuration.infrastructure.snapshotStrategy;
 
     // Step 5: Resolve saga persistence (only when processModel is configured)
     if (configuration.processModel) {
@@ -585,14 +613,23 @@ export class Domain<
     const existingUow = this._uowStorage.getStore();
     const ownsUow = !existingUow;
 
-    const runLifecycle = (uow: UnitOfWork) =>
-      this.executeCommandLifecycle(
+    const snapshotResult: {
+      value: {
+        aggregateName: string;
+        aggregateId: string;
+        snapshot: Snapshot;
+      } | null;
+    } = { value: null };
+
+    const runLifecycle = async (uow: UnitOfWork) => {
+      snapshotResult.value = await this.executeCommandLifecycle(
         aggregateName,
         aggregate,
         command,
         persistence,
         uow,
       );
+    };
 
     if (ownsUow) {
       // Implicit UoW — strategy wraps the full attempt (UoW create + commit)
@@ -614,6 +651,20 @@ export class Domain<
           }
         },
       );
+
+      // Save snapshot after successful commit (best-effort)
+      if (snapshotResult.value && this._snapshotStore) {
+        try {
+          await this._snapshotStore.save(
+            snapshotResult.value.aggregateName,
+            snapshotResult.value.aggregateId,
+            snapshotResult.value.snapshot,
+          );
+        } catch {
+          // Best-effort: snapshot save failure does not affect the command result
+        }
+      }
+
       for (const event of events) {
         await eventBus.dispatch(event);
       }
@@ -633,6 +684,9 @@ export class Domain<
   /**
    * The core load→execute→apply→enlist→defer cycle, extracted to support
    * retry in the implicit UoW path.
+   *
+   * Returns a pending snapshot (if the snapshot strategy triggers) for the
+   * caller to save after UoW commit. Returns `null` if no snapshot is needed.
    */
   private async executeCommandLifecycle(
     aggregateName: string,
@@ -640,33 +694,73 @@ export class Domain<
     command: AggregateCommand,
     persistence: PersistenceConfiguration,
     uow: UnitOfWork,
-  ): Promise<void> {
-    // Step 1: Load
-    const loaded = await persistence.load(
-      aggregateName,
-      command.targetAggregateId,
-    );
+  ): Promise<{
+    aggregateName: string;
+    aggregateId: string;
+    snapshot: Snapshot;
+  } | null> {
+    // Step 1: Load (snapshot-aware for event-sourced persistence)
+    let snapshot: Snapshot | null = null;
+    if (this._snapshotStore) {
+      snapshot = await this._snapshotStore.load(
+        aggregateName,
+        command.targetAggregateId,
+      );
+    }
 
     let currentState: any;
     let version: number;
-    const isEventSourced = Array.isArray(loaded);
+    let isEventSourced: boolean;
 
-    if (isEventSourced) {
-      // Event-sourced: replay events to rebuild state; version = stream length
-      const events = loaded as Event[];
-      version = events.length;
+    if (snapshot) {
+      // Snapshot available — we know this is event-sourced
+      isEventSourced = true;
+      let events: Event[];
+      if ("loadAfterVersion" in persistence) {
+        // Optimized path: load only post-snapshot events
+        events = await (persistence as PartialEventLoad).loadAfterVersion(
+          aggregateName,
+          command.targetAggregateId,
+          snapshot.version,
+        );
+      } else {
+        // Fallback: load all events and slice
+        const allEvents = await persistence.load(
+          aggregateName,
+          command.targetAggregateId,
+        );
+        events = (allEvents as Event[]).slice(snapshot.version);
+      }
+      version = snapshot.version + events.length;
       currentState = events.reduce((state: any, event: Event) => {
         const applyHandler = aggregate.apply[event.name];
         return applyHandler ? applyHandler(event.payload, state) : state;
-      }, aggregate.initialState);
+      }, snapshot.state);
     } else {
-      // State-stored: load returns { state, version } | null
-      const stateResult = loaded as {
-        state: any;
-        version: number;
-      } | null;
-      version = stateResult?.version ?? 0;
-      currentState = stateResult?.state ?? aggregate.initialState;
+      // No snapshot — standard path
+      const loaded = await persistence.load(
+        aggregateName,
+        command.targetAggregateId,
+      );
+      isEventSourced = Array.isArray(loaded);
+
+      if (isEventSourced) {
+        // Event-sourced: replay events to rebuild state; version = stream length
+        const events = loaded as Event[];
+        version = events.length;
+        currentState = events.reduce((state: any, event: Event) => {
+          const applyHandler = aggregate.apply[event.name];
+          return applyHandler ? applyHandler(event.payload, state) : state;
+        }, aggregate.initialState);
+      } else {
+        // State-stored: load returns { state, version } | null
+        const stateResult = loaded as {
+          state: any;
+          version: number;
+        } | null;
+        version = stateResult?.version ?? 0;
+        currentState = stateResult?.state ?? aggregate.initialState;
+      }
     }
 
     // Step 2: Execute command handler
@@ -732,6 +826,28 @@ export class Domain<
 
     // Step 6: Defer event publishing (published after commit)
     uow.deferPublish(...enrichedEvents);
+
+    // Step 7: Evaluate snapshot strategy (if configured)
+    if (isEventSourced && this._snapshotStore && this._snapshotStrategy) {
+      const newVersion = version + newEvents.length;
+      const lastSnapshotVersion = snapshot?.version ?? 0;
+      const eventsSinceSnapshot = newVersion - lastSnapshotVersion;
+      if (
+        this._snapshotStrategy({
+          version: newVersion,
+          lastSnapshotVersion,
+          eventsSinceSnapshot,
+        })
+      ) {
+        return {
+          aggregateName,
+          aggregateId: command.targetAggregateId,
+          snapshot: { state: newState, version: newVersion },
+        };
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/packages/engine/src/implementations/in-memory-aggregate-persistence.ts
+++ b/packages/engine/src/implementations/in-memory-aggregate-persistence.ts
@@ -1,6 +1,7 @@
 import type {
   Event,
   EventSourcedAggregatePersistence,
+  PartialEventLoad,
   StateStoredAggregatePersistence,
 } from "@noddde/core";
 import { ConcurrencyError } from "@noddde/core";
@@ -18,7 +19,7 @@ import { ConcurrencyError } from "@noddde/core";
  * For production, use a durable event store (PostgreSQL, EventStoreDB, etc.).
  */
 export class InMemoryEventSourcedAggregatePersistence
-  implements EventSourcedAggregatePersistence
+  implements EventSourcedAggregatePersistence, PartialEventLoad
 {
   private readonly store = new Map<string, Event[]>();
 
@@ -49,6 +50,25 @@ export class InMemoryEventSourcedAggregatePersistence
    * @param events - The new events to append.
    * @param expectedVersion - The stream length observed at load time.
    */
+  /**
+   * Loads events that occurred after the given version.
+   * Returns events at positions `afterVersion, afterVersion+1, ...`.
+   *
+   * @param aggregateName - The aggregate type name (used as a namespace).
+   * @param aggregateId - The unique identifier of the aggregate instance.
+   * @param afterVersion - The number of events to skip from the beginning.
+   * @returns Events after the given version, or `[]` if none.
+   */
+  public async loadAfterVersion(
+    aggregateName: string,
+    aggregateId: string,
+    afterVersion: number,
+  ): Promise<Event[]> {
+    const key = `${aggregateName}:${aggregateId}`;
+    const events = this.store.get(key) ?? [];
+    return events.slice(afterVersion);
+  }
+
   public async save(
     aggregateName: string,
     aggregateId: string,

--- a/packages/engine/src/implementations/in-memory-snapshot-store.ts
+++ b/packages/engine/src/implementations/in-memory-snapshot-store.ts
@@ -1,0 +1,49 @@
+import type { Snapshot, SnapshotStore } from "@noddde/core";
+
+/**
+ * In-memory {@link SnapshotStore} implementation that stores aggregate
+ * state snapshots in a `Map`. Snapshots are lost when the process exits.
+ *
+ * Snapshots are keyed by a composite `${aggregateName}:${aggregateId}` string.
+ * Each `save` call **overwrites** the previously stored snapshot. `load` returns
+ * the latest snapshot or `null` if none exists.
+ *
+ * Suitable for development, testing, and prototyping.
+ * For production, use a durable snapshot store (PostgreSQL, Redis, etc.).
+ */
+export class InMemorySnapshotStore implements SnapshotStore {
+  private readonly store = new Map<string, Snapshot>();
+
+  /**
+   * Loads the latest snapshot for an aggregate instance.
+   * Returns `null` if no snapshot has been saved for the given key.
+   *
+   * @param aggregateName - The aggregate type name (used as a namespace).
+   * @param aggregateId - The unique identifier of the aggregate instance.
+   * @returns The stored snapshot, or `null` if not found.
+   */
+  public async load(
+    aggregateName: string,
+    aggregateId: string,
+  ): Promise<Snapshot | null> {
+    const key = `${aggregateName}:${aggregateId}`;
+    return this.store.get(key) ?? null;
+  }
+
+  /**
+   * Saves a snapshot, replacing any previously stored snapshot for the same
+   * aggregate instance.
+   *
+   * @param aggregateName - The aggregate type name (used as a namespace).
+   * @param aggregateId - The unique identifier of the aggregate instance.
+   * @param snapshot - The snapshot to save.
+   */
+  public async save(
+    aggregateName: string,
+    aggregateId: string,
+    snapshot: Snapshot,
+  ): Promise<void> {
+    const key = `${aggregateName}:${aggregateId}`;
+    this.store.set(key, snapshot);
+  }
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -4,5 +4,6 @@ export * from "./implementations/in-memory-command-bus";
 export * from "./implementations/in-memory-query-bus";
 export * from "./implementations/in-memory-aggregate-persistence";
 export * from "./implementations/in-memory-saga-persistence";
+export * from "./implementations/in-memory-snapshot-store";
 export * from "./implementations/in-memory-unit-of-work";
 export * from "./implementations/in-memory-aggregate-locker";

--- a/specs/core/persistence/persistence.spec.md
+++ b/specs/core/persistence/persistence.spec.md
@@ -12,6 +12,11 @@ exports:
     AggregateLocker,
     LockTimeoutError,
     fnv1a64,
+    Snapshot,
+    SnapshotStore,
+    SnapshotStrategy,
+    PartialEventLoad,
+    everyNEvents,
   ]
 depends_on: [edd/event]
 docs:
@@ -178,7 +183,7 @@ The framework should define a clear discrimination mechanism so that custom pers
 - **Concurrent saves to the same aggregate** -- Both persistence strategies use optimistic concurrency control via version checking. The first save succeeds; subsequent saves with the same `expectedVersion` throw `ConcurrencyError`. The domain engine may retry on `ConcurrencyError` (configurable via `aggregateConcurrency.maxRetries`).
 - **Save with expectedVersion 0 on new aggregate** -- For event-sourced: appends events to a new stream (stream was empty, so `length === 0 === expectedVersion`). For state-stored: inserts new state at version 1.
 - **Save with expectedVersion 0 on existing aggregate** -- Must throw `ConcurrencyError` (the aggregate already has events/state at a higher version).
-- **Very large event streams** -- `EventSourcedAggregatePersistence.load` returns the full stream. For aggregates with thousands of events, implementations may want to support snapshots, but the current interface does not define a snapshot mechanism.
+- **Very large event streams** -- `EventSourcedAggregatePersistence.load` returns the full stream. For aggregates with thousands of events, implementations should adopt the `SnapshotStore` and `PartialEventLoad` interfaces (defined in `persistence/snapshot`) to optimize load times. See `specs/core/persistence/snapshot.spec.md`.
 - **Null vs undefined** -- `SagaPersistence.load` returns `any | undefined | null`. The domain engine should check `state == null` (loose equality) to handle both.
 - **Empty string as name or ID** -- Valid per the interface but likely a bug. Implementations should not reject them; validation belongs at a higher layer.
 

--- a/specs/core/persistence/snapshot.spec.md
+++ b/specs/core/persistence/snapshot.spec.md
@@ -1,0 +1,386 @@
+---
+title: "Snapshot Store & Strategy"
+module: persistence/snapshot
+source_file: packages/core/src/persistence/snapshot.ts
+status: implemented
+exports:
+  [Snapshot, SnapshotStore, SnapshotStrategy, PartialEventLoad, everyNEvents]
+depends_on: [edd/event]
+docs:
+  - running/persistence.mdx
+  - running/domain-configuration.mdx
+---
+
+# Snapshot Store & Strategy
+
+> Defines the snapshotting contracts for event-sourced aggregate persistence. A `SnapshotStore` saves and loads periodic state snapshots so the domain engine can skip replaying the full event stream. A `SnapshotStrategy` decides when to take a snapshot. `PartialEventLoad` is an optional interface that persistence implementations can adopt to load only events after a given version, avoiding full-stream I/O. `everyNEvents` is a built-in strategy factory.
+
+## Type Contract
+
+```ts
+/**
+ * A snapshot of an aggregate's state at a specific event stream version.
+ */
+interface Snapshot {
+  /** The aggregate state at the time of the snapshot. */
+  state: any;
+  /** The event stream version (number of events) at which this snapshot was taken. */
+  version: number;
+}
+
+/**
+ * Storage interface for aggregate state snapshots.
+ * Snapshots are an optimization for event-sourced aggregates — they allow
+ * the domain engine to avoid replaying the full event stream on every command.
+ *
+ * Snapshots are not the source of truth — the event stream is. Deleting all
+ * snapshots does not lose data; the engine falls back to full replay.
+ */
+interface SnapshotStore {
+  /**
+   * Loads the latest snapshot for an aggregate instance.
+   * Returns `null` if no snapshot exists.
+   */
+  load(aggregateName: string, aggregateId: string): Promise<Snapshot | null>;
+
+  /**
+   * Saves a snapshot of an aggregate's state at a given version.
+   * Overwrites any previously stored snapshot for the same instance.
+   */
+  save(
+    aggregateName: string,
+    aggregateId: string,
+    snapshot: Snapshot,
+  ): Promise<void>;
+}
+
+/**
+ * Strategy function that decides whether to take a snapshot after
+ * processing a command. Called by the domain engine after each
+ * successful event-sourced command dispatch.
+ */
+type SnapshotStrategy = (context: {
+  /** Current event stream version (total number of events after this command). */
+  version: number;
+  /** Version at which the last snapshot was taken (0 if no snapshot exists). */
+  lastSnapshotVersion: number;
+  /** Number of events since the last snapshot (`version - lastSnapshotVersion`). */
+  eventsSinceSnapshot: number;
+}) => boolean;
+
+/**
+ * Optional interface that event-sourced persistence implementations
+ * can adopt to efficiently load only events after a given version.
+ *
+ * When the domain engine has a snapshot, it uses this method (if available)
+ * to avoid loading the full event stream. If the persistence does not
+ * implement this interface, the engine falls back to `load()` + `Array.slice()`.
+ */
+interface PartialEventLoad {
+  /**
+   * Loads events that occurred after the given version.
+   * `afterVersion` is the number of events to skip from the beginning
+   * of the stream. Returns events at positions `afterVersion, afterVersion+1, ...`.
+   *
+   * - `afterVersion = 0` returns all events (equivalent to `load()`).
+   * - `afterVersion >= streamLength` returns an empty array.
+   */
+  loadAfterVersion(
+    aggregateName: string,
+    aggregateId: string,
+    afterVersion: number,
+  ): Promise<Event[]>;
+}
+
+/**
+ * Creates a snapshot strategy that triggers every N events since the
+ * last snapshot (or since the beginning if no snapshot exists).
+ *
+ * @param n - The number of events between snapshots. Must be >= 1.
+ */
+function everyNEvents(n: number): SnapshotStrategy;
+```
+
+- `Snapshot.state` is `any` for the same reason as persistence: type safety is enforced at the aggregate definition layer, not the snapshot layer.
+- `Snapshot.version` corresponds to `events.length` at the time of the snapshot. It is always a non-negative integer.
+- `SnapshotStore` is configured separately from `EventSourcedAggregatePersistence`. They may use different backends.
+- `SnapshotStrategy` is a pure function — no side effects, no I/O. It receives computed context and returns a boolean.
+- `PartialEventLoad` is checked via duck typing (`'loadAfterVersion' in persistence`), not via `instanceof`. Any persistence implementation can adopt it by adding the method.
+
+## Behavioral Requirements
+
+### SnapshotStore
+
+1. **save(aggregateName, aggregateId, snapshot)** -- Persists the snapshot, overwriting any previously stored snapshot for the same `(aggregateName, aggregateId)` pair. There is no versioned history of snapshots — only the latest snapshot is kept.
+2. **load(aggregateName, aggregateId)** -- Returns the latest snapshot, or `null` if no snapshot exists for this aggregate instance.
+3. **Namespace semantics** -- `aggregateName` serves as a namespace. Snapshots for `("Order", "1")` and `("Account", "1")` are independent.
+4. **Snapshot is not the source of truth** -- Deleting or corrupting a snapshot is safe. The engine falls back to full event replay. Snapshot data is a cache, not authoritative.
+
+### SnapshotStrategy
+
+1. **Pure function** -- The strategy receives a context object and returns `true` (take snapshot) or `false` (skip). It must not have side effects.
+2. **Context accuracy** -- `eventsSinceSnapshot` is always equal to `version - lastSnapshotVersion`. It is provided for convenience.
+
+### everyNEvents
+
+1. **Triggers at threshold** -- `everyNEvents(n)` returns `true` when `eventsSinceSnapshot >= n`.
+2. **Does not trigger below threshold** -- Returns `false` when `eventsSinceSnapshot < n`.
+3. **n = 1 always triggers** -- Every command produces at least one event, so `everyNEvents(1)` triggers after every command.
+4. **n must be >= 1** -- Passing `n < 1` is undefined behavior (no runtime validation required).
+
+### PartialEventLoad
+
+1. **loadAfterVersion(aggregateName, aggregateId, afterVersion)** -- Returns events from the stream starting at position `afterVersion` (0-indexed). Equivalent to `allEvents.slice(afterVersion)`.
+2. **afterVersion = 0** -- Returns all events, same as `load()`.
+3. **afterVersion >= stream length** -- Returns an empty array.
+4. **Ordering** -- Events are returned in insertion order, same as `load()`.
+
+## Invariants
+
+- `Snapshot.version` is always a non-negative integer.
+- `SnapshotStore.save()` is idempotent for the same `(aggregateName, aggregateId)` — calling it twice with different snapshots simply keeps the latest.
+- `PartialEventLoad.loadAfterVersion()` must return the same events as `load().slice(afterVersion)` for correctness. Implementations may use more efficient queries, but the result must be equivalent.
+- Snapshot deletion is always safe. The domain engine must handle `null` from `SnapshotStore.load()` gracefully by falling back to full replay.
+
+## Edge Cases
+
+- **Snapshot at version 0** -- A snapshot with `version: 0` is effectively useless (state = initialState, no events to skip). The engine should handle it gracefully.
+- **Snapshot version exceeds actual stream length** -- This can happen if events are deleted (which violates the append-only invariant). The engine should treat this as a corrupted snapshot and fall back to full replay.
+- **Concurrent snapshot saves** -- Two commands complete simultaneously and both decide to snapshot. Last-write-wins is acceptable — both snapshots are valid, and the slightly newer one overwrites the slightly older one.
+- **Empty event stream with no snapshot** -- Normal first-command case. The engine uses `initialState` and version 0.
+
+## Integration Points
+
+- **DomainConfiguration.infrastructure.snapshotStore** -- Factory function returning a `SnapshotStore`. Optional — if omitted, no snapshotting occurs.
+- **DomainConfiguration.infrastructure.snapshotStrategy** -- A `SnapshotStrategy` function. Optional — if omitted (but snapshot store is provided), no automatic snapshotting occurs.
+- **Domain.executeCommandLifecycle()** -- Uses `SnapshotStore.load()` before event loading and `SnapshotStore.save()` after successful commit.
+- **EventSourcedAggregatePersistence** -- If the persistence implementation also implements `PartialEventLoad`, the engine uses `loadAfterVersion()` for optimized I/O.
+
+## Test Scenarios
+
+### everyNEvents returns false below threshold
+
+```ts
+import { describe, it, expect } from "vitest";
+import { everyNEvents } from "@noddde/core";
+
+describe("everyNEvents", () => {
+  it("should return false when eventsSinceSnapshot is below n", () => {
+    const strategy = everyNEvents(10);
+
+    expect(
+      strategy({ version: 5, lastSnapshotVersion: 0, eventsSinceSnapshot: 5 }),
+    ).toBe(false);
+    expect(
+      strategy({ version: 9, lastSnapshotVersion: 0, eventsSinceSnapshot: 9 }),
+    ).toBe(false);
+    expect(
+      strategy({
+        version: 15,
+        lastSnapshotVersion: 10,
+        eventsSinceSnapshot: 5,
+      }),
+    ).toBe(false);
+  });
+});
+```
+
+### everyNEvents returns true at or above threshold
+
+```ts
+import { describe, it, expect } from "vitest";
+import { everyNEvents } from "@noddde/core";
+
+describe("everyNEvents", () => {
+  it("should return true when eventsSinceSnapshot >= n", () => {
+    const strategy = everyNEvents(10);
+
+    expect(
+      strategy({
+        version: 10,
+        lastSnapshotVersion: 0,
+        eventsSinceSnapshot: 10,
+      }),
+    ).toBe(true);
+    expect(
+      strategy({
+        version: 15,
+        lastSnapshotVersion: 0,
+        eventsSinceSnapshot: 15,
+      }),
+    ).toBe(true);
+    expect(
+      strategy({
+        version: 20,
+        lastSnapshotVersion: 10,
+        eventsSinceSnapshot: 10,
+      }),
+    ).toBe(true);
+  });
+});
+```
+
+### everyNEvents with n=1 always triggers
+
+```ts
+import { describe, it, expect } from "vitest";
+import { everyNEvents } from "@noddde/core";
+
+describe("everyNEvents", () => {
+  it("should always return true with n=1", () => {
+    const strategy = everyNEvents(1);
+
+    expect(
+      strategy({ version: 1, lastSnapshotVersion: 0, eventsSinceSnapshot: 1 }),
+    ).toBe(true);
+    expect(
+      strategy({
+        version: 100,
+        lastSnapshotVersion: 99,
+        eventsSinceSnapshot: 1,
+      }),
+    ).toBe(true);
+  });
+});
+```
+
+### SnapshotStore contract: save then load returns the snapshot
+
+```ts
+import { describe, it, expect } from "vitest";
+import type { SnapshotStore } from "@noddde/core";
+
+describe("SnapshotStore contract", () => {
+  function runContractTests(createStore: () => SnapshotStore) {
+    it("should return the saved snapshot on load", async () => {
+      const store = createStore();
+      const snapshot = { state: { balance: 100, owner: "Alice" }, version: 5 };
+
+      await store.save("BankAccount", "acc-1", snapshot);
+      const loaded = await store.load("BankAccount", "acc-1");
+
+      expect(loaded).toEqual(snapshot);
+    });
+
+    it("should return null for an unknown aggregate", async () => {
+      const store = createStore();
+      const loaded = await store.load("BankAccount", "nonexistent");
+
+      expect(loaded).toBeNull();
+    });
+
+    it("should overwrite snapshot on repeated saves", async () => {
+      const store = createStore();
+
+      await store.save("BankAccount", "acc-1", {
+        state: { balance: 100 },
+        version: 5,
+      });
+      await store.save("BankAccount", "acc-1", {
+        state: { balance: 200 },
+        version: 10,
+      });
+
+      const loaded = await store.load("BankAccount", "acc-1");
+      expect(loaded).toEqual({ state: { balance: 200 }, version: 10 });
+    });
+
+    it("should isolate by aggregate name", async () => {
+      const store = createStore();
+
+      await store.save("Order", "1", {
+        state: { total: 50 },
+        version: 3,
+      });
+      await store.save("Account", "1", {
+        state: { balance: 999 },
+        version: 7,
+      });
+
+      const orderSnapshot = await store.load("Order", "1");
+      const accountSnapshot = await store.load("Account", "1");
+
+      expect(orderSnapshot).toEqual({ state: { total: 50 }, version: 3 });
+      expect(accountSnapshot).toEqual({
+        state: { balance: 999 },
+        version: 7,
+      });
+    });
+  }
+
+  describe("InMemorySnapshotStore", () => {
+    const { InMemorySnapshotStore } = require("@noddde/core");
+    runContractTests(() => new InMemorySnapshotStore());
+  });
+});
+```
+
+### PartialEventLoad contract: loadAfterVersion slices the stream
+
+```ts
+import { describe, it, expect } from "vitest";
+import { InMemoryEventSourcedAggregatePersistence } from "@noddde/core";
+import type { PartialEventLoad } from "@noddde/core";
+
+describe("PartialEventLoad contract", () => {
+  it("should return events after the given version", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+
+    await persistence.save(
+      "Account",
+      "acc-1",
+      [
+        { name: "AccountCreated", payload: { id: "acc-1" } },
+        { name: "DepositMade", payload: { amount: 50 } },
+        { name: "DepositMade", payload: { amount: 75 } },
+      ],
+      0,
+    );
+
+    const partial = persistence as unknown as PartialEventLoad;
+    const events = await partial.loadAfterVersion("Account", "acc-1", 1);
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({ name: "DepositMade", payload: { amount: 50 } });
+    expect(events[1]).toEqual({
+      name: "DepositMade",
+      payload: { amount: 75 },
+    });
+  });
+
+  it("should return all events when afterVersion is 0", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+
+    await persistence.save(
+      "Account",
+      "acc-1",
+      [
+        { name: "AccountCreated", payload: { id: "acc-1" } },
+        { name: "DepositMade", payload: { amount: 50 } },
+      ],
+      0,
+    );
+
+    const partial = persistence as unknown as PartialEventLoad;
+    const events = await partial.loadAfterVersion("Account", "acc-1", 0);
+
+    expect(events).toHaveLength(2);
+  });
+
+  it("should return empty array when afterVersion >= stream length", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+
+    await persistence.save(
+      "Account",
+      "acc-1",
+      [{ name: "AccountCreated", payload: { id: "acc-1" } }],
+      0,
+    );
+
+    const partial = persistence as unknown as PartialEventLoad;
+    const events = await partial.loadAfterVersion("Account", "acc-1", 5);
+
+    expect(events).toEqual([]);
+  });
+});
+```

--- a/specs/drizzle/drizzle-persistence.spec.md
+++ b/specs/drizzle/drizzle-persistence.spec.md
@@ -7,21 +7,26 @@ exports:
   - createDrizzlePersistence
   - DrizzlePersistenceInfrastructure
   - DrizzleNodddeSchema
+  - DrizzleSnapshotStore
   # @noddde/drizzle/sqlite
   - events (sqliteTable)
   - aggregateStates (sqliteTable)
   - sagaStates (sqliteTable)
+  - snapshots (sqliteTable)
   # @noddde/drizzle/pg
   - events (pgTable)
   - aggregateStates (pgTable)
   - sagaStates (pgTable)
+  - snapshots (pgTable)
   # @noddde/drizzle/mysql
   - events (mysqlTable)
   - aggregateStates (mysqlTable)
   - sagaStates (mysqlTable)
+  - snapshots (mysqlTable)
 depends_on:
   - core/persistence/persistence
   - core/persistence/unit-of-work
+  - core/persistence/snapshot
 docs:
   - docs/content/docs/infrastructure/orm-adapters.mdx
   - docs/content/docs/domain-configuration/unit-of-work.mdx
@@ -41,6 +46,10 @@ import type {
   StateStoredAggregatePersistence,
   SagaPersistence,
   UnitOfWorkFactory,
+  SnapshotStore,
+  Snapshot,
+  PartialEventLoad,
+  Event,
 } from "@noddde/core";
 
 /**
@@ -51,6 +60,7 @@ export interface DrizzleNodddeSchema {
   events: any;
   aggregateStates: any;
   sagaStates: any;
+  snapshots?: any; // Optional — only needed if using snapshot store
 }
 
 /**
@@ -61,6 +71,38 @@ export interface DrizzlePersistenceInfrastructure {
   stateStoredPersistence: StateStoredAggregatePersistence;
   sagaPersistence: SagaPersistence;
   unitOfWorkFactory: UnitOfWorkFactory;
+  snapshotStore?: SnapshotStore; // Present only when schema.snapshots is provided
+}
+
+/**
+ * Drizzle-backed snapshot store for event-sourced aggregates.
+ */
+export class DrizzleSnapshotStore implements SnapshotStore {
+  constructor(
+    db: any,
+    txStore: DrizzleTransactionStore,
+    schema: DrizzleNodddeSchema,
+  );
+  load(aggregateName: string, aggregateId: string): Promise<Snapshot | null>;
+  save(
+    aggregateName: string,
+    aggregateId: string,
+    snapshot: Snapshot,
+  ): Promise<void>;
+}
+
+/**
+ * DrizzleEventSourcedAggregatePersistence also implements PartialEventLoad.
+ */
+export class DrizzleEventSourcedAggregatePersistence
+  implements EventSourcedAggregatePersistence, PartialEventLoad
+{
+  // ... existing methods ...
+  loadAfterVersion(
+    aggregateName: string,
+    aggregateId: string,
+    afterVersion: number,
+  ): Promise<Event[]>;
 }
 
 /**
@@ -87,6 +129,7 @@ import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 export const events: SQLiteTableWithColumns<...>;
 export const aggregateStates: SQLiteTableWithColumns<...>;
 export const sagaStates: SQLiteTableWithColumns<...>;
+export const snapshots: SQLiteTableWithColumns<...>;
 ```
 
 **`@noddde/drizzle/pg`**
@@ -97,6 +140,7 @@ import { pgTable, text, serial, integer, jsonb } from "drizzle-orm/pg-core";
 export const events: PgTableWithColumns<...>;       // serial PK, jsonb payload
 export const aggregateStates: PgTableWithColumns<...>;
 export const sagaStates: PgTableWithColumns<...>;
+export const snapshots: PgTableWithColumns<...>;     // jsonb state
 ```
 
 **`@noddde/drizzle/mysql`**
@@ -107,6 +151,7 @@ import { mysqlTable, varchar, int, text, json } from "drizzle-orm/mysql-core";
 export const events: MySqlTableWithColumns<...>;     // auto-increment int PK, json payload, varchar(255) for names
 export const aggregateStates: MySqlTableWithColumns<...>;
 export const sagaStates: MySqlTableWithColumns<...>;
+export const snapshots: MySqlTableWithColumns<...>;
 ```
 
 All three dialects define the same logical schema with the same table names (`noddde_events`, `noddde_aggregate_states`, `noddde_saga_states`) and column names.
@@ -150,6 +195,14 @@ All three dialects define the same logical schema with the same table names (`no
 24. PostgreSQL schema uses `serial` for auto-increment PK and `jsonb` for payload/state columns.
 25. MySQL schema uses `int` with `.autoincrement()` for PK, `varchar(255)` for name columns, and `json` for payload/state columns.
 26. SQLite schema uses `integer` with `autoIncrement` for PK and `text` for all string/JSON columns.
+
+### Snapshots and Partial Event Load
+
+27. `DrizzleSnapshotStore.save()` upserts the snapshot (insert if new, update if exists) using the `snapshots` schema table.
+28. `DrizzleSnapshotStore.load()` returns the JSON-parsed state and version, or `null` if no snapshot exists.
+29. `DrizzleEventSourcedAggregatePersistence.loadAfterVersion()` loads events with `sequence_number > afterVersion` ordered by `sequence_number ASC`.
+30. `snapshotStore` is only included in the factory return when `schema.snapshots` is provided.
+31. Snapshot operations route through `txStore.current` like all other persistence operations.
 
 ## Invariants
 
@@ -199,6 +252,12 @@ noddde_saga_states
 ├── saga_name        (string, PK part 1)
 ├── saga_id          (string, PK part 2)
 └── state            (JSON string, NOT NULL)
+
+noddde_snapshots
+├── aggregate_name   (string, PK part 1)
+├── aggregate_id     (string, PK part 2)
+├── state            (JSON string, NOT NULL)
+└── version          (integer, NOT NULL)
 ```
 
 ## Test Scenarios
@@ -514,5 +573,157 @@ it("throws on any operation after commit or rollback", async () => {
   expect(() => uow.deferPublish()).toThrow("UnitOfWork already completed");
   await expect(uow.commit()).rejects.toThrow("UnitOfWork already completed");
   await expect(uow.rollback()).rejects.toThrow("UnitOfWork already completed");
+});
+```
+
+### Snapshot store: save and load roundtrip
+
+```ts
+it("snapshot store: save and load roundtrip", async () => {
+  const db = createTestDb();
+  const infra = createDrizzlePersistence(db, {
+    events,
+    aggregateStates,
+    sagaStates,
+    snapshots,
+  });
+
+  expect(infra.snapshotStore).toBeDefined();
+  const store = infra.snapshotStore!;
+
+  await store.save("Order", "order-1", {
+    state: { status: "confirmed", total: 100 },
+    version: 5,
+  });
+
+  const loaded = await store.load("Order", "order-1");
+  expect(loaded).toEqual({
+    state: { status: "confirmed", total: 100 },
+    version: 5,
+  });
+});
+```
+
+### Snapshot store: returns null for unknown aggregate
+
+```ts
+it("snapshot store: returns null for unknown aggregate", async () => {
+  const db = createTestDb();
+  const infra = createDrizzlePersistence(db, {
+    events,
+    aggregateStates,
+    sagaStates,
+    snapshots,
+  });
+
+  const loaded = await infra.snapshotStore!.load("Order", "nonexistent");
+  expect(loaded).toBeNull();
+});
+```
+
+### Snapshot store: overwrites on repeated saves
+
+```ts
+it("snapshot store: overwrites on repeated saves", async () => {
+  const db = createTestDb();
+  const infra = createDrizzlePersistence(db, {
+    events,
+    aggregateStates,
+    sagaStates,
+    snapshots,
+  });
+  const store = infra.snapshotStore!;
+
+  await store.save("Order", "order-1", {
+    state: { status: "placed" },
+    version: 1,
+  });
+  await store.save("Order", "order-1", {
+    state: { status: "confirmed" },
+    version: 3,
+  });
+
+  const loaded = await store.load("Order", "order-1");
+  expect(loaded).toEqual({
+    state: { status: "confirmed" },
+    version: 3,
+  });
+});
+```
+
+### snapshotStore is not present when schema.snapshots is not provided
+
+```ts
+it("snapshotStore is not present when schema.snapshots is not provided", () => {
+  const db = createTestDb();
+  const infra = createDrizzlePersistence(db, {
+    events,
+    aggregateStates,
+    sagaStates,
+  });
+
+  expect(infra.snapshotStore).toBeUndefined();
+});
+```
+
+### loadAfterVersion: returns events after given version
+
+```ts
+it("loadAfterVersion: returns events after given version", async () => {
+  const db = createTestDb();
+  const infra = createDrizzlePersistence(db, {
+    events,
+    aggregateStates,
+    sagaStates,
+    snapshots,
+  });
+  const persistence = infra.eventSourcedPersistence;
+
+  await persistence.save(
+    "Order",
+    "order-1",
+    [
+      { name: "OrderPlaced", payload: { total: 100 } },
+      { name: "OrderConfirmed", payload: {} },
+      { name: "OrderShipped", payload: { trackingId: "T1" } },
+    ],
+    0,
+  );
+
+  const afterV1 = await persistence.loadAfterVersion("Order", "order-1", 1);
+  expect(afterV1).toHaveLength(2);
+  expect(afterV1[0]!.name).toBe("OrderConfirmed");
+  expect(afterV1[1]!.name).toBe("OrderShipped");
+});
+```
+
+### loadAfterVersion: returns empty array when afterVersion >= stream length
+
+```ts
+it("loadAfterVersion: returns empty array when afterVersion >= stream length", async () => {
+  const db = createTestDb();
+  const infra = createDrizzlePersistence(db, {
+    events,
+    aggregateStates,
+    sagaStates,
+    snapshots,
+  });
+  const persistence = infra.eventSourcedPersistence;
+
+  await persistence.save(
+    "Order",
+    "order-1",
+    [
+      { name: "OrderPlaced", payload: {} },
+      { name: "OrderConfirmed", payload: {} },
+    ],
+    0,
+  );
+
+  const afterV2 = await persistence.loadAfterVersion("Order", "order-1", 2);
+  expect(afterV2).toEqual([]);
+
+  const afterV10 = await persistence.loadAfterVersion("Order", "order-1", 10);
+  expect(afterV10).toEqual([]);
 });
 ```

--- a/specs/engine/domain.spec.md
+++ b/specs/engine/domain.spec.md
@@ -65,6 +65,8 @@ type DomainConfiguration<
           lockTimeoutMs?: number;
         };
     sagaPersistence?: () => SagaPersistence | Promise<SagaPersistence>;
+    snapshotStore?: () => SnapshotStore | Promise<SnapshotStore>;
+    snapshotStrategy?: SnapshotStrategy;
     provideInfrastructure?: () => Promise<TInfrastructure> | TInfrastructure;
     cqrsInfrastructure?: (
       infrastructure: TInfrastructure,
@@ -112,13 +114,14 @@ The `init()` method must execute the following steps in order:
 2. **Resolve CQRS infrastructure** -- Call `configuration.infrastructure.cqrsInfrastructure(infrastructure)` if provided, passing the resolved custom infrastructure. Store the `CommandBus`, `EventBus`, and `QueryBus`. If not provided, create default in-memory implementations (`InMemoryCommandBus`, `EventEmitterEventBus`, `InMemoryQueryBus`).
 3. **Merge infrastructure** -- Combine custom infrastructure and CQRS infrastructure into `this._infrastructure` as `TInfrastructure & CQRSInfrastructure`.
 4. **Resolve aggregate persistence** -- Call `configuration.infrastructure.aggregatePersistence()` if provided. Store as `this._persistence`. If not provided, use a default in-memory persistence.
-5. **Resolve saga persistence** -- Call `configuration.infrastructure.sagaPersistence()` if provided. Required if `processModel` is configured.
-6. **Register command handlers** -- For each aggregate in `writeModel.aggregates`, register a command handler on the command bus for each command name defined in `Aggregate.commands`. The registered handler encapsulates the full command lifecycle (load, execute, apply, persist, publish).
-7. **Register standalone command handlers** -- For each handler in `writeModel.standaloneCommandHandlers`, register it on the command bus, wrapping it to receive the merged infrastructure.
-8. **Register query handlers** -- For each projection in `readModel.projections`, register each query handler from `Projection.queryHandlers` on the query bus.
-9. **Register standalone query handlers** -- For each handler in `readModel.standaloneQueryHandlers`, register it on the query bus.
-10. **Register event listeners for projections** -- For each projection, subscribe to each event name in `Projection.reducers` on the event bus. When an event arrives, invoke the reducer to update the projection's view.
-11. **Register event listeners for sagas** -- For each saga in `processModel.sagas`, subscribe to each event name in `Saga.handlers` on the event bus. When an event arrives, execute the saga event handling lifecycle.
+5. **Resolve snapshot store** -- Call `configuration.infrastructure.snapshotStore()` if provided. Store as `this._snapshotStore`. Store `configuration.infrastructure.snapshotStrategy` as `this._snapshotStrategy`. Both are optional.
+6. **Resolve saga persistence** -- Call `configuration.infrastructure.sagaPersistence()` if provided. Required if `processModel` is configured.
+7. **Register command handlers** -- For each aggregate in `writeModel.aggregates`, register a command handler on the command bus for each command name defined in `Aggregate.commands`. The registered handler encapsulates the full command lifecycle (load, execute, apply, persist, publish).
+8. **Register standalone command handlers** -- For each handler in `writeModel.standaloneCommandHandlers`, register it on the command bus, wrapping it to receive the merged infrastructure.
+9. **Register query handlers** -- For each projection in `readModel.projections`, register each query handler from `Projection.queryHandlers` on the query bus.
+10. **Register standalone query handlers** -- For each handler in `readModel.standaloneQueryHandlers`, register it on the query bus.
+11. **Register event listeners for projections** -- For each projection, subscribe to each event name in `Projection.reducers` on the event bus. When an event arrives, invoke the reducer to update the projection's view.
+12. **Register event listeners for sagas** -- For each saga in `processModel.sagas`, subscribe to each event name in `Saga.handlers` on the event bus. When an event arrives, execute the saga event handling lifecycle.
 
 ### Domain.dispatchCommand() -- Command Dispatch Lifecycle
 
@@ -126,7 +129,8 @@ The `dispatchCommand` method executes the following lifecycle for aggregate comm
 
 1. **Route** -- Look up the aggregate whose `commands` map contains a handler for `command.name`. If no aggregate handles this command, check standalone command handlers.
 2. **Load** -- Using the resolved persistence:
-   - **Event-sourced**: Call `persistence.load(aggregateName, command.targetAggregateId)` to get the event stream. Derive `version = events.length`. Replay all events through `Aggregate.apply` handlers, starting from `Aggregate.initialState`, to rebuild the current state.
+   - **Event-sourced (with snapshot)**: If a `SnapshotStore` is configured, call `snapshotStore.load(aggregateName, command.targetAggregateId)` first. If a snapshot is found and the persistence implements `PartialEventLoad`, call `persistence.loadAfterVersion(aggregateName, id, snapshot.version)` to load only post-snapshot events. If the persistence does not implement `PartialEventLoad`, call `persistence.load(aggregateName, id)` and slice the result: `events.slice(snapshot.version)`. Derive `version = snapshot.version + loadedEvents.length`. Replay only the post-snapshot events through `Aggregate.apply` handlers, starting from `snapshot.state`.
+   - **Event-sourced (without snapshot)**: Call `persistence.load(aggregateName, command.targetAggregateId)` to get the full event stream. Derive `version = events.length`. Replay all events through `Aggregate.apply` handlers, starting from `Aggregate.initialState`, to rebuild the current state.
    - **State-stored**: Call `persistence.load(aggregateName, command.targetAggregateId)` to get `{ state, version }` or `null`. If `null`, use `Aggregate.initialState` with `version = 0`.
 3. **Execute** -- Invoke the aggregate's command handler: `aggregate.commands[command.name](command, currentState, infrastructure)`. The handler returns one or more events.
 4. **Apply** -- For each returned event, apply it to the state via `aggregate.apply[event.name](event.payload, state)` to compute the new state. This ensures the aggregate's in-memory state is consistent with the events.
@@ -134,7 +138,8 @@ The `dispatchCommand` method executes the following lifecycle for aggregate comm
    - **Event-sourced**: Call `persistence.save(aggregateName, command.targetAggregateId, newEvents, version)` to append the new events. `version` is the stream length observed at load time.
    - **State-stored**: Call `persistence.save(aggregateName, command.targetAggregateId, newState, version)` to store the updated state. `version` is the version observed at load time.
 6. **Publish** -- For each new event, call `eventBus.dispatch(event)`. This triggers projections and sagas.
-7. **Return** -- Return `command.targetAggregateId`.
+7. **Snapshot (best-effort)** -- After successful persistence and before returning, if both a `SnapshotStore` and `SnapshotStrategy` are configured, evaluate the strategy with `{ version: newVersion, lastSnapshotVersion, eventsSinceSnapshot }`. If the strategy returns `true`, save a snapshot with the new state and version. Snapshot saving is best-effort: failures are silently ignored and do not affect the command result.
+8. **Return** -- Return `command.targetAggregateId`.
 
 ### Domain.dispatchCommand() -- Concurrency Strategy (Strategy Pattern)
 

--- a/specs/engine/implementations/in-memory-aggregate-persistence.spec.md
+++ b/specs/engine/implementations/in-memory-aggregate-persistence.spec.md
@@ -21,7 +21,7 @@ docs:
 
 ```ts
 class InMemoryEventSourcedAggregatePersistence
-  implements EventSourcedAggregatePersistence
+  implements EventSourcedAggregatePersistence, PartialEventLoad
 {
   load(aggregateName: string, aggregateId: string): Promise<Event[]>;
   save(
@@ -30,6 +30,11 @@ class InMemoryEventSourcedAggregatePersistence
     events: Event[],
     expectedVersion: number,
   ): Promise<void>;
+  loadAfterVersion(
+    aggregateName: string,
+    aggregateId: string,
+    afterVersion: number,
+  ): Promise<Event[]>;
 }
 
 class InMemoryStateStoredAggregatePersistence
@@ -61,6 +66,7 @@ class InMemoryStateStoredAggregatePersistence
 4. **Namespace isolation** -- Events for `("Order", "1")` and `("Account", "1")` are stored independently. The aggregate name acts as a namespace.
 5. **Event ordering** -- Events are returned in the order they were appended across all `save` calls. If `save` is called twice with `[e1, e2]` then `[e3]`, `load` returns `[e1, e2, e3]`.
 6. **Concurrency error on version mismatch** -- If `expectedVersion !== currentStreamLength`, `save` throws `ConcurrencyError` with the aggregate name, ID, expected version, and actual version (stream length).
+7. **loadAfterVersion returns partial stream** -- `loadAfterVersion(name, id, afterVersion)` returns events starting at position `afterVersion` in the stream (0-indexed). Equivalent to `allEvents.slice(afterVersion)`. Returns `[]` if `afterVersion >= streamLength`. Returns all events if `afterVersion === 0`.
 
 ### InMemoryStateStoredAggregatePersistence
 
@@ -227,6 +233,84 @@ describe("InMemoryEventSourcedAggregatePersistence", () => {
 
     const loaded = await persistence.load("BankAccount", "acc-1");
     expect(loaded).toHaveLength(1);
+  });
+});
+```
+
+### Event-sourced: loadAfterVersion returns partial stream
+
+```ts
+import { describe, it, expect } from "vitest";
+import { InMemoryEventSourcedAggregatePersistence } from "@noddde/core";
+
+describe("InMemoryEventSourcedAggregatePersistence", () => {
+  it("should return events after the given version", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+
+    await persistence.save(
+      "BankAccount",
+      "acc-1",
+      [
+        { name: "AccountCreated", payload: { id: "acc-1" } },
+        { name: "DepositMade", payload: { amount: 50 } },
+        { name: "DepositMade", payload: { amount: 75 } },
+      ],
+      0,
+    );
+
+    const events = await persistence.loadAfterVersion(
+      "BankAccount",
+      "acc-1",
+      1,
+    );
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({ name: "DepositMade", payload: { amount: 50 } });
+    expect(events[1]).toEqual({
+      name: "DepositMade",
+      payload: { amount: 75 },
+    });
+  });
+
+  it("should return all events when afterVersion is 0", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+
+    await persistence.save(
+      "BankAccount",
+      "acc-1",
+      [
+        { name: "AccountCreated", payload: { id: "acc-1" } },
+        { name: "DepositMade", payload: { amount: 50 } },
+      ],
+      0,
+    );
+
+    const events = await persistence.loadAfterVersion(
+      "BankAccount",
+      "acc-1",
+      0,
+    );
+
+    expect(events).toHaveLength(2);
+  });
+
+  it("should return empty array when afterVersion >= stream length", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+
+    await persistence.save(
+      "BankAccount",
+      "acc-1",
+      [{ name: "AccountCreated", payload: { id: "acc-1" } }],
+      0,
+    );
+
+    const events = await persistence.loadAfterVersion(
+      "BankAccount",
+      "acc-1",
+      5,
+    );
+
+    expect(events).toEqual([]);
   });
 });
 ```

--- a/specs/engine/implementations/in-memory-snapshot-store.spec.md
+++ b/specs/engine/implementations/in-memory-snapshot-store.spec.md
@@ -1,0 +1,169 @@
+---
+title: "InMemorySnapshotStore"
+module: engine/implementations/in-memory-snapshot-store
+source_file: packages/engine/src/implementations/in-memory-snapshot-store.ts
+status: implemented
+exports: [InMemorySnapshotStore]
+depends_on: [persistence/snapshot]
+docs:
+  - running/persistence.mdx
+---
+
+# InMemorySnapshotStore
+
+> In-memory `SnapshotStore` implementation that stores aggregate state snapshots in a `Map`. Snapshots are keyed by a composite `${aggregateName}:${aggregateId}` string. Each `save` call overwrites the previously stored snapshot. `load` returns the latest snapshot or `null` if none exists. Data is lost when the process exits. Suitable for development, testing, and prototyping.
+
+## Type Contract
+
+```ts
+import type { SnapshotStore, Snapshot } from "@noddde/core";
+
+class InMemorySnapshotStore implements SnapshotStore {
+  load(aggregateName: string, aggregateId: string): Promise<Snapshot | null>;
+  save(
+    aggregateName: string,
+    aggregateId: string,
+    snapshot: Snapshot,
+  ): Promise<void>;
+}
+```
+
+- Implements the `SnapshotStore` interface from `@noddde/core`.
+- Uses `Promise`-based APIs for consistency with durable snapshot store implementations, even though the in-memory operations are synchronous.
+
+## Behavioral Requirements
+
+1. **Save overwrites snapshot** -- `save(name, id, snapshot)` stores the snapshot, replacing any previously stored snapshot for the same `(name, id)` pair.
+2. **Load returns latest snapshot** -- `load(name, id)` returns the most recently saved snapshot for `(name, id)`.
+3. **Load returns null for unknown aggregate** -- If no snapshot has been saved for `(name, id)`, `load` returns `null`.
+4. **Namespace isolation** -- Snapshots for `("Order", "1")` and `("Account", "1")` are stored independently.
+5. **Instance isolation** -- Snapshots for `("Order", "1")` and `("Order", "2")` are stored independently.
+
+## Invariants
+
+- Purely in-memory. No filesystem, database, or network I/O.
+- Supports arbitrary aggregate names and IDs (any string).
+- Does not perform validation on the snapshot data being stored.
+- Single-process, non-thread-safe. Concurrent access from multiple async contexts is safe (JavaScript is single-threaded).
+
+## Edge Cases
+
+- **Save then overwrite** -- Saving a new snapshot for the same aggregate replaces the previous one entirely. Only the latest snapshot is accessible.
+- **Save snapshot with version 0** -- Valid but useless (represents initialState). The store does not reject it.
+
+## Integration Points
+
+- **DomainConfiguration.infrastructure.snapshotStore** -- Factory function that creates and returns an `InMemorySnapshotStore`.
+- **Domain.executeCommandLifecycle()** -- The domain loads the snapshot before loading events, and saves a new snapshot after successful commit if the strategy triggers.
+
+## Test Scenarios
+
+### Save and load round-trip
+
+```ts
+import { describe, it, expect } from "vitest";
+import { InMemorySnapshotStore } from "@noddde/core";
+
+describe("InMemorySnapshotStore", () => {
+  it("should store and retrieve a snapshot", async () => {
+    const store = new InMemorySnapshotStore();
+    const snapshot = { state: { balance: 250, owner: "Alice" }, version: 5 };
+
+    await store.save("BankAccount", "acc-1", snapshot);
+    const loaded = await store.load("BankAccount", "acc-1");
+
+    expect(loaded).toEqual(snapshot);
+  });
+});
+```
+
+### Load returns null for unknown aggregate
+
+```ts
+import { describe, it, expect } from "vitest";
+import { InMemorySnapshotStore } from "@noddde/core";
+
+describe("InMemorySnapshotStore", () => {
+  it("should return null when no snapshot exists", async () => {
+    const store = new InMemorySnapshotStore();
+    const loaded = await store.load("BankAccount", "nonexistent");
+
+    expect(loaded).toBeNull();
+  });
+});
+```
+
+### Save overwrites previous snapshot
+
+```ts
+import { describe, it, expect } from "vitest";
+import { InMemorySnapshotStore } from "@noddde/core";
+
+describe("InMemorySnapshotStore", () => {
+  it("should overwrite the snapshot on subsequent saves", async () => {
+    const store = new InMemorySnapshotStore();
+
+    await store.save("BankAccount", "acc-1", {
+      state: { balance: 100 },
+      version: 3,
+    });
+    await store.save("BankAccount", "acc-1", {
+      state: { balance: 200 },
+      version: 7,
+    });
+
+    const loaded = await store.load("BankAccount", "acc-1");
+    expect(loaded).toEqual({ state: { balance: 200 }, version: 7 });
+  });
+});
+```
+
+### Namespace isolation between aggregate types
+
+```ts
+import { describe, it, expect } from "vitest";
+import { InMemorySnapshotStore } from "@noddde/core";
+
+describe("InMemorySnapshotStore", () => {
+  it("should isolate snapshots between different aggregate names", async () => {
+    const store = new InMemorySnapshotStore();
+
+    await store.save("Order", "1", { state: { total: 50 }, version: 2 });
+    await store.save("Account", "1", { state: { balance: 999 }, version: 5 });
+
+    const orderSnapshot = await store.load("Order", "1");
+    const accountSnapshot = await store.load("Account", "1");
+
+    expect(orderSnapshot).toEqual({ state: { total: 50 }, version: 2 });
+    expect(accountSnapshot).toEqual({ state: { balance: 999 }, version: 5 });
+  });
+});
+```
+
+### Instance isolation between aggregate IDs
+
+```ts
+import { describe, it, expect } from "vitest";
+import { InMemorySnapshotStore } from "@noddde/core";
+
+describe("InMemorySnapshotStore", () => {
+  it("should isolate snapshots between different aggregate IDs", async () => {
+    const store = new InMemorySnapshotStore();
+
+    await store.save("BankAccount", "acc-1", {
+      state: { balance: 100 },
+      version: 3,
+    });
+    await store.save("BankAccount", "acc-2", {
+      state: { balance: 500 },
+      version: 8,
+    });
+
+    const acc1 = await store.load("BankAccount", "acc-1");
+    const acc2 = await store.load("BankAccount", "acc-2");
+
+    expect(acc1).toEqual({ state: { balance: 100 }, version: 3 });
+    expect(acc2).toEqual({ state: { balance: 500 }, version: 8 });
+  });
+});
+```

--- a/specs/integration/command-dispatch-lifecycle.spec.md
+++ b/specs/integration/command-dispatch-lifecycle.spec.md
@@ -59,6 +59,9 @@ docs:
 - **Async command handler**: The command handler returns a `Promise<Event[]>`. The framework must await it.
 - **Command handler returns an empty array**: No events are applied, persisted, or published. The aggregate state is unchanged. `dispatchCommand` still returns the aggregateId.
 - **Multiple aggregates**: Two aggregates with different command names coexist; dispatching a command routes to the correct one.
+- **Snapshot-aware dispatch**: When a snapshot store is configured, the engine loads the snapshot, replays only post-snapshot events, and produces the correct state. After enough events, a snapshot is saved per the strategy.
+- **Snapshot fallback**: When the persistence does not implement `PartialEventLoad`, the engine falls back to `load()` + `slice()` and still produces correct state.
+- **No snapshot configured**: Behavior is identical to the non-snapshot path (no regression).
 
 ## Integration Points
 
@@ -455,6 +458,208 @@ describe("Async command handler", () => {
     const events = await persistence.load("AsyncAggregate", "async-1");
     expect(events).toHaveLength(1);
     expect(events[0].payload.result).toBe("HELLO");
+  });
+});
+```
+
+### Snapshot-aware dispatch: snapshot triggers and subsequent command uses snapshot
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import {
+  defineAggregate,
+  configureDomain,
+  InMemoryEventSourcedAggregatePersistence,
+  InMemorySnapshotStore,
+  InMemoryCommandBus,
+  InMemoryQueryBus,
+  EventEmitterEventBus,
+  everyNEvents,
+} from "@noddde/core";
+import type { DefineCommands, DefineEvents } from "@noddde/core";
+
+type CounterState = { count: number };
+
+type CounterEvent = DefineEvents<{
+  Incremented: { amount: number };
+}>;
+
+type CounterCommand = DefineCommands<{
+  Increment: { amount: number };
+}>;
+
+type CounterTypes = {
+  state: CounterState;
+  events: CounterEvent;
+  commands: CounterCommand;
+  infrastructure: {};
+};
+
+const Counter = defineAggregate<CounterTypes>({
+  initialState: { count: 0 },
+  commands: {
+    Increment: (command, state) => ({
+      name: "Incremented",
+      payload: { amount: command.payload.amount },
+    }),
+  },
+  apply: {
+    Incremented: (payload, state) => ({ count: state.count + payload.amount }),
+  },
+});
+
+describe("Snapshot-aware command dispatch", () => {
+  it("should save a snapshot when the strategy triggers and use it for subsequent loads", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+    const snapshotStore = new InMemorySnapshotStore();
+    const eventBus = new EventEmitterEventBus();
+
+    const domain = await configureDomain({
+      writeModel: { aggregates: { Counter } },
+      readModel: { projections: {} },
+      infrastructure: {
+        aggregatePersistence: () => persistence,
+        snapshotStore: () => snapshotStore,
+        snapshotStrategy: everyNEvents(3),
+        cqrsInfrastructure: () => ({
+          commandBus: new InMemoryCommandBus(),
+          eventBus,
+          queryBus: new InMemoryQueryBus(),
+        }),
+      },
+    });
+
+    // Dispatch 3 commands — snapshot should trigger after the 3rd
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "counter-1",
+      payload: { amount: 1 },
+    });
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "counter-1",
+      payload: { amount: 2 },
+    });
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "counter-1",
+      payload: { amount: 3 },
+    });
+
+    // Verify snapshot was saved at version 3 with state { count: 6 }
+    const snapshot = await snapshotStore.load("Counter", "counter-1");
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.version).toBe(3);
+    expect(snapshot!.state).toEqual({ count: 6 });
+
+    // Spy on loadAfterVersion to verify it's used for subsequent commands
+    const loadAfterVersionSpy = vi.spyOn(persistence, "loadAfterVersion");
+
+    // Dispatch a 4th command — should use the snapshot
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "counter-1",
+      payload: { amount: 4 },
+    });
+
+    // Verify loadAfterVersion was called with snapshot version
+    expect(loadAfterVersionSpy).toHaveBeenCalledWith("Counter", "counter-1", 3);
+
+    // Verify the event stream has all 4 events
+    const events = await persistence.load("Counter", "counter-1");
+    expect(events).toHaveLength(4);
+  });
+
+  it("should produce correct state across snapshot boundaries", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+    const snapshotStore = new InMemorySnapshotStore();
+
+    const domain = await configureDomain({
+      writeModel: { aggregates: { Counter } },
+      readModel: { projections: {} },
+      infrastructure: {
+        aggregatePersistence: () => persistence,
+        snapshotStore: () => snapshotStore,
+        snapshotStrategy: everyNEvents(2),
+        cqrsInfrastructure: () => ({
+          commandBus: new InMemoryCommandBus(),
+          eventBus: new EventEmitterEventBus(),
+          queryBus: new InMemoryQueryBus(),
+        }),
+      },
+    });
+
+    // Dispatch 5 commands: snapshots at version 2 and 4
+    for (let i = 1; i <= 5; i++) {
+      await domain.dispatchCommand({
+        name: "Increment",
+        targetAggregateId: "counter-1",
+        payload: { amount: i },
+      });
+    }
+
+    // Verify final event stream (1+2+3+4+5 = 15 total)
+    const events = await persistence.load("Counter", "counter-1");
+    expect(events).toHaveLength(5);
+
+    // Verify the latest snapshot exists
+    const snapshot = await snapshotStore.load("Counter", "counter-1");
+    expect(snapshot).not.toBeNull();
+    // Snapshot should be at version 4 (last threshold crossing)
+    // with state { count: 1+2+3+4 = 10 }
+    expect(snapshot!.version).toBe(4);
+    expect(snapshot!.state).toEqual({ count: 10 });
+  });
+});
+```
+
+### Snapshot-aware dispatch: no snapshot configured (no regression)
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  defineAggregate,
+  configureDomain,
+  InMemoryEventSourcedAggregatePersistence,
+  InMemoryCommandBus,
+  InMemoryQueryBus,
+  EventEmitterEventBus,
+} from "@noddde/core";
+import type { DefineCommands, DefineEvents } from "@noddde/core";
+
+// Reuse Counter from above
+
+describe("Command dispatch without snapshot (regression check)", () => {
+  it("should work identically without snapshot store configured", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+
+    const domain = await configureDomain({
+      writeModel: { aggregates: { Counter } },
+      readModel: { projections: {} },
+      infrastructure: {
+        aggregatePersistence: () => persistence,
+        // No snapshotStore, no snapshotStrategy
+        cqrsInfrastructure: () => ({
+          commandBus: new InMemoryCommandBus(),
+          eventBus: new EventEmitterEventBus(),
+          queryBus: new InMemoryQueryBus(),
+        }),
+      },
+    });
+
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "counter-1",
+      payload: { amount: 5 },
+    });
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "counter-1",
+      payload: { amount: 3 },
+    });
+
+    const events = await persistence.load("Counter", "counter-1");
+    expect(events).toHaveLength(2);
   });
 });
 ```

--- a/specs/prisma/prisma-persistence.spec.md
+++ b/specs/prisma/prisma-persistence.spec.md
@@ -9,12 +9,14 @@ exports:
   - PrismaEventSourcedAggregatePersistence
   - PrismaStateStoredAggregatePersistence
   - PrismaSagaPersistence
+  - PrismaSnapshotStore
   - PrismaAdvisoryLocker
   - PrismaUnitOfWork
   - PrismaTransactionStore
 depends_on:
   - core/persistence/persistence
   - core/persistence/unit-of-work
+  - core/persistence/snapshot
 docs:
   - running/orm-adapters.mdx
 ---
@@ -33,6 +35,9 @@ import type {
   SagaPersistence,
   UnitOfWorkFactory,
   AggregateLocker,
+  SnapshotStore,
+  Snapshot,
+  PartialEventLoad,
 } from "@noddde/core";
 
 /**
@@ -50,6 +55,7 @@ export interface PrismaPersistenceInfrastructure {
   eventSourcedPersistence: EventSourcedAggregatePersistence;
   stateStoredPersistence: StateStoredAggregatePersistence;
   sagaPersistence: SagaPersistence;
+  snapshotStore: SnapshotStore;
   unitOfWorkFactory: UnitOfWorkFactory;
 }
 
@@ -66,7 +72,7 @@ export function createPrismaPersistence(
  * Prisma-backed event-sourced aggregate persistence.
  */
 export class PrismaEventSourcedAggregatePersistence
-  implements EventSourcedAggregatePersistence
+  implements EventSourcedAggregatePersistence, PartialEventLoad
 {
   constructor(prisma: PrismaClient, txStore: PrismaTransactionStore);
   save(
@@ -76,6 +82,11 @@ export class PrismaEventSourcedAggregatePersistence
     expectedVersion: number,
   ): Promise<void>;
   load(aggregateName: string, aggregateId: string): Promise<Event[]>;
+  loadAfterVersion(
+    aggregateName: string,
+    aggregateId: string,
+    afterVersion: number,
+  ): Promise<Event[]>;
 }
 
 /**
@@ -135,6 +146,19 @@ export class PrismaAdvisoryLocker implements AggregateLocker {
   ): Promise<void>;
   release(aggregateName: string, aggregateId: string): Promise<void>;
 }
+
+/**
+ * Prisma-backed snapshot store for event-sourced aggregate state snapshotting.
+ */
+export class PrismaSnapshotStore implements SnapshotStore {
+  constructor(prisma: PrismaClient, txStore: PrismaTransactionStore);
+  load(aggregateName: string, aggregateId: string): Promise<Snapshot | null>;
+  save(
+    aggregateName: string,
+    aggregateId: string,
+    snapshot: Snapshot,
+  ): Promise<void>;
+}
 ```
 
 ## Behavioral Requirements
@@ -186,6 +210,13 @@ export class PrismaAdvisoryLocker implements AggregateLocker {
 
 26. All persistence classes use `getExecutor()` which returns `txStore.current ?? prisma`, routing operations through the active transaction when inside a UoW.
 
+### Snapshot Store
+
+27. `PrismaSnapshotStore.save()` upserts the snapshot using `findUnique` + conditional `create`/`update` on the `NodddeSnapshot` model.
+28. `PrismaSnapshotStore.load()` uses `findUnique` on the composite key and returns `{ state: JSON.parse(row.state), version: row.version }`, or `null` if not found.
+29. `PrismaEventSourcedAggregatePersistence.loadAfterVersion()` loads events with `sequenceNumber: { gt: afterVersion }` ordered by `sequenceNumber: "asc"`.
+30. Snapshot operations route through `txStore.current` like all other persistence operations.
+
 ## Invariants
 
 - [ ] Events saved and loaded maintain FIFO order (sequenceNumber ordering).
@@ -214,7 +245,9 @@ export class PrismaAdvisoryLocker implements AggregateLocker {
 - UoW satisfies `UnitOfWork` from `@noddde/core`.
 - Advisory locker satisfies `AggregateLocker` from `@noddde/core`.
 - Factory return type matches the infrastructure shape expected by `configureDomain()`.
-- Requires a Prisma schema with `NodddeEvent`, `NodddeAggregateState`, and `NodddeSagaState` models.
+- Snapshot store satisfies `SnapshotStore` from `@noddde/core`.
+- Event-sourced persistence also satisfies `PartialEventLoad` from `@noddde/core`.
+- Requires a Prisma schema with `NodddeEvent`, `NodddeAggregateState`, `NodddeSagaState`, and `NodddeSnapshot` models.
 
 ## Storage Schema (Prisma)
 
@@ -248,6 +281,16 @@ model NodddeSagaState {
 
   @@id([sagaName, sagaId])
   @@map("noddde_saga_states")
+}
+
+model NodddeSnapshot {
+  aggregateName String @map("aggregate_name")
+  aggregateId   String @map("aggregate_id")
+  state         String
+  version       Int
+
+  @@id([aggregateName, aggregateId])
+  @@map("noddde_snapshots")
 }
 ```
 
@@ -547,5 +590,137 @@ it("should rollback without persisting anything", async () => {
   await uow.rollback();
   const events = await infra.eventSourcedPersistence.load("Account", "acc-1");
   expect(events).toEqual([]);
+});
+```
+
+### Snapshot store: save and load roundtrip
+
+```ts
+describe("PrismaSnapshotStore", () => {
+  beforeEach(setupDb);
+  afterEach(teardownDb);
+
+  it("should save and load a snapshot", async () => {
+    await infra.snapshotStore.save("Account", "acc-1", {
+      state: { balance: 500 },
+      version: 5,
+    });
+    const snapshot = await infra.snapshotStore.load("Account", "acc-1");
+    expect(snapshot).toEqual({ state: { balance: 500 }, version: 5 });
+  });
+});
+```
+
+### Snapshot store: returns null for unknown aggregate
+
+```ts
+it("should return null for unknown aggregate", async () => {
+  const snapshot = await infra.snapshotStore.load("Account", "nonexistent");
+  expect(snapshot).toBeNull();
+});
+```
+
+### Snapshot store: overwrites on repeated saves
+
+```ts
+it("should overwrite snapshot on repeated saves", async () => {
+  await infra.snapshotStore.save("Account", "acc-1", {
+    state: { balance: 100 },
+    version: 2,
+  });
+  await infra.snapshotStore.save("Account", "acc-1", {
+    state: { balance: 500 },
+    version: 5,
+  });
+  const snapshot = await infra.snapshotStore.load("Account", "acc-1");
+  expect(snapshot).toEqual({ state: { balance: 500 }, version: 5 });
+});
+```
+
+### Snapshot store: isolates by aggregate name
+
+```ts
+it("should isolate snapshots by aggregate name", async () => {
+  await infra.snapshotStore.save("Account", "1", {
+    state: { balance: 100 },
+    version: 2,
+  });
+  await infra.snapshotStore.save("Order", "1", {
+    state: { total: 200 },
+    version: 3,
+  });
+  const account = await infra.snapshotStore.load("Account", "1");
+  const order = await infra.snapshotStore.load("Order", "1");
+  expect(account).toEqual({ state: { balance: 100 }, version: 2 });
+  expect(order).toEqual({ state: { total: 200 }, version: 3 });
+});
+```
+
+### Event-sourced: loadAfterVersion returns events after given version
+
+```ts
+describe("PrismaEventSourcedAggregatePersistence - PartialEventLoad", () => {
+  beforeEach(setupDb);
+  afterEach(teardownDb);
+
+  it("should load events after a given version", async () => {
+    await infra.eventSourcedPersistence.save(
+      "Account",
+      "acc-1",
+      [
+        { name: "AccountCreated", payload: { owner: "Alice" } },
+        { name: "DepositMade", payload: { amount: 100 } },
+        { name: "DepositMade", payload: { amount: 200 } },
+      ],
+      0,
+    );
+    const events = await (
+      infra.eventSourcedPersistence as any
+    ).loadAfterVersion("Account", "acc-1", 1);
+    expect(events).toHaveLength(2);
+    expect(events[0]!.name).toBe("DepositMade");
+    expect(events[0]!.payload).toEqual({ amount: 100 });
+  });
+});
+```
+
+### Event-sourced: loadAfterVersion returns empty for version beyond stream
+
+```ts
+it("should return empty array when afterVersion >= stream length", async () => {
+  await infra.eventSourcedPersistence.save(
+    "Account",
+    "acc-1",
+    [{ name: "AccountCreated", payload: { owner: "Alice" } }],
+    0,
+  );
+  const events = await (infra.eventSourcedPersistence as any).loadAfterVersion(
+    "Account",
+    "acc-1",
+    99,
+  );
+  expect(events).toEqual([]);
+});
+```
+
+### Event-sourced: loadAfterVersion with version 0 returns all events
+
+```ts
+it("should return all events when afterVersion is 0", async () => {
+  await infra.eventSourcedPersistence.save(
+    "Account",
+    "acc-1",
+    [
+      { name: "AccountCreated", payload: { owner: "Alice" } },
+      { name: "DepositMade", payload: { amount: 50 } },
+    ],
+    0,
+  );
+  const events = await (infra.eventSourcedPersistence as any).loadAfterVersion(
+    "Account",
+    "acc-1",
+    0,
+  );
+  expect(events).toHaveLength(2);
 });
 ```

--- a/specs/typeorm/typeorm-persistence.spec.md
+++ b/specs/typeorm/typeorm-persistence.spec.md
@@ -9,15 +9,18 @@ exports:
   - TypeORMEventSourcedAggregatePersistence
   - TypeORMStateStoredAggregatePersistence
   - TypeORMSagaPersistence
+  - TypeORMSnapshotStore
   - TypeORMAdvisoryLocker
   - TypeORMUnitOfWork
   - TypeORMTransactionStore
   - NodddeEventEntity
   - NodddeAggregateStateEntity
   - NodddeSagaStateEntity
+  - NodddeSnapshotEntity
 depends_on:
   - core/persistence/persistence
   - core/persistence/unit-of-work
+  - core/persistence/snapshot
 docs:
   - running/orm-adapters.mdx
 ---
@@ -32,6 +35,9 @@ docs:
 import type { DataSource, EntityManager } from "typeorm";
 import type {
   EventSourcedAggregatePersistence,
+  PartialEventLoad,
+  Snapshot,
+  SnapshotStore,
   StateStoredAggregatePersistence,
   SagaPersistence,
   UnitOfWorkFactory,
@@ -53,6 +59,7 @@ export interface TypeORMPersistenceInfrastructure {
   eventSourcedPersistence: EventSourcedAggregatePersistence;
   stateStoredPersistence: StateStoredAggregatePersistence;
   sagaPersistence: SagaPersistence;
+  snapshotStore: SnapshotStore;
   unitOfWorkFactory: UnitOfWorkFactory;
 }
 
@@ -69,7 +76,7 @@ export function createTypeORMPersistence(
  * TypeORM-backed event-sourced aggregate persistence.
  */
 export class TypeORMEventSourcedAggregatePersistence
-  implements EventSourcedAggregatePersistence
+  implements EventSourcedAggregatePersistence, PartialEventLoad
 {
   constructor(dataSource: DataSource, txStore: TypeORMTransactionStore);
   save(
@@ -79,6 +86,24 @@ export class TypeORMEventSourcedAggregatePersistence
     expectedVersion: number,
   ): Promise<void>;
   load(aggregateName: string, aggregateId: string): Promise<Event[]>;
+  loadAfterVersion(
+    aggregateName: string,
+    aggregateId: string,
+    afterVersion: number,
+  ): Promise<Event[]>;
+}
+
+/**
+ * TypeORM-backed snapshot store for aggregate state snapshots.
+ */
+export class TypeORMSnapshotStore implements SnapshotStore {
+  constructor(dataSource: DataSource, txStore: TypeORMTransactionStore);
+  load(aggregateName: string, aggregateId: string): Promise<Snapshot | null>;
+  save(
+    aggregateName: string,
+    aggregateId: string,
+    snapshot: Snapshot,
+  ): Promise<void>;
 }
 
 /**
@@ -206,6 +231,24 @@ export class NodddeSagaStateEntity {
   @Column({ type: "text" })
   state!: string;
 }
+
+/**
+ * TypeORM entity for aggregate state snapshots.
+ */
+@Entity("noddde_snapshots")
+export class NodddeSnapshotEntity {
+  @PrimaryColumn({ name: "aggregate_name" })
+  aggregateName!: string;
+
+  @PrimaryColumn({ name: "aggregate_id" })
+  aggregateId!: string;
+
+  @Column({ type: "text" })
+  state!: string;
+
+  @Column({ type: "int" })
+  version!: number;
+}
 ```
 
 ## Behavioral Requirements
@@ -265,6 +308,14 @@ export class NodddeSagaStateEntity {
 30. `NodddeAggregateStateEntity` maps to table `noddde_aggregate_states` with `@PrimaryColumn` composite key on `[aggregateName, aggregateId]` and a `version` column with `default: 0`.
 31. `NodddeSagaStateEntity` maps to table `noddde_saga_states` with `@PrimaryColumn` composite key on `[sagaName, sagaId]`.
 
+### Snapshot Store
+
+32. `TypeORMSnapshotStore.save()` upserts the snapshot using `findOne` + conditional `save` (create if new, update if exists).
+33. `TypeORMSnapshotStore.load()` uses `findOne` and returns `{ state: JSON.parse(row.state), version: row.version }`, or `null` if not found.
+34. `TypeORMEventSourcedAggregatePersistence.loadAfterVersion()` uses TypeORM's `MoreThan(afterVersion)` operator to load events with `sequenceNumber > afterVersion`, ordered by `sequenceNumber: "ASC"`.
+35. `NodddeSnapshotEntity` maps to table `noddde_snapshots` with `@PrimaryColumn` composite key on `[aggregateName, aggregateId]`.
+36. Snapshot operations route through `txStore.current` like all other persistence operations.
+
 ## Invariants
 
 - [ ] Events saved and loaded maintain FIFO order (sequenceNumber ordering).
@@ -322,6 +373,12 @@ noddde_saga_states
 ├── saga_name        (string, PK part 1, @PrimaryColumn)
 ├── saga_id          (string, PK part 2, @PrimaryColumn)
 └── state            (text, NOT NULL)
+
+noddde_snapshots
+├── aggregate_name   (string, PK part 1, @PrimaryColumn)
+├── aggregate_id     (string, PK part 2, @PrimaryColumn)
+├── state            (text, NOT NULL)
+└── version          (int, NOT NULL)
 ```
 
 ## Test Scenarios
@@ -638,6 +695,133 @@ it("should rollback without persisting anything", async () => {
   );
   await uow.rollback();
   const events = await infra.eventSourcedPersistence.load("Account", "acc-1");
+  expect(events).toEqual([]);
+});
+```
+
+### Snapshot store: save and load roundtrip
+
+```ts
+describe("TypeORMSnapshotStore", () => {
+  beforeEach(setupDb);
+  afterEach(teardownDb);
+
+  it("should save and load a snapshot", async () => {
+    await infra.snapshotStore.save("Account", "acc-1", {
+      state: { balance: 500 },
+      version: 10,
+    });
+    const snapshot = await infra.snapshotStore.load("Account", "acc-1");
+    expect(snapshot).toEqual({ state: { balance: 500 }, version: 10 });
+  });
+});
+```
+
+### Snapshot store: returns null for unknown aggregate
+
+```ts
+it("should return null for unknown aggregate", async () => {
+  const snapshot = await infra.snapshotStore.load("Account", "nonexistent");
+  expect(snapshot).toBeNull();
+});
+```
+
+### Snapshot store: overwrites on repeated saves
+
+```ts
+it("should overwrite snapshot on repeated saves", async () => {
+  await infra.snapshotStore.save("Account", "acc-1", {
+    state: { balance: 100 },
+    version: 5,
+  });
+  await infra.snapshotStore.save("Account", "acc-1", {
+    state: { balance: 300 },
+    version: 15,
+  });
+  const snapshot = await infra.snapshotStore.load("Account", "acc-1");
+  expect(snapshot).toEqual({ state: { balance: 300 }, version: 15 });
+});
+```
+
+### Snapshot store: isolates by aggregate name and id
+
+```ts
+it("should isolate snapshots by aggregate name and id", async () => {
+  await infra.snapshotStore.save("Order", "1", {
+    state: { total: 200 },
+    version: 3,
+  });
+  await infra.snapshotStore.save("Account", "1", {
+    state: { balance: 100 },
+    version: 7,
+  });
+  const orderSnapshot = await infra.snapshotStore.load("Order", "1");
+  const accountSnapshot = await infra.snapshotStore.load("Account", "1");
+  expect(orderSnapshot).toEqual({ state: { total: 200 }, version: 3 });
+  expect(accountSnapshot).toEqual({ state: { balance: 100 }, version: 7 });
+});
+```
+
+### loadAfterVersion: loads events after a given version
+
+```ts
+describe("TypeORMEventSourcedAggregatePersistence (loadAfterVersion)", () => {
+  beforeEach(setupDb);
+  afterEach(teardownDb);
+
+  it("should load events after a given version", async () => {
+    await infra.eventSourcedPersistence.save(
+      "Account",
+      "acc-1",
+      [
+        { name: "AccountCreated", payload: { owner: "Alice" } },
+        { name: "DepositMade", payload: { amount: 100 } },
+        { name: "DepositMade", payload: { amount: 50 } },
+      ],
+      0,
+    );
+    const persistence =
+      infra.eventSourcedPersistence as TypeORMEventSourcedAggregatePersistence;
+    const events = await persistence.loadAfterVersion("Account", "acc-1", 1);
+    expect(events).toHaveLength(2);
+    expect(events[0]!.name).toBe("DepositMade");
+  });
+});
+```
+
+### loadAfterVersion: returns all events when afterVersion is 0
+
+```ts
+it("should return all events when afterVersion is 0", async () => {
+  await infra.eventSourcedPersistence.save(
+    "Account",
+    "acc-1",
+    [
+      { name: "AccountCreated", payload: { owner: "Alice" } },
+      { name: "DepositMade", payload: { amount: 100 } },
+    ],
+    0,
+  );
+  const persistence =
+    infra.eventSourcedPersistence as TypeORMEventSourcedAggregatePersistence;
+  const events = await persistence.loadAfterVersion("Account", "acc-1", 0);
+  expect(events).toHaveLength(2);
+});
+```
+
+### loadAfterVersion: returns empty array when afterVersion >= stream length
+
+```ts
+it("should return empty array when afterVersion >= stream length", async () => {
+  await infra.eventSourcedPersistence.save(
+    "Account",
+    "acc-1",
+    [{ name: "AccountCreated", payload: { owner: "Alice" } }],
+    0,
+  );
+  const persistence =
+    infra.eventSourcedPersistence as TypeORMEventSourcedAggregatePersistence;
+  const events = await persistence.loadAfterVersion("Account", "acc-1", 10);
   expect(events).toEqual([]);
 });
 ```


### PR DESCRIPTION
## Summary

- Add periodic state snapshotting to avoid replaying the full event stream on every command dispatch for event-sourced aggregates
- Core types: `Snapshot`, `SnapshotStore`, `SnapshotStrategy`, `PartialEventLoad`, `everyNEvents` in `@noddde/core`
- In-memory implementations (`InMemorySnapshotStore`, `PartialEventLoad` on `InMemoryEventSourcedAggregatePersistence`) in `@noddde/engine`
- Domain engine integration: snapshot-aware load path + post-commit snapshot save (best-effort, outside UoW)
- ORM adapter support for all 3 adapters:
  - `DrizzleSnapshotStore` with `noddde_snapshots` table (pg/mysql/sqlite)
  - `PrismaSnapshotStore` with `NodddeSnapshot` Prisma model
  - `TypeORMSnapshotStore` with `NodddeSnapshotEntity`
  - `PartialEventLoad.loadAfterVersion()` on all event-sourced persistence classes

## Design decisions

- **Separate `SnapshotStore` interface** (not embedded in `EventSourcedAggregatePersistence`): single responsibility, independent lifecycle, non-breaking
- **Optional `PartialEventLoad`**: duck-typed interface for I/O optimization; engine falls back to `load()` + `slice()` if not available
- **Snapshot saving outside UoW**: snapshots are a cache, not a consistency guarantee — failed save doesn't roll back committed events
- **`noddde_snapshots` table**: composite PK on `(aggregate_name, aggregate_id)`, upsert on save, JSON state column

## Test plan

- [x] `everyNEvents` strategy: below/at/above threshold, n=1 always triggers
- [x] `InMemorySnapshotStore`: save/load round-trip, null for unknown, overwrite, namespace/instance isolation
- [x] `InMemoryEventSourcedAggregatePersistence.loadAfterVersion`: partial load, afterVersion=0, afterVersion >= length
- [x] Snapshot-aware command dispatch integration tests (with and without `PartialEventLoad`)
- [x] Drizzle adapter: `DrizzleSnapshotStore` + `loadAfterVersion` (21/21 passing)
- [x] Prisma adapter: `PrismaSnapshotStore` + `loadAfterVersion` (27/27 passing)
- [x] TypeORM adapter: `TypeORMSnapshotStore` + `loadAfterVersion` (35/35 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)