### PR TITLE
ci: publish all packages and deploy docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,64 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/out
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,21 +39,65 @@ jobs:
       - name: Test
         run: yarn test
 
-      - name: Set package version from tag
+      - name: Set package versions from tag
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           echo "Publishing version: $VERSION"
-          cd packages/core && npm version "$VERSION" --no-git-tag-version && cd ../..
-          cd packages/engine && npm version "$VERSION" --no-git-tag-version && cd ../..
 
+          # Set own version for all publishable packages
+          for dir in packages/core packages/engine packages/testing packages/adapters/drizzle packages/adapters/prisma packages/adapters/typeorm; do
+            cd "$dir"
+            npm version "$VERSION" --no-git-tag-version
+            cd "$GITHUB_WORKSPACE"
+          done
+
+          # Rewrite internal dependency versions
+          for dir in packages/engine packages/adapters/drizzle packages/adapters/prisma packages/adapters/typeorm; do
+            cd "$dir"
+            npm pkg set "dependencies.@noddde/core=$VERSION"
+            cd "$GITHUB_WORKSPACE"
+          done
+
+          cd packages/testing
+          npm pkg set "dependencies.@noddde/core=$VERSION"
+          npm pkg set "dependencies.@noddde/engine=$VERSION"
+          cd "$GITHUB_WORKSPACE"
+
+      # Tier 1: no internal dependencies
       - name: Publish @noddde/core
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         working-directory: packages/core
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # Tier 2: depends on core only
       - name: Publish @noddde/engine
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         working-directory: packages/engine
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @noddde/drizzle
+        run: npm publish --access public --provenance
+        working-directory: packages/adapters/drizzle
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @noddde/prisma
+        run: npm publish --access public --provenance
+        working-directory: packages/adapters/prisma
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @noddde/typeorm
+        run: npm publish --access public --provenance
+        working-directory: packages/adapters/typeorm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Tier 3: depends on core + engine
+      - name: Publish @noddde/testing
+        run: npm publish --access public --provenance
+        working-directory: packages/testing
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -5,6 +5,9 @@ const withMDX = createMDX();
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
+  output: "export",
+  basePath: "/noddde",
+  images: { unoptimized: true },
 };
 
 export default withMDX(config);

--- a/docs/src/app/docs/layout.tsx
+++ b/docs/src/app/docs/layout.tsx
@@ -1,5 +1,6 @@
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { source } from "@/lib/source";
+import Image from "next/image";
 import type { ReactNode } from "react";
 
 export default function Layout({ children }: { children: ReactNode }) {
@@ -9,16 +10,14 @@ export default function Layout({ children }: { children: ReactNode }) {
       nav={{
         title: (
           <div className="flex items-center gap-2">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
+            <Image
               src="/icon-light.png"
               alt=""
               width={20}
               height={14}
               className="logo-light"
             />
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
+            <Image
               src="/icon-dark.png"
               alt=""
               width={20}

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -1,18 +1,17 @@
+import Image from "next/image";
 import Link from "next/link";
 
 export default function HomePage() {
   return (
     <main className="fixed inset-0 flex flex-col items-center justify-center px-6">
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
+      <Image
         src="/icon-light.png"
         alt="noddde"
         width={56}
         height={40}
         className="logo-light"
       />
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
+      <Image
         src="/icon-dark.png"
         alt="noddde"
         width={56}


### PR DESCRIPTION
## Summary
- Extend release workflow to publish all 6 public packages (`core`, `engine`, `testing`, `drizzle`, `prisma`, `typeorm`) with tiered dependency ordering and internal version rewriting
- Add `--provenance` flag for npm supply-chain security
- Add new GitHub Pages workflow to deploy Fumadocs documentation on every push to `main`
- Configure Next.js static export with `basePath: "/noddde"` and switch `<img>` to `next/image` for correct asset paths

## Test plan
- [ ] Verify CI passes (lint, build, test)
- [ ] Enable GitHub Pages in repo settings with Source = "GitHub Actions"
- [ ] Test release workflow on next `v*` tag — confirm all 6 packages are published to npm
- [ ] Verify docs deploy to `https://dogganidhal.github.io/noddde/` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)