### PR TITLE
fix(docs): remove basePath and add CNAME for custom domain

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -6,7 +6,6 @@ const withMDX = createMDX();
 const config = {
   reactStrictMode: true,
   output: "export",
-  basePath: "/noddde",
   images: { unoptimized: true },
 };
 

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+noddde.dev


### PR DESCRIPTION
## Summary
- Remove `basePath: "/noddde"` from Next.js config — it was breaking all asset/link paths since the site is served from `noddde.dev` (root), not a GitHub Pages subpath
- Add `docs/public/CNAME` with `noddde.dev` so GitHub Pages preserves the custom domain across deployments

## Test plan
- [ ] Verify docs deploy succeeds after merge
- [ ] Confirm `noddde.dev` loads correctly with working navigation and assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)