### PR TITLE
fix(ci): use npm pkg set instead of npm version for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           # Set own version for all publishable packages
           for dir in packages/core packages/engine packages/testing packages/adapters/drizzle packages/adapters/prisma packages/adapters/typeorm; do
             cd "$dir"
-            npm version "$VERSION" --no-git-tag-version
+            npm pkg set "version=$VERSION"
             cd "$GITHUB_WORKSPACE"
           done
 


### PR DESCRIPTION
## Summary
- Replace `npm version` with `npm pkg set "version=$VERSION"` in the release workflow
- `npm version` queries the registry and fails with 404 when a package has never been published; `npm pkg set` edits `package.json` directly without registry lookups

## Test plan
- [ ] Merge, then delete and re-push the `v0.0.2-alpha` tag to re-trigger the release workflow
- [ ] Verify all 6 packages are published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)