### PR TITLE
fix: add repository and metadata to all publishable packages

### DIFF
--- a/packages/adapters/drizzle/package.json
+++ b/packages/adapters/drizzle/package.json
@@ -1,6 +1,26 @@
 {
   "name": "@noddde/drizzle",
   "version": "0.0.0",
+  "description": "Drizzle ORM persistence adapter for noddde",
+  "license": "MIT",
+  "author": "Nidhal Dogga",
+  "homepage": "https://noddde.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dogganidhal/noddde",
+    "directory": "packages/adapters/drizzle"
+  },
+  "bugs": {
+    "url": "https://github.com/dogganidhal/noddde/issues"
+  },
+  "keywords": [
+    "ddd",
+    "cqrs",
+    "event-sourcing",
+    "drizzle",
+    "typescript",
+    "persistence"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/adapters/prisma/package.json
+++ b/packages/adapters/prisma/package.json
@@ -1,6 +1,26 @@
 {
   "name": "@noddde/prisma",
   "version": "0.0.0",
+  "description": "Prisma persistence adapter for noddde",
+  "license": "MIT",
+  "author": "Nidhal Dogga",
+  "homepage": "https://noddde.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dogganidhal/noddde",
+    "directory": "packages/adapters/prisma"
+  },
+  "bugs": {
+    "url": "https://github.com/dogganidhal/noddde/issues"
+  },
+  "keywords": [
+    "ddd",
+    "cqrs",
+    "event-sourcing",
+    "prisma",
+    "typescript",
+    "persistence"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/adapters/typeorm/package.json
+++ b/packages/adapters/typeorm/package.json
@@ -1,6 +1,26 @@
 {
   "name": "@noddde/typeorm",
   "version": "0.0.0",
+  "description": "TypeORM persistence adapter for noddde",
+  "license": "MIT",
+  "author": "Nidhal Dogga",
+  "homepage": "https://noddde.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dogganidhal/noddde",
+    "directory": "packages/adapters/typeorm"
+  },
+  "bugs": {
+    "url": "https://github.com/dogganidhal/noddde/issues"
+  },
+  "keywords": [
+    "ddd",
+    "cqrs",
+    "event-sourcing",
+    "typeorm",
+    "typescript",
+    "persistence"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,26 @@
 {
   "name": "@noddde/core",
   "version": "0.0.0",
+  "description": "TypeScript types and definitions for DDD, CQRS, and Event Sourcing using the functional Decider pattern",
+  "license": "MIT",
+  "author": "Nidhal Dogga",
+  "homepage": "https://noddde.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dogganidhal/noddde",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/dogganidhal/noddde/issues"
+  },
+  "keywords": [
+    "ddd",
+    "cqrs",
+    "event-sourcing",
+    "decider",
+    "typescript",
+    "domain-driven-design"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,26 @@
 {
   "name": "@noddde/engine",
   "version": "0.0.0",
+  "description": "Runtime engine for noddde: domain orchestration and in-memory implementations for DDD, CQRS, and Event Sourcing",
+  "license": "MIT",
+  "author": "Nidhal Dogga",
+  "homepage": "https://noddde.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dogganidhal/noddde",
+    "directory": "packages/engine"
+  },
+  "bugs": {
+    "url": "https://github.com/dogganidhal/noddde/issues"
+  },
+  "keywords": [
+    "ddd",
+    "cqrs",
+    "event-sourcing",
+    "decider",
+    "typescript",
+    "domain-driven-design"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,25 @@
 {
   "name": "@noddde/testing",
   "version": "0.0.0",
+  "description": "Testing utilities and harnesses for noddde domains",
+  "license": "MIT",
+  "author": "Nidhal Dogga",
+  "homepage": "https://noddde.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dogganidhal/noddde",
+    "directory": "packages/testing"
+  },
+  "bugs": {
+    "url": "https://github.com/dogganidhal/noddde/issues"
+  },
+  "keywords": [
+    "ddd",
+    "cqrs",
+    "event-sourcing",
+    "testing",
+    "typescript"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary
- Add `repository.url`, `license`, `description`, `author`, `homepage`, `bugs`, and `keywords` to all 6 publishable packages (`core`, `engine`, `testing`, `drizzle`, `prisma`, `typeorm`)
- Fixes npm provenance 422 error: `--provenance` requires `repository.url` to match the GitHub repo URL

## Test plan
- [ ] Verify CI passes (lint, build, test)
- [ ] Merge, then re-tag `v0.0.2-alpha` to trigger release workflow
- [ ] Confirm all 6 packages publish successfully to npm with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)