### PR TITLE
docs: cross-link sample directories from pattern pages and getting started

### DIFF
--- a/docs/content/docs/getting-started/quick-start.mdx
+++ b/docs/content/docs/getting-started/quick-start.mdx
@@ -260,3 +260,11 @@ This example uses optimistic concurrency with no retries (the default). For high
 - [Modeling Your Domain](/docs/modeling/defining-aggregates) — Deep dive into aggregate definitions
 - [Projections](/docs/read-model/projections) — Building read models
 - [Running Your Domain](/docs/running/domain-configuration) — Complete wiring reference
+
+Ready to explore a full working example? The [fund transfer sample](https://github.com/dogganidhal/noddde/tree/main/samples/sample-transfers) is the simplest end-to-end domain — 5 files, in-memory only, no database setup. Clone the repo and run it:
+
+```bash
+git clone https://github.com/dogganidhal/noddde.git
+cd noddde && yarn install
+cd samples/sample-transfers && yarn start
+```

--- a/docs/content/docs/patterns/auction-domain.mdx
+++ b/docs/content/docs/patterns/auction-domain.mdx
@@ -5,6 +5,8 @@ description: Complete walkthrough of an auction aggregate with time-based valida
 
 This example walks through the auction domain sample. It demonstrates infrastructure injection via the Clock pattern, multi-validation command handlers, rejection events, and no-op apply handlers.
 
+> **Full source**: [samples/sample-auction](https://github.com/dogganidhal/noddde/tree/main/samples/sample-auction) — clone and run locally with `npm start`.
+
 ## Domain Overview
 
 The auction domain models a simple auction that supports:

--- a/docs/content/docs/patterns/banking-domain.mdx
+++ b/docs/content/docs/patterns/banking-domain.mdx
@@ -5,6 +5,8 @@ description: Complete walkthrough of a bank account aggregate with transactions,
 
 This example walks through the complete banking domain sample included with noddde. It demonstrates commands, events, aggregates, projections, queries, infrastructure, and domain configuration working together.
 
+> **Full source**: [samples/sample-banking](https://github.com/dogganidhal/noddde/tree/main/samples/sample-banking) — clone and run locally with `npm start`.
+
 ## Domain Overview
 
 The banking domain models a simple bank account that supports:

--- a/docs/content/docs/patterns/flash-sale.mdx
+++ b/docs/content/docs/patterns/flash-sale.mdx
@@ -5,6 +5,8 @@ description: Handling concurrent purchases with optimistic concurrency control, 
 
 A flash sale where limited stock sells first-come-first-served. Multiple buyers purchase the same item concurrently. This sample demonstrates **optimistic concurrency with retry** — the right strategy when command handlers are cheap and retries are fast.
 
+> **Full source**: [samples/sample-flash-sale](https://github.com/dogganidhal/noddde/tree/main/samples/sample-flash-sale) — clone and run locally with `npm start`.
+
 **Stack**: Drizzle + PostgreSQL + Testcontainers
 
 ## Why Optimistic

--- a/docs/content/docs/patterns/fund-transfer.mdx
+++ b/docs/content/docs/patterns/fund-transfer.mdx
@@ -5,6 +5,8 @@ description: Atomic multi-command operations using domain.withUnitOfWork() to tr
 
 This example walks through the fund transfer sample included with noddde. It demonstrates the [Unit of Work](/docs/running/persistence#unit-of-work) pattern for grouping multiple commands into a single atomic boundary — both succeed or neither takes effect.
 
+> **Full source**: [samples/sample-transfers](https://github.com/dogganidhal/noddde/tree/main/samples/sample-transfers) — clone and run locally with `npm start`.
+
 ## Domain Overview
 
 The fund transfer domain models a simple account that supports:

--- a/docs/content/docs/patterns/order-fulfillment.mdx
+++ b/docs/content/docs/patterns/order-fulfillment.mdx
@@ -5,6 +5,8 @@ description: A complete e-commerce order fulfillment example using three aggrega
 
 This example demonstrates a full e-commerce order fulfillment domain with **three aggregates** (Order, Payment, Shipping) and a **saga** that coordinates them. It exercises every saga capability: multi-aggregate coordination, conditional commands, multi-command dispatch, async handlers with infrastructure, and compensation.
 
+> **Full source**: [samples/sample-orders](https://github.com/dogganidhal/noddde/tree/main/samples/sample-orders) — clone and run locally with `npm start`.
+
 ## Domain Overview
 
 ```

--- a/docs/content/docs/patterns/seat-reservation.mdx
+++ b/docs/content/docs/patterns/seat-reservation.mdx
@@ -5,6 +5,8 @@ description: Serializing concurrent seat reservations with pessimistic locking, 
 
 A concert venue where customers reserve specific seats. Multiple customers attempt to reserve the same seat concurrently. This sample demonstrates **pessimistic concurrency with advisory locks** — the right strategy when command handlers involve expensive validation and wasted retries are costly.
 
+> **Full source**: [samples/sample-seat-reservation](https://github.com/dogganidhal/noddde/tree/main/samples/sample-seat-reservation) — clone and run locally with `npm start`.
+
 **Stack**: Prisma + MySQL + Testcontainers
 
 ## Why Pessimistic


### PR DESCRIPTION
## Why

The docs site and the sample code live in the same repo but never reference each other. A reader finishes a pattern walkthrough with no way to find the actual runnable code, and the Quick Start ends without pointing to a full working example.

## How

Added a `> **Full source**` callout near the top of each pattern page linking to the corresponding `samples/` directory on GitHub. Added a closing section to the Quick Start page pointing to the fund transfer sample (simplest: 5 files, in-memory, no DB setup) with clone-and-run instructions.

## Changes

- **6 pattern pages** — added GitHub source link callout to banking, auction, order fulfillment, fund transfer, flash sale, and seat reservation
- **Quick Start** — added "explore a full working example" closing section with the fund transfer sample

## Test Plan

- `cd docs && npm run build` passes cleanly

---

_This pull request was created with AI assistance._