### PR TITLE
docs: add SEO, analytics, and LLM discoverability

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -188,7 +188,42 @@ Add the new page to the appropriate category's `meta.json` file at `docs/content
 
 Read the existing `meta.json`, add the new page name (without extension) to the `pages` array in a logical position (usually at the end, unless there's a clear ordering).
 
-## Step 6: Flag API Reference Changes
+## Step 6: Update llms.txt
+
+When documentation pages are **created, deleted, or renamed** in Step 5, update `docs/public/llms.txt` to keep it in sync.
+
+`llms.txt` is a static Markdown file following the [llmstxt.org](https://llmstxt.org) specification that makes the docs discoverable by AI crawlers. It mirrors the documentation structure with one link per page.
+
+### When to update
+
+- **Page created** → Add a link entry under the matching H2 section
+- **Page deleted** → Remove the corresponding link entry
+- **Page renamed/moved** → Update the link URL and title
+- **Page title or description changed** → Update the link text and description
+
+### Format
+
+Each entry follows this pattern:
+```
+- [Page Title](https://noddde.dev/docs/<section>/<slug>): <description from MDX frontmatter>
+```
+
+Entries are grouped under H2 sections that match the docs navigation structure (Getting Started, Core Concepts, Modeling Your Domain, etc.).
+
+### Rules
+
+- **Always** read the current `llms.txt` before editing — do not rewrite the whole file
+- **Only** add/remove/update the specific entries that changed
+- **Preserve** the existing section order and formatting
+- If a new section is needed (new docs category), add the H2 in the same position as in the docs navigation
+
+### Skip conditions
+
+Skip this step when:
+- Only existing page content changed (no structural changes)
+- No pages were created, deleted, or renamed
+
+## Step 7: Flag API Reference Changes
 
 If the spec added new exports, removed exports, or changed existing signatures:
 
@@ -196,7 +231,7 @@ If the spec added new exports, removed exports, or changed existing signatures:
 2. Note these in the report as needing regeneration
 3. **Do NOT manually edit these files** — they are auto-generated
 
-## Step 7: Documentation Update Report
+## Step 8: Documentation Update Report
 
 ```
 📖 Step 6 complete: Documentation updated
@@ -212,6 +247,11 @@ If the spec added new exports, removed exports, or changed existing signatures:
     - <N> auto-generated pages may need regeneration (exports changed: <list>)
     — OR —
     - No API surface changes — auto-generated docs are up to date
+
+  LLM discoverability:
+    - llms.txt updated: added <N> entries, removed <N> entries
+    — OR —
+    - llms.txt: no structural changes needed
 
   Flagged for review: <N>
     - docs/content/docs/<path>.mdx (prose may need updating — <reason>)

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,71 @@
+# noddde
+
+> A TypeScript framework for DDD, CQRS, and Event Sourcing using the functional Decider pattern — no base classes, no decorators, just typed objects and pure functions.
+
+## Getting Started
+
+- [Introduction](https://noddde.dev/docs/getting-started/introduction): What is noddde and why use it
+- [Quick Start](https://noddde.dev/docs/getting-started/quick-start): Install noddde and build your first aggregate
+
+## Core Concepts
+
+- [Messages & Type System](https://noddde.dev/docs/core-concepts/messages-and-types): Typed messages and mapped types for type-safe communication
+- [ID Types](https://noddde.dev/docs/core-concepts/id-types): String, number, and bigint identifiers via the ID type alias
+- [The Decider Pattern](https://noddde.dev/docs/core-concepts/decider-pattern): Pure functions instead of OOP aggregates
+- [CQRS & Event Sourcing](https://noddde.dev/docs/core-concepts/cqrs-and-event-sourcing): Separate write/read models with events as source of truth
+
+## Modeling Your Domain
+
+- [Defining Aggregates](https://noddde.dev/docs/modeling/defining-aggregates): Events, commands, state, AggregateTypes bundle, and defineAggregate
+- [Command Handlers](https://noddde.dev/docs/modeling/command-handlers): Validation, returning events, infrastructure access, and type safety
+- [State Design & Event Application](https://noddde.dev/docs/modeling/state-and-events): Designing state and writing pure apply handlers
+- [Command Routing & Dispatch](https://noddde.dev/docs/modeling/routing-and-dispatch): How commands flow from dispatch through to event publication
+- [Type Inference Helpers](https://noddde.dev/docs/modeling/type-inference): InferAggregateID, InferAggregateState, and other extraction utilities
+
+## Read Model & Queries
+
+- [Projections](https://noddde.dev/docs/read-model/projections): Building read-optimized views from event streams
+- [View Persistence](https://noddde.dev/docs/read-model/view-persistence): ViewStore, auto-persistence, and consistency strategies
+- [Queries](https://noddde.dev/docs/read-model/queries): DefineQueries, query handlers, and the QueryBus
+
+## Process Managers
+
+- [Sagas](https://noddde.dev/docs/process-managers/sagas): Event-driven process managers coordinating workflows across aggregates
+- [Standalone Command Handlers](https://noddde.dev/docs/process-managers/standalone-commands): Commands outside aggregates for orchestration and integrations
+
+## Running Your Domain
+
+- [Domain Configuration](https://noddde.dev/docs/running/domain-configuration): Wiring aggregates, projections, sagas, and infrastructure with configureDomain
+- [Infrastructure](https://noddde.dev/docs/running/infrastructure): Injectable infrastructure for pure domain logic
+- [Persistence](https://noddde.dev/docs/running/persistence): Event-sourced vs state-stored persistence strategies
+- [Idempotent Commands](https://noddde.dev/docs/running/idempotent-commands): Preventing duplicate execution with commandId and IdempotencyStore
+- [ORM Adapters](https://noddde.dev/docs/running/orm-adapters): Production persistence with Drizzle, Prisma, or TypeORM
+
+## Testing
+
+- [Testing Overview](https://noddde.dev/docs/testing/overview): How functional design makes testing natural
+- [Testing Aggregates & Projections](https://noddde.dev/docs/testing/testing-aggregates-and-projections): Given-When-Then testing with testAggregate and testProjection
+- [Testing Sagas](https://noddde.dev/docs/testing/testing-sagas): Given-When-Then saga testing with testSaga
+- [Testing Domains](https://noddde.dev/docs/testing/testing-domains): Zero-boilerplate slice and integration tests with testDomain
+
+## Patterns & Examples
+
+- [The Clock Pattern](https://noddde.dev/docs/patterns/clock-pattern): Injecting time as infrastructure for deterministic handlers
+- [Banking Domain](https://noddde.dev/docs/patterns/banking-domain): Bank account aggregate with transactions, projections, and queries
+- [Auction Domain](https://noddde.dev/docs/patterns/auction-domain): Auction aggregate with time-based validation and the Clock pattern
+- [Order Fulfillment](https://noddde.dev/docs/patterns/order-fulfillment): E-commerce order fulfillment with three aggregates and a saga
+- [Fund Transfer](https://noddde.dev/docs/patterns/fund-transfer): Atomic multi-command operations with domain.withUnitOfWork()
+- [Flash Sale](https://noddde.dev/docs/patterns/flash-sale): Optimistic concurrency control with automatic retry
+- [Seat Reservation](https://noddde.dev/docs/patterns/seat-reservation): Pessimistic locking with advisory locks and timeout handling
+
+## Design Decisions
+
+- [Why the Decider Pattern?](https://noddde.dev/docs/design-decisions/why-decider): Pure functions instead of OOP aggregate classes
+- [Why the AggregateTypes Bundle?](https://noddde.dev/docs/design-decisions/why-aggregate-types): Named type bundle instead of positional generic parameters
+- [Why DefineCommands / DefineEvents?](https://noddde.dev/docs/design-decisions/why-define-commands-events): Mapped type utilities instead of enum + interface declarations
+- [Why Commands Return Events?](https://noddde.dev/docs/design-decisions/why-commands-return-events): Return events instead of calling eventBus.dispatch() directly
+- [Why Is the Aggregate ID Not in State?](https://noddde.dev/docs/design-decisions/why-id-not-in-state): ID on commands rather than in aggregate state
+- [Why Are Apply Handlers Pure?](https://noddde.dev/docs/design-decisions/why-pure-apply-handlers): No infrastructure access in apply handlers
+- [Why Two Persistence Strategies?](https://noddde.dev/docs/design-decisions/why-two-persistence-strategies): Both event sourcing and state storage
+- [Why Injectable Infrastructure?](https://noddde.dev/docs/design-decisions/why-injectable-infrastructure): Function parameter injection instead of DI containers
+- [Why Sagas Return Commands](https://noddde.dev/docs/design-decisions/why-sagas-return-commands): SagaReaction instead of imperative command dispatch

--- a/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/docs/src/app/docs/[[...slug]]/page.tsx
@@ -7,6 +7,9 @@ import {
 } from "fumadocs-ui/page";
 import { notFound } from "next/navigation";
 import defaultMdxComponents from "fumadocs-ui/mdx";
+import type { Metadata } from "next";
+
+const BASE_URL = "https://noddde.dev";
 
 export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
@@ -34,7 +37,7 @@ export function generateStaticParams() {
 
 export async function generateMetadata(props: {
   params: Promise<{ slug?: string[] }>;
-}) {
+}): Promise<Metadata> {
   const params = await props.params;
   const page = source.getPage(params.slug);
   if (!page) notFound();
@@ -42,5 +45,13 @@ export async function generateMetadata(props: {
   return {
     title: page.data.title,
     description: page.data.description,
+    alternates: {
+      canonical: `${BASE_URL}${page.url}`,
+    },
+    openGraph: {
+      title: page.data.title,
+      description: page.data.description,
+      url: `${BASE_URL}${page.url}`,
+    },
   };
 }

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -1,19 +1,59 @@
 import { RootProvider } from "fumadocs-ui/provider/next";
 import "fumadocs-ui/style.css";
 import "./globals.css";
+import type { Metadata } from "next";
+import Script from "next/script";
 import type { ReactNode } from "react";
 
-export const metadata = {
+export const metadata: Metadata = {
+  metadataBase: new URL("https://noddde.dev"),
   title: {
     default: "noddde",
     template: "%s | noddde",
   },
   description: "A TypeScript framework for DDD, CQRS, and Event Sourcing",
+  openGraph: {
+    type: "website",
+    siteName: "noddde",
+    title: {
+      default: "noddde",
+      template: "%s | noddde",
+    },
+    description: "A TypeScript framework for DDD, CQRS, and Event Sourcing",
+    url: "https://noddde.dev",
+  },
+  verification: {
+    google: "_SAdehsZlCb-zjOyICC50XtkE91DtBJgxBERkq2PtbE",
+  },
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "SoftwareSourceCode",
+              name: "noddde",
+              description:
+                "Functional DDD framework for TypeScript — Decider pattern, Event Sourcing & CQRS",
+              url: "https://noddde.dev",
+              codeRepository: "https://github.com/dogganidhal/noddde",
+              programmingLanguage: "TypeScript",
+              license: "https://opensource.org/licenses/MIT",
+              runtimePlatform: "Node.js",
+            }),
+          }}
+        />
+        <Script
+          src="https://cloud.umami.is/script.js"
+          data-website-id="92e48cc6-8033-403c-9f0b-17f011bce691"
+          strategy="afterInteractive"
+        />
+      </head>
       <body>
         <RootProvider search={{ options: { type: "static" } }}>
           {children}

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -1,5 +1,12 @@
 import Image from "next/image";
 import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "https://noddde.dev",
+  },
+};
 
 export default function HomePage() {
   return (

--- a/docs/src/app/robots.ts
+++ b/docs/src/app/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: "*", allow: "/" },
+    sitemap: "https://noddde.dev/sitemap.xml",
+  };
+}

--- a/docs/src/app/sitemap.ts
+++ b/docs/src/app/sitemap.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from "next";
+import { source } from "@/lib/source";
+
+export const dynamic = "force-static";
+
+const BASE_URL = "https://noddde.dev";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const pages = source.getPages();
+
+  const docEntries = pages.map((page) => ({
+    url: `${BASE_URL}${page.url}`,
+    changeFrequency: "weekly" as const,
+    priority: 0.7,
+  }));
+
+  return [
+    {
+      url: BASE_URL,
+      changeFrequency: "monthly" as const,
+      priority: 1.0,
+    },
+    ...docEntries,
+  ];
+}


### PR DESCRIPTION
## Summary

- Add sitemap.xml (dynamic, 43 URLs from Fumadocs source loader), robots.txt, and llms.txt for search engine and AI crawler discoverability
- Add Open Graph meta tags, canonical URLs, and JSON-LD structured data (SoftwareSourceCode schema) to all pages
- Add Google Search Console verification tag and Umami analytics
- Update the `update-docs` skill to maintain llms.txt when docs pages change

## Test plan

- [x] `yarn build` succeeds with static export (`output: "export"`)
- [x] `out/sitemap.xml` contains 43 URLs (homepage + 42 docs pages)
- [x] `out/robots.txt` allows all crawlers with sitemap reference
- [x] `out/llms.txt` present as static file
- [x] Homepage HTML has `og:title`, `og:description`, `og:url`, `og:site_name`, `og:type`, `<link rel="canonical">`, `<meta name="google-site-verification">`, JSON-LD script, and Umami analytics script
- [x] Docs page HTML (e.g. introduction) has per-page OG tags and canonical URL with title template applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)