### PR TITLE
feat(engine): add per-aggregate persistence strategy configuration

### DIFF
--- a/docs/content/docs/running/domain-configuration.mdx
+++ b/docs/content/docs/running/domain-configuration.mdx
@@ -67,7 +67,9 @@ type DomainConfiguration<TInfrastructure extends Infrastructure> = {
     sagas: Record<string, Saga<any, any>>;
   };
   infrastructure: {
-    aggregatePersistence?: () => PersistenceConfiguration | Promise<PersistenceConfiguration>;
+    aggregatePersistence?:
+      | (() => PersistenceConfiguration | Promise<PersistenceConfiguration>)
+      | Record<string, () => PersistenceConfiguration | Promise<PersistenceConfiguration>>;
     aggregateConcurrency?:
       | { strategy?: "optimistic"; maxRetries?: number }
       | { strategy: "pessimistic"; locker: AggregateLocker; lockTimeoutMs?: number };
@@ -218,7 +220,7 @@ The providers are:
 
 - **`provideInfrastructure`** -- Your custom domain infrastructure (loggers, repositories, clients)
 - **`cqrsInfrastructure`** -- The three CQRS buses (CommandBus, EventBus, QueryBus)
-- **`aggregatePersistence`** -- The persistence strategy for aggregate state. See [Persistence](/docs/running/persistence).
+- **`aggregatePersistence`** -- The persistence strategy for aggregate state. Either a single factory (domain-wide) or a per-aggregate record. See [Persistence](/docs/running/persistence).
 - **`aggregateConcurrency`** -- Optimistic or pessimistic concurrency strategy. See [Concurrency Control](/docs/running/persistence#concurrency-control).
 - **`snapshotStore`** / **`snapshotStrategy`** -- Snapshot caching for event-sourced aggregates. See [State Snapshotting](/docs/running/persistence#state-snapshotting-event-sourced-optimization).
 - **`idempotencyStore`** -- Duplicate command detection. See [Idempotent Commands](/docs/running/idempotent-commands).

--- a/docs/content/docs/running/infrastructure.mdx
+++ b/docs/content/docs/running/infrastructure.mdx
@@ -137,11 +137,20 @@ cqrsInfrastructure: (customInfra) => ({
 
 ### aggregatePersistence
 
-Provides the persistence strategy for aggregate state. Returns either an `EventSourcedAggregatePersistence` or a `StateStoredAggregatePersistence`. See [Persistence](/docs/running/persistence) for details.
+Provides the persistence strategy for aggregate state. Either a single factory (domain-wide) or a per-aggregate record mapping each aggregate name to its own factory. Each factory returns either an `EventSourcedAggregatePersistence` or a `StateStoredAggregatePersistence`. See [Persistence](/docs/running/persistence) for details.
 
 ```ts
+// Domain-wide: all aggregates use the same persistence
 aggregatePersistence: () => new InMemoryEventSourcedAggregatePersistence(),
+
+// Per-aggregate: each aggregate gets its own persistence strategy
+aggregatePersistence: {
+  Order: () => new InMemoryEventSourcedAggregatePersistence(),
+  Inventory: () => new InMemoryStateStoredAggregatePersistence(),
+},
 ```
+
+When using the per-aggregate form, all registered aggregates must have a corresponding entry. TypeScript enforces this at compile time, and a runtime validation check runs during `init()`.
 
 ### unitOfWorkFactory
 
@@ -190,7 +199,7 @@ When `configureDomain` is called:
 
 1. `provideInfrastructure()` is called first to create custom infrastructure
 2. `cqrsInfrastructure(customInfra)` is called with the custom infrastructure
-3. `aggregatePersistence()` is called to set up persistence
+3. `aggregatePersistence` is resolved: if a function, called once; if a per-aggregate record, each factory is called
 4. `snapshotStore()` is called to set up the snapshot store (if configured)
 5. `idempotencyStore()` is called to set up the idempotency store (if configured)
 6. `unitOfWorkFactory()` is called to set up the unit of work factory

--- a/docs/content/docs/running/persistence.mdx
+++ b/docs/content/docs/running/persistence.mdx
@@ -181,7 +181,22 @@ const domain = await configureDomain<BankingInfrastructure>({
 });
 ```
 
-The `aggregatePersistence` factory returns either an `EventSourcedAggregatePersistence` or a `StateStoredAggregatePersistence`. The framework uses it to load and save state for all aggregates in the domain.
+The `aggregatePersistence` field accepts either a single factory (domain-wide) or a per-aggregate record. Each factory returns either an `EventSourcedAggregatePersistence` or a `StateStoredAggregatePersistence`.
+
+For per-aggregate persistence, provide a record mapping each aggregate name to its own factory. All registered aggregates must have an entry:
+
+```ts
+const domain = await configureDomain<MyInfrastructure>({
+  writeModel: { aggregates: { Order, Inventory } },
+  readModel: { projections: {} },
+  infrastructure: {
+    aggregatePersistence: {
+      Order: () => new InMemoryEventSourcedAggregatePersistence(),
+      Inventory: () => new InMemoryStateStoredAggregatePersistence(),
+    },
+  },
+});
+```
 
 ## Concurrency Control
 
@@ -332,7 +347,8 @@ This means you can:
 
 - Start with state storage for simplicity, then migrate to event sourcing without changing your aggregate
 - Use event sourcing in production and state storage in tests
-- Switch strategies by changing only the `aggregatePersistence` factory
+- Switch strategies by changing only the `aggregatePersistence` configuration
+- Mix strategies in the same domain using per-aggregate persistence
 
 The strategy is a configuration choice, not a modeling choice.
 

--- a/packages/engine/src/__tests__/engine/aggregate-persistence-resolver.test.ts
+++ b/packages/engine/src/__tests__/engine/aggregate-persistence-resolver.test.ts
@@ -1,0 +1,55 @@
+/* eslint-disable no-unused-vars */
+import { describe, it, expect } from "vitest";
+import {
+  InMemoryEventSourcedAggregatePersistence,
+  InMemoryStateStoredAggregatePersistence,
+} from "@noddde/engine";
+import {
+  GlobalAggregatePersistenceResolver,
+  PerAggregatePersistenceResolver,
+} from "../../aggregate-persistence-resolver";
+
+// ============================================================
+// GlobalAggregatePersistenceResolver returns the same persistence for any aggregate
+// ============================================================
+
+describe("GlobalAggregatePersistenceResolver", () => {
+  it("should return the same persistence instance for any aggregate name", () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+    const resolver = new GlobalAggregatePersistenceResolver(persistence);
+
+    expect(resolver.resolve("Foo")).toBe(persistence);
+    expect(resolver.resolve("Bar")).toBe(persistence);
+    expect(resolver.resolve("Foo")).toBe(resolver.resolve("Bar"));
+  });
+});
+
+// ============================================================
+// PerAggregatePersistenceResolver returns the correct persistence per aggregate
+// ============================================================
+
+describe("PerAggregatePersistenceResolver", () => {
+  it("should return the correct persistence for each aggregate name", () => {
+    const esPersistence = new InMemoryEventSourcedAggregatePersistence();
+    const ssPersistence = new InMemoryStateStoredAggregatePersistence();
+    const map = new Map([
+      ["Counter", esPersistence as any],
+      ["BankAccount", ssPersistence as any],
+    ]);
+    const resolver = new PerAggregatePersistenceResolver(map);
+
+    expect(resolver.resolve("Counter")).toBe(esPersistence);
+    expect(resolver.resolve("BankAccount")).toBe(ssPersistence);
+  });
+
+  it("should throw for unknown aggregate names", () => {
+    const map = new Map([
+      ["Counter", new InMemoryEventSourcedAggregatePersistence() as any],
+    ]);
+    const resolver = new PerAggregatePersistenceResolver(map);
+
+    expect(() => resolver.resolve("NonExistent")).toThrow(
+      /No persistence configured for aggregate "NonExistent"/,
+    );
+  });
+});

--- a/packages/engine/src/__tests__/engine/domain.test.ts
+++ b/packages/engine/src/__tests__/engine/domain.test.ts
@@ -22,8 +22,10 @@ import {
   InMemoryIdempotencyStore,
   InMemoryQueryBus,
   InMemorySagaPersistence,
+  InMemorySnapshotStore,
   InMemoryStateStoredAggregatePersistence,
 } from "@noddde/engine";
+import { everyNEvents } from "@noddde/core";
 
 // ============================================================
 // configureDomain creates and initializes a domain
@@ -1314,5 +1316,200 @@ describe("Idempotent command processing", () => {
 
     // Idempotency record should NOT have been saved (UoW rolled back)
     expect(await idempotencyStore.exists("cmd-fail")).toBe(false);
+  });
+});
+
+// ============================================================
+// Per-aggregate persistence
+// ============================================================
+
+// Reuse BankAccount aggregate defined above (Balance types with Deposit/DepositMade)
+
+describe("Per-aggregate persistence", () => {
+  it("should route each aggregate to its configured persistence", async () => {
+    const esPersistence = new InMemoryEventSourcedAggregatePersistence();
+    const ssPersistence = new InMemoryStateStoredAggregatePersistence();
+
+    const domain = await configureDomain<Infrastructure>({
+      writeModel: { aggregates: { Counter, BankAccount } },
+      readModel: { projections: {} },
+      infrastructure: {
+        aggregatePersistence: {
+          Counter: () => esPersistence,
+          BankAccount: () => ssPersistence,
+        },
+        cqrsInfrastructure: () => ({
+          commandBus: new InMemoryCommandBus(),
+          eventBus: new EventEmitterEventBus(),
+          queryBus: new InMemoryQueryBus(),
+        }),
+      },
+    });
+
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "c-1",
+      payload: { by: 5 },
+    });
+    await domain.dispatchCommand({
+      name: "Deposit",
+      targetAggregateId: "acc-1",
+      payload: { amount: 100 },
+    });
+
+    // Counter uses event-sourced persistence
+    const counterEvents = await esPersistence.load("Counter", "c-1");
+    expect(counterEvents).toHaveLength(1);
+    expect(counterEvents[0]!.name).toBe("Incremented");
+
+    // BankAccount uses state-stored persistence
+    const bankState = await ssPersistence.load("BankAccount", "acc-1");
+    expect(bankState).not.toBeNull();
+    expect(bankState!.state.balance).toBe(100);
+  });
+});
+
+describe("Per-aggregate persistence validation", () => {
+  it("should throw if per-aggregate persistence is missing entries for registered aggregates", async () => {
+    await expect(
+      configureDomain<Infrastructure>({
+        writeModel: { aggregates: { Counter, BankAccount } },
+        readModel: { projections: {} },
+        infrastructure: {
+          aggregatePersistence: {
+            Counter: () => new InMemoryEventSourcedAggregatePersistence(),
+          } as any,
+          cqrsInfrastructure: () => ({
+            commandBus: new InMemoryCommandBus(),
+            eventBus: new EventEmitterEventBus(),
+            queryBus: new InMemoryQueryBus(),
+          }),
+        },
+      }),
+    ).rejects.toThrow(/missing.*BankAccount/i);
+  });
+
+  it("should throw if per-aggregate persistence references unknown aggregates", async () => {
+    await expect(
+      configureDomain<Infrastructure>({
+        writeModel: { aggregates: { Counter } },
+        readModel: { projections: {} },
+        infrastructure: {
+          aggregatePersistence: {
+            Counter: () => new InMemoryEventSourcedAggregatePersistence(),
+            NonExistent: () => new InMemoryEventSourcedAggregatePersistence(),
+          } as any,
+          cqrsInfrastructure: () => ({
+            commandBus: new InMemoryCommandBus(),
+            eventBus: new EventEmitterEventBus(),
+            queryBus: new InMemoryQueryBus(),
+          }),
+        },
+      }),
+    ).rejects.toThrow(/unknown.*NonExistent/i);
+  });
+});
+
+describe("Domain-wide persistence (backward compatibility)", () => {
+  it("should use a single persistence factory for all aggregates", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+
+    const domain = await configureDomain<Infrastructure>({
+      writeModel: { aggregates: { Counter } },
+      readModel: { projections: {} },
+      infrastructure: {
+        aggregatePersistence: () => persistence,
+        cqrsInfrastructure: () => ({
+          commandBus: new InMemoryCommandBus(),
+          eventBus: new EventEmitterEventBus(),
+          queryBus: new InMemoryQueryBus(),
+        }),
+      },
+    });
+
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "c-1",
+      payload: { by: 3 },
+    });
+
+    const events = await persistence.load("Counter", "c-1");
+    expect(events).toHaveLength(1);
+  });
+});
+
+describe("Per-aggregate persistence factory resolution", () => {
+  it("should resolve all async per-aggregate factories during init", async () => {
+    const esFactory = vi.fn(
+      async () => new InMemoryEventSourcedAggregatePersistence(),
+    );
+    const ssFactory = vi.fn(
+      async () => new InMemoryStateStoredAggregatePersistence(),
+    );
+
+    await configureDomain<Infrastructure>({
+      writeModel: { aggregates: { Counter, BankAccount } },
+      readModel: { projections: {} },
+      infrastructure: {
+        aggregatePersistence: {
+          Counter: esFactory,
+          BankAccount: ssFactory,
+        },
+        cqrsInfrastructure: () => ({
+          commandBus: new InMemoryCommandBus(),
+          eventBus: new EventEmitterEventBus(),
+          queryBus: new InMemoryQueryBus(),
+        }),
+      },
+    });
+
+    expect(esFactory).toHaveBeenCalledOnce();
+    expect(ssFactory).toHaveBeenCalledOnce();
+  });
+});
+
+describe("Mixed persistence with snapshots", () => {
+  it("should only create snapshots for event-sourced aggregates", async () => {
+    const snapshotStore = new InMemorySnapshotStore();
+
+    const domain = await configureDomain<Infrastructure>({
+      writeModel: { aggregates: { Counter, BankAccount } },
+      readModel: { projections: {} },
+      infrastructure: {
+        aggregatePersistence: {
+          Counter: () => new InMemoryEventSourcedAggregatePersistence(),
+          BankAccount: () => new InMemoryStateStoredAggregatePersistence(),
+        },
+        snapshotStore: () => snapshotStore,
+        snapshotStrategy: everyNEvents(1),
+        cqrsInfrastructure: () => ({
+          commandBus: new InMemoryCommandBus(),
+          eventBus: new EventEmitterEventBus(),
+          queryBus: new InMemoryQueryBus(),
+        }),
+      },
+    });
+
+    // Dispatch to event-sourced aggregate
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "c-1",
+      payload: { by: 5 },
+    });
+
+    // Dispatch to state-stored aggregate
+    await domain.dispatchCommand({
+      name: "Deposit",
+      targetAggregateId: "acc-1",
+      payload: { amount: 100 },
+    });
+
+    // Snapshot should exist for event-sourced Counter
+    const counterSnapshot = await snapshotStore.load("Counter", "c-1");
+    expect(counterSnapshot).not.toBeNull();
+
+    // No snapshot for state-stored BankAccount
+    const bankSnapshot = await snapshotStore.load("BankAccount", "acc-1");
+    expect(bankSnapshot).toBeNull();
   });
 });

--- a/packages/engine/src/__tests__/engine/executors/command-lifecycle-executor.test.ts
+++ b/packages/engine/src/__tests__/engine/executors/command-lifecycle-executor.test.ts
@@ -26,6 +26,7 @@ import {
   OptimisticConcurrencyStrategy,
   type ConcurrencyStrategy,
 } from "../../../concurrency-strategy";
+import { GlobalAggregatePersistenceResolver } from "../../../aggregate-persistence-resolver";
 
 // ============================================================
 // Shared aggregate definitions
@@ -84,7 +85,7 @@ describe("CommandLifecycleExecutor", () => {
     const strategy = new OptimisticConcurrencyStrategy(0);
 
     const executor = new CommandLifecycleExecutor(
-      persistence,
+      new GlobalAggregatePersistenceResolver(persistence),
       infrastructure,
       createInMemoryUnitOfWork,
       strategy,
@@ -152,7 +153,7 @@ describe("CommandLifecycleExecutor", () => {
     const strategy = new OptimisticConcurrencyStrategy(0);
 
     const executor = new CommandLifecycleExecutor(
-      persistence,
+      new GlobalAggregatePersistenceResolver(persistence),
       infrastructure,
       createInMemoryUnitOfWork,
       strategy,
@@ -202,7 +203,7 @@ describe("CommandLifecycleExecutor", () => {
     const strategy = new OptimisticConcurrencyStrategy(0);
 
     const executor = new CommandLifecycleExecutor(
-      persistence,
+      new GlobalAggregatePersistenceResolver(persistence),
       infrastructure,
       createInMemoryUnitOfWork,
       strategy,
@@ -264,7 +265,7 @@ describe("CommandLifecycleExecutor", () => {
     const strategy = new OptimisticConcurrencyStrategy(0);
 
     const executor = new CommandLifecycleExecutor(
-      persistence,
+      new GlobalAggregatePersistenceResolver(persistence),
       infrastructure,
       createInMemoryUnitOfWork,
       strategy,
@@ -345,7 +346,7 @@ describe("CommandLifecycleExecutor", () => {
     const snapshotStrategy = everyNEvents(3);
 
     const executor = new CommandLifecycleExecutor(
-      persistence,
+      new GlobalAggregatePersistenceResolver(persistence),
       infrastructure,
       createInMemoryUnitOfWork,
       strategy,
@@ -429,7 +430,7 @@ describe("CommandLifecycleExecutor", () => {
     vi.spyOn(persistence, "load");
 
     const executor = new CommandLifecycleExecutor(
-      persistence,
+      new GlobalAggregatePersistenceResolver(persistence),
       infrastructure,
       createInMemoryUnitOfWork,
       strategy,
@@ -495,7 +496,7 @@ describe("CommandLifecycleExecutor", () => {
     const strategy = new OptimisticConcurrencyStrategy(0);
 
     const executor = new CommandLifecycleExecutor(
-      persistence,
+      new GlobalAggregatePersistenceResolver(persistence),
       infrastructure,
       createInMemoryUnitOfWork,
       strategy,
@@ -572,7 +573,7 @@ describe("CommandLifecycleExecutor", () => {
     };
 
     const executor = new CommandLifecycleExecutor(
-      persistence,
+      new GlobalAggregatePersistenceResolver(persistence),
       infrastructure,
       createInMemoryUnitOfWork,
       mockStrategy,

--- a/packages/engine/src/aggregate-persistence-resolver.ts
+++ b/packages/engine/src/aggregate-persistence-resolver.ts
@@ -1,0 +1,61 @@
+/* eslint-disable no-unused-vars */
+import type { PersistenceConfiguration } from "@noddde/core";
+
+/**
+ * Internal strategy interface for resolving the correct aggregate
+ * persistence at command dispatch time. The Domain constructs the
+ * appropriate implementation during `init()` based on the
+ * `aggregatePersistence` configuration.
+ *
+ * @internal Not exported — users configure persistence via
+ * `DomainConfiguration.infrastructure.aggregatePersistence`.
+ */
+export interface AggregatePersistenceResolver {
+  /**
+   * Resolves the persistence configuration for the given aggregate.
+   *
+   * @param aggregateName - The aggregate type name.
+   * @returns The persistence configuration for this aggregate.
+   */
+  resolve(aggregateName: string): PersistenceConfiguration;
+}
+
+/**
+ * Domain-wide persistence resolver: all aggregates share one persistence
+ * instance. Used when `aggregatePersistence` is omitted (in-memory default)
+ * or is a single factory function.
+ *
+ * @internal
+ */
+export class GlobalAggregatePersistenceResolver
+  implements AggregatePersistenceResolver
+{
+  constructor(private readonly persistence: PersistenceConfiguration) {}
+
+  resolve(_aggregateName: string): PersistenceConfiguration {
+    return this.persistence;
+  }
+}
+
+/**
+ * Per-aggregate persistence resolver: each aggregate has its own
+ * persistence instance. Used when `aggregatePersistence` is a
+ * per-aggregate record mapping aggregate names to factories.
+ *
+ * @internal
+ */
+export class PerAggregatePersistenceResolver
+  implements AggregatePersistenceResolver
+{
+  constructor(private readonly map: Map<string, PersistenceConfiguration>) {}
+
+  resolve(aggregateName: string): PersistenceConfiguration {
+    const persistence = this.map.get(aggregateName);
+    if (!persistence) {
+      throw new Error(
+        `No persistence configured for aggregate "${aggregateName}"`,
+      );
+    }
+    return persistence;
+  }
+}

--- a/packages/engine/src/domain.ts
+++ b/packages/engine/src/domain.ts
@@ -55,6 +55,11 @@ import {
 import { MetadataEnricher } from "./executors/metadata-enricher";
 import { CommandLifecycleExecutor } from "./executors/command-lifecycle-executor";
 import { SagaExecutor } from "./executors/saga-executor";
+import {
+  GlobalAggregatePersistenceResolver,
+  PerAggregatePersistenceResolver,
+} from "./aggregate-persistence-resolver";
+import type { AggregatePersistenceResolver } from "./aggregate-persistence-resolver";
 
 type AggregateMap = Record<string | symbol, Aggregate<any>>;
 
@@ -88,6 +93,14 @@ type StandaloneQueryHandlerMap<
 };
 
 /**
+ * Factory function returning a persistence configuration, either synchronously
+ * or as a promise.
+ */
+type PersistenceFactory = () =>
+  | PersistenceConfiguration
+  | Promise<PersistenceConfiguration>;
+
+/**
  * The full configuration object for a domain, wiring together the write model
  * (aggregates + standalone command handlers), the read model (projections +
  * standalone query handlers), and infrastructure factories.
@@ -97,16 +110,18 @@ type StandaloneQueryHandlerMap<
  * @typeParam TInfrastructure - The custom infrastructure type for this domain.
  * @typeParam TStandaloneCommand - Union of standalone command types (inferred).
  * @typeParam TStandaloneQuery - Union of standalone query types (inferred).
+ * @typeParam TAggregates - The aggregate map type (inferred from `writeModel.aggregates`).
  */
 export type DomainConfiguration<
   TInfrastructure extends Infrastructure,
   TStandaloneCommand extends Command = Command,
   TStandaloneQuery extends Query<any> = Query<any>,
+  TAggregates extends AggregateMap = AggregateMap,
 > = {
   /** The write side: aggregates and standalone command handlers. */
   writeModel: {
     /** A map of aggregate definitions keyed by aggregate name. */
-    aggregates: AggregateMap;
+    aggregates: TAggregates;
     /** Optional map of standalone command handlers keyed by command name. */
     standaloneCommandHandlers?: StandaloneCommandHandlerMap<
       TInfrastructure,
@@ -135,13 +150,30 @@ export type DomainConfiguration<
   /** Factory functions for providing infrastructure at startup. */
   infrastructure: {
     /**
-     * Factory for the aggregate persistence strategy.
-     * Return either a {@link StateStoredAggregatePersistence} or
-     * {@link EventSourcedAggregatePersistence}.
+     * Aggregate persistence strategy. Either a single factory function
+     * (domain-wide — all aggregates share one persistence) or a per-aggregate
+     * record mapping each aggregate name to its own factory.
+     *
+     * When using the per-aggregate form, **all** registered aggregate names
+     * must have a corresponding entry. TypeScript enforces this at compile
+     * time via `Record<keyof TAggregates & string, PersistenceFactory>`,
+     * and a runtime validation check runs during `init()`.
+     *
+     * @example
+     * ```ts
+     * // Domain-wide (single factory for all aggregates)
+     * aggregatePersistence: () => drizzleInfra.eventSourcedPersistence
+     *
+     * // Per-aggregate (each aggregate has its own persistence)
+     * aggregatePersistence: {
+     *   Order: () => drizzleInfra.eventSourcedPersistence,
+     *   Inventory: () => drizzleInfra.stateStoredPersistence,
+     * }
+     * ```
      */
-    aggregatePersistence?: () =>
-      | PersistenceConfiguration
-      | Promise<PersistenceConfiguration>;
+    aggregatePersistence?:
+      | PersistenceFactory
+      | Record<keyof TAggregates & string, PersistenceFactory>;
     /**
      * Concurrency control strategy for aggregate persistence.
      *
@@ -320,10 +352,50 @@ export class Domain<
       ...cqrsInfra,
     } as TInfrastructure & CQRSInfrastructure;
 
-    // Step 4: Resolve aggregate persistence
-    const persistence = configuration.infrastructure.aggregatePersistence
-      ? await configuration.infrastructure.aggregatePersistence()
-      : new InMemoryEventSourcedAggregatePersistence();
+    // Step 4: Resolve aggregate persistence → AggregatePersistenceResolver
+    const persistenceConfig = configuration.infrastructure.aggregatePersistence;
+    let persistenceResolver: AggregatePersistenceResolver;
+
+    if (!persistenceConfig) {
+      // Omitted — in-memory default for all
+      persistenceResolver = new GlobalAggregatePersistenceResolver(
+        new InMemoryEventSourcedAggregatePersistence(),
+      );
+    } else if (typeof persistenceConfig === "function") {
+      // Domain-wide factory
+      persistenceResolver = new GlobalAggregatePersistenceResolver(
+        await persistenceConfig(),
+      );
+    } else {
+      // Per-aggregate map — runtime validation
+      const aggregateNames = new Set(
+        Object.keys(configuration.writeModel.aggregates),
+      );
+      const configNames = new Set(Object.keys(persistenceConfig));
+
+      // Check: every aggregate must have a persistence entry
+      const missing = [...aggregateNames].filter((n) => !configNames.has(n));
+      if (missing.length > 0) {
+        throw new Error(
+          `Per-aggregate persistence is missing entries for: ${missing.join(", ")}. ` +
+            `All aggregates must have a persistence factory.`,
+        );
+      }
+      // Check: no unknown aggregate names in persistence config
+      const unknown = [...configNames].filter((n) => !aggregateNames.has(n));
+      if (unknown.length > 0) {
+        throw new Error(
+          `Per-aggregate persistence references unknown aggregates: ${unknown.join(", ")}. ` +
+            `Registered aggregates: ${[...aggregateNames].join(", ")}.`,
+        );
+      }
+
+      const resolved = new Map<string, PersistenceConfiguration>();
+      for (const [name, factory] of Object.entries(persistenceConfig)) {
+        resolved.set(name, await factory());
+      }
+      persistenceResolver = new PerAggregatePersistenceResolver(resolved);
+    }
 
     // Step 4.5: Resolve snapshot store and strategy
     let snapshotStore: SnapshotStore | undefined;
@@ -426,7 +498,7 @@ export class Domain<
 
     // Step 5.11: Create command executor
     this._commandExecutor = new CommandLifecycleExecutor(
-      persistence,
+      persistenceResolver,
       this._infrastructure,
       this._unitOfWorkFactory,
       concurrencyStrategy,
@@ -725,11 +797,13 @@ export const configureDomain = async <
   TInfrastructure extends Infrastructure,
   TStandaloneCommand extends Command = Command,
   TStandaloneQuery extends Query<any> = Query<any>,
+  TAggregates extends AggregateMap = AggregateMap,
 >(
   configuration: DomainConfiguration<
     TInfrastructure,
     TStandaloneCommand,
-    TStandaloneQuery
+    TStandaloneQuery,
+    TAggregates
   >,
 ): Promise<Domain<TInfrastructure, TStandaloneCommand, TStandaloneQuery>> => {
   const domain = new Domain(configuration);

--- a/packages/engine/src/executors/command-lifecycle-executor.ts
+++ b/packages/engine/src/executors/command-lifecycle-executor.ts
@@ -18,6 +18,7 @@ import type {
   UnitOfWork,
   UnitOfWorkFactory,
 } from "@noddde/core";
+import type { AggregatePersistenceResolver } from "../aggregate-persistence-resolver";
 import type { ConcurrencyStrategy } from "../concurrency-strategy";
 import type { MetadataEnricher } from "./metadata-enricher";
 
@@ -33,7 +34,7 @@ import type { MetadataEnricher } from "./metadata-enricher";
  */
 export class CommandLifecycleExecutor {
   constructor(
-    private readonly persistence: PersistenceConfiguration,
+    private readonly persistenceResolver: AggregatePersistenceResolver,
     private readonly infrastructure: Infrastructure & CQRSInfrastructure,
     private readonly unitOfWorkFactory: UnitOfWorkFactory,
     private readonly concurrencyStrategy: ConcurrencyStrategy,
@@ -75,7 +76,8 @@ export class CommandLifecycleExecutor {
       }
     }
 
-    const { persistence, infrastructure } = this;
+    const persistence = this.persistenceResolver.resolve(aggregateName);
+    const { infrastructure } = this;
     const eventBus = infrastructure.eventBus;
 
     const existingUow = this.uowStorage.getStore();

--- a/specs/engine/aggregate-persistence-resolver.spec.md
+++ b/specs/engine/aggregate-persistence-resolver.spec.md
@@ -1,0 +1,120 @@
+---
+title: "AggregatePersistenceResolver"
+module: engine/aggregate-persistence-resolver
+source_file: packages/engine/src/aggregate-persistence-resolver.ts
+status: implemented
+exports: []
+depends_on:
+  - persistence
+---
+
+# AggregatePersistenceResolver
+
+> `AggregatePersistenceResolver` is the strategy interface for resolving the correct aggregate persistence at command dispatch time. It follows the same strategy pattern as `ConcurrencyStrategy`. Two implementations are provided: `GlobalAggregatePersistenceResolver` (all aggregates share one persistence) and `PerAggregatePersistenceResolver` (each aggregate has its own persistence). Both are engine-internal — users configure persistence via `DomainConfiguration.infrastructure.aggregatePersistence`.
+
+## Type Contract
+
+```ts
+import type { PersistenceConfiguration } from "@noddde/core";
+
+interface AggregatePersistenceResolver {
+  resolve(aggregateName: string): PersistenceConfiguration;
+}
+
+class GlobalAggregatePersistenceResolver
+  implements AggregatePersistenceResolver
+{
+  constructor(persistence: PersistenceConfiguration);
+  resolve(aggregateName: string): PersistenceConfiguration;
+}
+
+class PerAggregatePersistenceResolver implements AggregatePersistenceResolver {
+  constructor(map: Map<string, PersistenceConfiguration>);
+  resolve(aggregateName: string): PersistenceConfiguration;
+}
+```
+
+- `AggregatePersistenceResolver` is the strategy interface. A single method `resolve` takes an aggregate name and returns the `PersistenceConfiguration` for that aggregate.
+- `GlobalAggregatePersistenceResolver` wraps a single persistence instance, returning it for every aggregate name. This is used when `aggregatePersistence` is omitted or is a single factory function.
+- `PerAggregatePersistenceResolver` wraps a `Map` of persistence instances keyed by aggregate name. This is used when `aggregatePersistence` is a per-aggregate record.
+- All three types are engine-internal (`@internal`) and not exported from `@noddde/core`. They are constructed by `Domain.init()`.
+
+## Behavioral Requirements
+
+1. **GlobalAggregatePersistenceResolver.resolve** -- Always returns the same `PersistenceConfiguration` instance, regardless of the `aggregateName` parameter.
+2. **PerAggregatePersistenceResolver.resolve** -- Looks up the `aggregateName` in the internal map. If found, returns the corresponding `PersistenceConfiguration`. If not found, throws an error: `No persistence configured for aggregate "${aggregateName}"`.
+
+## Invariants
+
+- `GlobalAggregatePersistenceResolver` always returns a non-null `PersistenceConfiguration`.
+- `PerAggregatePersistenceResolver` returns a non-null `PersistenceConfiguration` for all aggregate names in the map. Throws for unknown names.
+- Both implementations are synchronous. All async factory resolution happens at `Domain.init()` time, not at resolve time.
+
+## Edge Cases
+
+- **PerAggregatePersistenceResolver with unknown aggregate name** -- Throws a descriptive error. This should never happen in practice because `Domain.init()` validates the map against registered aggregates.
+- **PerAggregatePersistenceResolver with empty map** -- Every call to `resolve` throws. This is valid but unusual (domain with no aggregates).
+
+## Integration Points
+
+- **Domain.init()** -- Constructs the appropriate resolver based on `aggregatePersistence` configuration.
+- **CommandLifecycleExecutor** -- Receives the resolver and calls `resolve(aggregateName)` at the start of each `execute()` invocation.
+- **ConcurrencyStrategy** -- Analogous engine-internal strategy pattern (`concurrency-strategy.ts`).
+
+## Test Scenarios
+
+### GlobalAggregatePersistenceResolver returns the same persistence for any aggregate
+
+```ts
+import { describe, it, expect } from "vitest";
+import { InMemoryEventSourcedAggregatePersistence } from "@noddde/engine";
+import { GlobalAggregatePersistenceResolver } from "../../../aggregate-persistence-resolver";
+
+describe("GlobalAggregatePersistenceResolver", () => {
+  it("should return the same persistence instance for any aggregate name", () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+    const resolver = new GlobalAggregatePersistenceResolver(persistence);
+
+    expect(resolver.resolve("Foo")).toBe(persistence);
+    expect(resolver.resolve("Bar")).toBe(persistence);
+    expect(resolver.resolve("Foo")).toBe(resolver.resolve("Bar"));
+  });
+});
+```
+
+### PerAggregatePersistenceResolver returns the correct persistence per aggregate
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  InMemoryEventSourcedAggregatePersistence,
+  InMemoryStateStoredAggregatePersistence,
+} from "@noddde/engine";
+import { PerAggregatePersistenceResolver } from "../../../aggregate-persistence-resolver";
+
+describe("PerAggregatePersistenceResolver", () => {
+  it("should return the correct persistence for each aggregate name", () => {
+    const esPersistence = new InMemoryEventSourcedAggregatePersistence();
+    const ssPersistence = new InMemoryStateStoredAggregatePersistence();
+    const map = new Map([
+      ["Counter", esPersistence],
+      ["BankAccount", ssPersistence],
+    ]);
+    const resolver = new PerAggregatePersistenceResolver(map);
+
+    expect(resolver.resolve("Counter")).toBe(esPersistence);
+    expect(resolver.resolve("BankAccount")).toBe(ssPersistence);
+  });
+
+  it("should throw for unknown aggregate names", () => {
+    const map = new Map([
+      ["Counter", new InMemoryEventSourcedAggregatePersistence()],
+    ]);
+    const resolver = new PerAggregatePersistenceResolver(map);
+
+    expect(() => resolver.resolve("NonExistent")).toThrow(
+      /No persistence configured for aggregate "NonExistent"/,
+    );
+  });
+});
+```

--- a/specs/engine/domain.spec.md
+++ b/specs/engine/domain.spec.md
@@ -10,6 +10,7 @@ depends_on:
   - engine/implementations/in-memory-query-bus
   - engine/implementations/in-memory-aggregate-persistence
   - engine/implementations/in-memory-saga-persistence
+  - engine/aggregate-persistence-resolver
   - engine/executors/command-lifecycle-executor
   - engine/executors/saga-executor
   - engine/executors/metadata-enricher
@@ -35,13 +36,18 @@ docs:
 ## Type Contract
 
 ```ts
+type PersistenceFactory = () =>
+  | PersistenceConfiguration
+  | Promise<PersistenceConfiguration>;
+
 type DomainConfiguration<
   TInfrastructure extends Infrastructure,
   TStandaloneCommand extends Command = Command,
   TStandaloneQuery extends Query<any> = Query<any>,
+  TAggregates extends AggregateMap = AggregateMap,
 > = {
   writeModel: {
-    aggregates: AggregateMap;
+    aggregates: TAggregates;
     standaloneCommandHandlers?: StandaloneCommandHandlerMap<
       TInfrastructure,
       TStandaloneCommand
@@ -58,9 +64,9 @@ type DomainConfiguration<
     sagas: SagaMap;
   };
   infrastructure: {
-    aggregatePersistence?: () =>
-      | PersistenceConfiguration
-      | Promise<PersistenceConfiguration>;
+    aggregatePersistence?:
+      | PersistenceFactory
+      | Record<keyof TAggregates & string, PersistenceFactory>;
     aggregateConcurrency?:
       | { strategy?: "optimistic"; maxRetries?: number }
       | {
@@ -94,16 +100,24 @@ class Domain<
   ): Promise<QueryResult<TQuery>>;
 }
 
-const configureDomain: <TInfrastructure, TStandaloneCommand, TStandaloneQuery>(
+const configureDomain: <
+  TInfrastructure,
+  TStandaloneCommand,
+  TStandaloneQuery,
+  TAggregates extends AggregateMap = AggregateMap,
+>(
   configuration: DomainConfiguration<
     TInfrastructure,
     TStandaloneCommand,
-    TStandaloneQuery
+    TStandaloneQuery,
+    TAggregates
   >,
 ) => Promise<Domain<TInfrastructure, TStandaloneCommand, TStandaloneQuery>>;
 ```
 
-- `DomainConfiguration` is fully generic over the infrastructure, standalone command, and standalone query types.
+- `PersistenceFactory` is a helper type alias for aggregate persistence factory functions.
+- `DomainConfiguration` is fully generic over the infrastructure, standalone command, standalone query, and aggregate map types. `TAggregates` defaults to `AggregateMap` for backward compatibility and is inferred by `configureDomain` from the `writeModel.aggregates` object, enabling type-safe per-aggregate persistence keys.
+- `aggregatePersistence` is a union type: a single `PersistenceFactory` (domain-wide, all aggregates share one persistence) or a `Record<keyof TAggregates & string, PersistenceFactory>` (per-aggregate, every aggregate must have an entry). When using the per-aggregate form, TypeScript enforces that all registered aggregate names have a corresponding persistence factory.
 - `Domain` stores the resolved infrastructure as `TInfrastructure & CQRSInfrastructure` -- custom dependencies merged with the CQRS buses.
 - `dispatchCommand` returns the `targetAggregateId` of the handled command, allowing callers to know which aggregate processed it.
 - `dispatchQuery` delegates to the query bus and returns the typed result. It is a convenience method providing API symmetry with `dispatchCommand`.
@@ -118,7 +132,11 @@ The `init()` method must execute the following steps in order:
 1. **Resolve custom infrastructure** -- Call `configuration.infrastructure.provideInfrastructure()` if provided. Store the result. If not provided, use `{}` as the default infrastructure.
 2. **Resolve CQRS infrastructure** -- Call `configuration.infrastructure.cqrsInfrastructure(infrastructure)` if provided, passing the resolved custom infrastructure. Store the `CommandBus`, `EventBus`, and `QueryBus`. If not provided, create default in-memory implementations (`InMemoryCommandBus`, `EventEmitterEventBus`, `InMemoryQueryBus`).
 3. **Merge infrastructure** -- Combine custom infrastructure and CQRS infrastructure into `this._infrastructure` as `TInfrastructure & CQRSInfrastructure`.
-4. **Resolve aggregate persistence** -- Call `configuration.infrastructure.aggregatePersistence()` if provided. Store as `this._persistence`. If not provided, use a default in-memory persistence.
+4. **Resolve aggregate persistence** -- Build an `AggregatePersistenceResolver` (strategy pattern, engine-internal) based on the `aggregatePersistence` configuration:
+   - **Omitted** (`undefined`): Create a `GlobalAggregatePersistenceResolver` wrapping a default `InMemoryEventSourcedAggregatePersistence`.
+   - **Function** (`typeof aggregatePersistence === 'function'`): Call the factory, create a `GlobalAggregatePersistenceResolver` wrapping the result.
+   - **Record** (per-aggregate map): Validate that every aggregate in `writeModel.aggregates` has a corresponding entry and that no unknown aggregate names are present. Throw a descriptive error on mismatch. Resolve each factory. Create a `PerAggregatePersistenceResolver` wrapping a `Map<string, PersistenceConfiguration>`.
+     Pass the resolver to `CommandLifecycleExecutor`, which calls `resolver.resolve(aggregateName)` at each command dispatch to obtain the persistence for the target aggregate.
 5. **Resolve snapshot store** -- Call `configuration.infrastructure.snapshotStore()` if provided. Store as `this._snapshotStore`. Store `configuration.infrastructure.snapshotStrategy` as `this._snapshotStrategy`. Both are optional.
 6. **Resolve saga persistence** -- Call `configuration.infrastructure.sagaPersistence()` if provided. Required if `processModel` is configured.
 7. **Register command handlers** -- For each aggregate in `writeModel.aggregates`, register a command handler on the command bus for each command name defined in `Aggregate.commands`. The registered handler encapsulates the full command lifecycle (load, execute, apply, persist, publish).
@@ -244,7 +262,11 @@ The `dispatchQuery` method delegates query dispatch to the underlying query bus:
 - **No sagas configured** -- `processModel` can be omitted. No saga listeners are registered.
 - **No custom infrastructure** -- `provideInfrastructure` can be omitted. The domain uses `{}` as the custom infrastructure.
 - **No CQRS infrastructure provided** -- `cqrsInfrastructure` can be omitted. The domain creates default in-memory buses.
-- **No persistence provided** -- `aggregatePersistence` can be omitted. The domain uses a default in-memory persistence.
+- **No persistence provided** -- `aggregatePersistence` can be omitted. The domain uses a default in-memory event-sourced persistence for all aggregates via `GlobalAggregatePersistenceResolver`.
+- **Per-aggregate persistence with missing aggregate** -- If the per-aggregate record is missing an entry for a registered aggregate, `init()` throws an error listing the missing aggregate names.
+- **Per-aggregate persistence with unknown aggregate name** -- If the per-aggregate record contains a key that does not match any registered aggregate, `init()` throws an error listing the unknown names.
+- **Per-aggregate persistence with mixed strategies** -- Some aggregates event-sourced, others state-stored. Snapshots only apply to event-sourced aggregates; the existing `isEventSourced` check in `CommandLifecycleExecutor` handles this correctly.
+- **Per-aggregate factory throws during init** -- The error propagates through `configureDomain` and the domain is not usable (same as existing factory error behavior).
 - **Command handler returns a single event** -- Must be normalized to an array before processing.
 - **Command handler returns empty array** -- No events to apply, persist, or publish. The aggregate state remains unchanged.
 - **Saga handler returns no commands** -- `reaction.commands` is `undefined` or empty. Only the saga state is persisted; no commands are dispatched.
@@ -259,7 +281,7 @@ The `dispatchQuery` method delegates query dispatch to the underlying query bus:
 ## Integration Points
 
 - **CQRS buses** -- The domain owns the command bus, query bus, and event bus. They are wired during init and exposed via `domain.infrastructure`.
-- **Persistence** -- The domain resolves aggregate and saga persistence during init from factory functions, passing them to the appropriate executors.
+- **Persistence** -- The domain resolves aggregate persistence during init from factory functions, building an `AggregatePersistenceResolver` (either `GlobalAggregatePersistenceResolver` or `PerAggregatePersistenceResolver`). The resolver is passed to `CommandLifecycleExecutor`. Saga persistence is resolved separately.
 - **CommandLifecycleExecutor** -- Internal executor that handles the full aggregate command lifecycle (load, execute, apply, enrich, persist, publish). Created during `init()` and used by `dispatchCommand()` and command bus handlers.
 - **SagaExecutor** -- Internal executor that handles the saga event handling lifecycle (derive ID, load state, bootstrap/resume, execute handler, dispatch commands atomically). Created during `init()` when `processModel` is configured.
 - **MetadataEnricher** -- Internal helper that enriches raw events with metadata (eventId, timestamp, correlationId, causationId, userId, aggregate context). Used by `CommandLifecycleExecutor`.
@@ -1621,6 +1643,516 @@ describe("Idempotent command processing", () => {
 
     // Idempotency record should NOT have been saved (UoW rolled back)
     expect(await idempotencyStore.exists("cmd-fail")).toBe(false);
+  });
+});
+```
+
+### per-aggregate persistence routes each aggregate to its own persistence
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  configureDomain,
+  defineAggregate,
+  EventEmitterEventBus,
+  InMemoryCommandBus,
+  InMemoryQueryBus,
+  InMemoryEventSourcedAggregatePersistence,
+  InMemoryStateStoredAggregatePersistence,
+} from "@noddde/core";
+import type {
+  DefineCommands,
+  DefineEvents,
+  AggregateTypes,
+  Infrastructure,
+} from "@noddde/core";
+
+type CounterState = { count: number };
+type CounterEvent = DefineEvents<{ Incremented: { by: number } }>;
+type CounterCommand = DefineCommands<{ Increment: { by: number } }>;
+type CounterTypes = AggregateTypes & {
+  state: CounterState;
+  events: CounterEvent;
+  commands: CounterCommand;
+  infrastructure: Infrastructure;
+};
+
+const Counter = defineAggregate<CounterTypes>({
+  initialState: { count: 0 },
+  commands: {
+    Increment: (cmd) => ({
+      name: "Incremented",
+      payload: { by: cmd.payload.by },
+    }),
+  },
+  apply: {
+    Incremented: (payload, state) => ({ count: state.count + payload.by }),
+  },
+});
+
+type BalanceState = { balance: number };
+type BalanceEvent = DefineEvents<{ Deposited: { amount: number } }>;
+type BalanceCommand = DefineCommands<{ Deposit: { amount: number } }>;
+type BalanceTypes = AggregateTypes & {
+  state: BalanceState;
+  events: BalanceEvent;
+  commands: BalanceCommand;
+  infrastructure: Infrastructure;
+};
+
+const BankAccount = defineAggregate<BalanceTypes>({
+  initialState: { balance: 0 },
+  commands: {
+    Deposit: (cmd) => ({
+      name: "Deposited",
+      payload: { amount: cmd.payload.amount },
+    }),
+  },
+  apply: {
+    Deposited: (payload, state) => ({
+      balance: state.balance + payload.amount,
+    }),
+  },
+});
+
+describe("Per-aggregate persistence", () => {
+  it("should route each aggregate to its configured persistence", async () => {
+    const esPersistence = new InMemoryEventSourcedAggregatePersistence();
+    const ssPersistence = new InMemoryStateStoredAggregatePersistence();
+
+    const domain = await configureDomain<Infrastructure>({
+      writeModel: { aggregates: { Counter, BankAccount } },
+      readModel: { projections: {} },
+      infrastructure: {
+        aggregatePersistence: {
+          Counter: () => esPersistence,
+          BankAccount: () => ssPersistence,
+        },
+        cqrsInfrastructure: () => ({
+          commandBus: new InMemoryCommandBus(),
+          eventBus: new EventEmitterEventBus(),
+          queryBus: new InMemoryQueryBus(),
+        }),
+      },
+    });
+
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "c-1",
+      payload: { by: 5 },
+    });
+    await domain.dispatchCommand({
+      name: "Deposit",
+      targetAggregateId: "acc-1",
+      payload: { amount: 100 },
+    });
+
+    // Counter uses event-sourced persistence
+    const counterEvents = await esPersistence.load("Counter", "c-1");
+    expect(counterEvents).toHaveLength(1);
+    expect(counterEvents[0]!.name).toBe("Incremented");
+
+    // BankAccount uses state-stored persistence
+    const bankState = await ssPersistence.load("BankAccount", "acc-1");
+    expect(bankState).not.toBeNull();
+    expect(bankState!.state.balance).toBe(100);
+  });
+});
+```
+
+### per-aggregate persistence init throws for missing aggregate entries
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  configureDomain,
+  defineAggregate,
+  EventEmitterEventBus,
+  InMemoryCommandBus,
+  InMemoryQueryBus,
+  InMemoryEventSourcedAggregatePersistence,
+} from "@noddde/core";
+import type {
+  DefineCommands,
+  DefineEvents,
+  AggregateTypes,
+  Infrastructure,
+} from "@noddde/core";
+
+type CounterState = { count: number };
+type CounterEvent = DefineEvents<{ Incremented: { by: number } }>;
+type CounterCommand = DefineCommands<{ Increment: { by: number } }>;
+type CounterTypes = AggregateTypes & {
+  state: CounterState;
+  events: CounterEvent;
+  commands: CounterCommand;
+  infrastructure: Infrastructure;
+};
+
+const Counter = defineAggregate<CounterTypes>({
+  initialState: { count: 0 },
+  commands: {
+    Increment: (cmd) => ({
+      name: "Incremented",
+      payload: { by: cmd.payload.by },
+    }),
+  },
+  apply: {
+    Incremented: (payload, state) => ({ count: state.count + payload.by }),
+  },
+});
+
+type BalanceState = { balance: number };
+type BalanceEvent = DefineEvents<{ Deposited: { amount: number } }>;
+type BalanceCommand = DefineCommands<{ Deposit: { amount: number } }>;
+type BalanceTypes = AggregateTypes & {
+  state: BalanceState;
+  events: BalanceEvent;
+  commands: BalanceCommand;
+  infrastructure: Infrastructure;
+};
+
+const BankAccount = defineAggregate<BalanceTypes>({
+  initialState: { balance: 0 },
+  commands: {
+    Deposit: (cmd) => ({
+      name: "Deposited",
+      payload: { amount: cmd.payload.amount },
+    }),
+  },
+  apply: {
+    Deposited: (payload, state) => ({
+      balance: state.balance + payload.amount,
+    }),
+  },
+});
+
+describe("Per-aggregate persistence validation", () => {
+  it("should throw if per-aggregate persistence is missing entries for registered aggregates", async () => {
+    await expect(
+      configureDomain<Infrastructure>({
+        writeModel: { aggregates: { Counter, BankAccount } },
+        readModel: { projections: {} },
+        infrastructure: {
+          // Only Counter has persistence — BankAccount is missing
+          aggregatePersistence: {
+            Counter: () => new InMemoryEventSourcedAggregatePersistence(),
+          } as any,
+          cqrsInfrastructure: () => ({
+            commandBus: new InMemoryCommandBus(),
+            eventBus: new EventEmitterEventBus(),
+            queryBus: new InMemoryQueryBus(),
+          }),
+        },
+      }),
+    ).rejects.toThrow(/missing.*BankAccount/i);
+  });
+
+  it("should throw if per-aggregate persistence references unknown aggregates", async () => {
+    await expect(
+      configureDomain<Infrastructure>({
+        writeModel: { aggregates: { Counter } },
+        readModel: { projections: {} },
+        infrastructure: {
+          aggregatePersistence: {
+            Counter: () => new InMemoryEventSourcedAggregatePersistence(),
+            NonExistent: () => new InMemoryEventSourcedAggregatePersistence(),
+          } as any,
+          cqrsInfrastructure: () => ({
+            commandBus: new InMemoryCommandBus(),
+            eventBus: new EventEmitterEventBus(),
+            queryBus: new InMemoryQueryBus(),
+          }),
+        },
+      }),
+    ).rejects.toThrow(/unknown.*NonExistent/i);
+  });
+});
+```
+
+### domain-wide persistence factory still works as before
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  configureDomain,
+  defineAggregate,
+  EventEmitterEventBus,
+  InMemoryCommandBus,
+  InMemoryQueryBus,
+  InMemoryEventSourcedAggregatePersistence,
+} from "@noddde/core";
+import type {
+  DefineCommands,
+  DefineEvents,
+  AggregateTypes,
+  Infrastructure,
+} from "@noddde/core";
+
+type CounterState = { count: number };
+type CounterEvent = DefineEvents<{ Incremented: { by: number } }>;
+type CounterCommand = DefineCommands<{ Increment: { by: number } }>;
+type CounterTypes = AggregateTypes & {
+  state: CounterState;
+  events: CounterEvent;
+  commands: CounterCommand;
+  infrastructure: Infrastructure;
+};
+
+const Counter = defineAggregate<CounterTypes>({
+  initialState: { count: 0 },
+  commands: {
+    Increment: (cmd) => ({
+      name: "Incremented",
+      payload: { by: cmd.payload.by },
+    }),
+  },
+  apply: {
+    Incremented: (payload, state) => ({ count: state.count + payload.by }),
+  },
+});
+
+describe("Domain-wide persistence (backward compatibility)", () => {
+  it("should use a single persistence factory for all aggregates", async () => {
+    const persistence = new InMemoryEventSourcedAggregatePersistence();
+
+    const domain = await configureDomain<Infrastructure>({
+      writeModel: { aggregates: { Counter } },
+      readModel: { projections: {} },
+      infrastructure: {
+        aggregatePersistence: () => persistence,
+        cqrsInfrastructure: () => ({
+          commandBus: new InMemoryCommandBus(),
+          eventBus: new EventEmitterEventBus(),
+          queryBus: new InMemoryQueryBus(),
+        }),
+      },
+    });
+
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "c-1",
+      payload: { by: 3 },
+    });
+
+    const events = await persistence.load("Counter", "c-1");
+    expect(events).toHaveLength(1);
+  });
+});
+```
+
+### per-aggregate async factories are resolved at init time
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import {
+  configureDomain,
+  defineAggregate,
+  EventEmitterEventBus,
+  InMemoryCommandBus,
+  InMemoryQueryBus,
+  InMemoryEventSourcedAggregatePersistence,
+  InMemoryStateStoredAggregatePersistence,
+} from "@noddde/core";
+import type {
+  DefineCommands,
+  DefineEvents,
+  AggregateTypes,
+  Infrastructure,
+} from "@noddde/core";
+
+type CounterState = { count: number };
+type CounterEvent = DefineEvents<{ Incremented: { by: number } }>;
+type CounterCommand = DefineCommands<{ Increment: { by: number } }>;
+type CounterTypes = AggregateTypes & {
+  state: CounterState;
+  events: CounterEvent;
+  commands: CounterCommand;
+  infrastructure: Infrastructure;
+};
+
+const Counter = defineAggregate<CounterTypes>({
+  initialState: { count: 0 },
+  commands: {
+    Increment: (cmd) => ({
+      name: "Incremented",
+      payload: { by: cmd.payload.by },
+    }),
+  },
+  apply: {
+    Incremented: (payload, state) => ({ count: state.count + payload.by }),
+  },
+});
+
+type BalanceState = { balance: number };
+type BalanceEvent = DefineEvents<{ Deposited: { amount: number } }>;
+type BalanceCommand = DefineCommands<{ Deposit: { amount: number } }>;
+type BalanceTypes = AggregateTypes & {
+  state: BalanceState;
+  events: BalanceEvent;
+  commands: BalanceCommand;
+  infrastructure: Infrastructure;
+};
+
+const BankAccount = defineAggregate<BalanceTypes>({
+  initialState: { balance: 0 },
+  commands: {
+    Deposit: (cmd) => ({
+      name: "Deposited",
+      payload: { amount: cmd.payload.amount },
+    }),
+  },
+  apply: {
+    Deposited: (payload, state) => ({
+      balance: state.balance + payload.amount,
+    }),
+  },
+});
+
+describe("Per-aggregate persistence factory resolution", () => {
+  it("should resolve all async per-aggregate factories during init", async () => {
+    const esFactory = vi.fn(
+      async () => new InMemoryEventSourcedAggregatePersistence(),
+    );
+    const ssFactory = vi.fn(
+      async () => new InMemoryStateStoredAggregatePersistence(),
+    );
+
+    await configureDomain<Infrastructure>({
+      writeModel: { aggregates: { Counter, BankAccount } },
+      readModel: { projections: {} },
+      infrastructure: {
+        aggregatePersistence: {
+          Counter: esFactory,
+          BankAccount: ssFactory,
+        },
+        cqrsInfrastructure: () => ({
+          commandBus: new InMemoryCommandBus(),
+          eventBus: new EventEmitterEventBus(),
+          queryBus: new InMemoryQueryBus(),
+        }),
+      },
+    });
+
+    expect(esFactory).toHaveBeenCalledOnce();
+    expect(ssFactory).toHaveBeenCalledOnce();
+  });
+});
+```
+
+### mixed persistence with snapshots only applies to event-sourced aggregates
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import {
+  configureDomain,
+  defineAggregate,
+  EventEmitterEventBus,
+  InMemoryCommandBus,
+  InMemoryQueryBus,
+  InMemoryEventSourcedAggregatePersistence,
+  InMemoryStateStoredAggregatePersistence,
+  InMemorySnapshotStore,
+  everyNEvents,
+} from "@noddde/core";
+import type {
+  DefineCommands,
+  DefineEvents,
+  AggregateTypes,
+  Infrastructure,
+} from "@noddde/core";
+
+type CounterState = { count: number };
+type CounterEvent = DefineEvents<{ Incremented: { by: number } }>;
+type CounterCommand = DefineCommands<{ Increment: { by: number } }>;
+type CounterTypes = AggregateTypes & {
+  state: CounterState;
+  events: CounterEvent;
+  commands: CounterCommand;
+  infrastructure: Infrastructure;
+};
+
+const Counter = defineAggregate<CounterTypes>({
+  initialState: { count: 0 },
+  commands: {
+    Increment: (cmd) => ({
+      name: "Incremented",
+      payload: { by: cmd.payload.by },
+    }),
+  },
+  apply: {
+    Incremented: (payload, state) => ({ count: state.count + payload.by }),
+  },
+});
+
+type BalanceState = { balance: number };
+type BalanceEvent = DefineEvents<{ Deposited: { amount: number } }>;
+type BalanceCommand = DefineCommands<{ Deposit: { amount: number } }>;
+type BalanceTypes = AggregateTypes & {
+  state: BalanceState;
+  events: BalanceEvent;
+  commands: BalanceCommand;
+  infrastructure: Infrastructure;
+};
+
+const BankAccount = defineAggregate<BalanceTypes>({
+  initialState: { balance: 0 },
+  commands: {
+    Deposit: (cmd) => ({
+      name: "Deposited",
+      payload: { amount: cmd.payload.amount },
+    }),
+  },
+  apply: {
+    Deposited: (payload, state) => ({
+      balance: state.balance + payload.amount,
+    }),
+  },
+});
+
+describe("Mixed persistence with snapshots", () => {
+  it("should only create snapshots for event-sourced aggregates", async () => {
+    const snapshotStore = new InMemorySnapshotStore();
+
+    const domain = await configureDomain<Infrastructure>({
+      writeModel: { aggregates: { Counter, BankAccount } },
+      readModel: { projections: {} },
+      infrastructure: {
+        aggregatePersistence: {
+          Counter: () => new InMemoryEventSourcedAggregatePersistence(),
+          BankAccount: () => new InMemoryStateStoredAggregatePersistence(),
+        },
+        snapshotStore: () => snapshotStore,
+        snapshotStrategy: everyNEvents(1), // snapshot after every event
+        cqrsInfrastructure: () => ({
+          commandBus: new InMemoryCommandBus(),
+          eventBus: new EventEmitterEventBus(),
+          queryBus: new InMemoryQueryBus(),
+        }),
+      },
+    });
+
+    // Dispatch to event-sourced aggregate
+    await domain.dispatchCommand({
+      name: "Increment",
+      targetAggregateId: "c-1",
+      payload: { by: 5 },
+    });
+
+    // Dispatch to state-stored aggregate
+    await domain.dispatchCommand({
+      name: "Deposit",
+      targetAggregateId: "acc-1",
+      payload: { amount: 100 },
+    });
+
+    // Snapshot should exist for event-sourced Counter
+    const counterSnapshot = await snapshotStore.load("Counter", "c-1");
+    expect(counterSnapshot).not.toBeNull();
+
+    // No snapshot for state-stored BankAccount
+    const bankSnapshot = await snapshotStore.load("BankAccount", "acc-1");
+    expect(bankSnapshot).toBeNull();
   });
 });
 ```

--- a/specs/engine/executors/command-lifecycle-executor.spec.md
+++ b/specs/engine/executors/command-lifecycle-executor.spec.md
@@ -6,6 +6,7 @@ status: implemented
 exports: []
 depends_on:
   - engine/executors/metadata-enricher
+  - engine/aggregate-persistence-resolver
   - edd/event
   - edd/event-metadata
   - ddd/aggregate-root
@@ -29,18 +30,18 @@ import type {
   CQRSInfrastructure,
   IdempotencyStore,
   Infrastructure,
-  PersistenceConfiguration,
   SnapshotStore,
   SnapshotStrategy,
   UnitOfWork,
   UnitOfWorkFactory,
 } from "@noddde/core";
+import type { AggregatePersistenceResolver } from "../aggregate-persistence-resolver";
 import type { ConcurrencyStrategy } from "../concurrency-strategy";
 import type { MetadataEnricher } from "./metadata-enricher";
 
 class CommandLifecycleExecutor {
   constructor(
-    persistence: PersistenceConfiguration,
+    persistenceResolver: AggregatePersistenceResolver,
     infrastructure: Infrastructure & CQRSInfrastructure,
     unitOfWorkFactory: UnitOfWorkFactory,
     concurrencyStrategy: ConcurrencyStrategy,
@@ -59,7 +60,7 @@ class CommandLifecycleExecutor {
 }
 ```
 
-- `CommandLifecycleExecutor` is constructed with all dependencies needed for the lifecycle: persistence, infrastructure (including CQRS buses), UoW factory, concurrency strategy, UoW storage (for detecting explicit UoW), metadata enricher, and optional snapshot store/strategy.
+- `CommandLifecycleExecutor` is constructed with all dependencies needed for the lifecycle: an `AggregatePersistenceResolver` (which resolves the correct persistence for each aggregate by name), infrastructure (including CQRS buses), UoW factory, concurrency strategy, UoW storage (for detecting explicit UoW), metadata enricher, and optional snapshot store/strategy.
 - `execute` is the single public method. It runs the full lifecycle for a given aggregate command, handling UoW creation/ownership and concurrency delegation internally.
 
 ## Behavioral Requirements
@@ -186,7 +187,7 @@ class CommandLifecycleExecutor {
 - **ConcurrencyStrategy** -- Wraps the attempt for retry (optimistic) or locking (pessimistic).
 - **UnitOfWork** -- Persistence and event publishing are enlisted/deferred on the UoW for atomic commit.
 - **AsyncLocalStorage<UnitOfWork>** -- Checked to determine implicit vs. explicit UoW ownership.
-- **PersistenceConfiguration** -- Either `EventSourcedAggregatePersistence` or `StateStoredAggregatePersistence`. The executor detects the type by checking whether `load` returns an array.
+- **AggregatePersistenceResolver** -- Resolves the correct `PersistenceConfiguration` for each aggregate by name. The executor calls `persistenceResolver.resolve(aggregateName)` at the start of `execute()` to obtain the persistence instance. The resolved persistence is either `EventSourcedAggregatePersistence` or `StateStoredAggregatePersistence`; the executor detects the type by checking whether `load` returns an array.
 - **SnapshotStore / SnapshotStrategy** -- Optional. Used for snapshot-aware loading and post-command snapshot evaluation.
 - **EventBus** -- Events are dispatched after implicit UoW commit.
 - **Domain** -- Constructs the executor during `init()` and calls `execute` for each aggregate command dispatch.


### PR DESCRIPTION
## Summary

- Add per-aggregate persistence strategy configuration to `DomainConfiguration`, allowing mixed persistence strategies (event-sourced + state-stored) within a single domain
- `aggregatePersistence` is now a union type: a single factory (domain-wide, backward compatible) or a `Record<keyof TAggregates & string, PersistenceFactory>` (per-aggregate, type-safe)
- Introduce `AggregatePersistenceResolver` strategy pattern (`GlobalAggregatePersistenceResolver` / `PerAggregatePersistenceResolver`), mirroring the existing `ConcurrencyStrategy` design

## Test plan

- [x] 198/198 tests pass (`npx vitest run`)
- [x] Type check clean (`npx tsc --noEmit`)
- [x] New `AggregatePersistenceResolver` tests (3 scenarios)
- [x] New domain integration tests (5 scenarios): per-aggregate routing, validation errors, backward compat, async factory resolution, mixed persistence with snapshots
- [x] Existing executor tests updated to use resolver pattern
- [x] Verify sample domains still compile (no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)