### PR TITLE
feat(core,engine): add type-safe Upcaster API for event versioning

### DIFF
--- a/docs/content/docs/modeling/event-versioning.mdx
+++ b/docs/content/docs/modeling/event-versioning.mdx
@@ -1,0 +1,145 @@
+---
+title: Event Versioning & Upcasters
+description: Evolving event schemas over time with type-safe upcaster chains that transform historical payloads to current versions during aggregate replay.
+---
+
+Event schemas inevitably change as your domain evolves. A field gets added, a type gets refined, a payload gets restructured. In an event-sourced system, old events are immutable — they're already persisted. Upcasters bridge the gap by transforming historical event payloads to the current schema version during aggregate replay.
+
+## The Problem
+
+Consider a `BankAccountCreated` event that originally had this payload:
+
+```typescript
+// Version 1 (original)
+{
+  id: string;
+  owner: string;
+}
+```
+
+Later, you add a `status` field:
+
+```typescript
+// Version 2 (current)
+{
+  id: string;
+  owner: string;
+  status: "active" | "closed";
+}
+```
+
+Without upcasting, replaying version 1 events through apply handlers that expect version 2 payloads will produce incorrect state — the `status` field will be `undefined`.
+
+## Defining Upcaster Chains
+
+An upcaster chain declares all historical payload versions as a tuple and provides transform functions between consecutive versions.
+
+```typescript
+import {
+  defineEventUpcasterChain,
+  defineUpcasters,
+  DefineEvents,
+} from "@noddde/core";
+
+// Current event types
+type BankAccountEvent = DefineEvents<{
+  BankAccountCreated: {
+    id: string;
+    owner: string;
+    status: "active" | "closed";
+  };
+  DepositMade: { amount: number; currency: string };
+}>;
+
+// Declare historical payload types
+type BankAccountCreatedV1 = { id: string; owner: string };
+
+// Build the upcaster map
+const bankAccountUpcasters = defineUpcasters<BankAccountEvent>({
+  BankAccountCreated: defineEventUpcasterChain<
+    [
+      BankAccountCreatedV1,
+      { id: string; owner: string; status: "active" | "closed" },
+    ]
+  >((v1) => ({ ...v1, status: "active" as const })),
+});
+```
+
+### Multi-Version Chains
+
+Events can go through many versions. Each step in the chain transforms from one version to the next:
+
+```typescript
+type CreatedV1 = { id: string };
+type CreatedV2 = { id: string; status: "active" | "closed" };
+type CreatedV3 = { id: string; status: "active" | "closed"; createdAt: string };
+
+const upcasters = defineUpcasters<MyEvent>({
+  Created: defineEventUpcasterChain<[CreatedV1, CreatedV2, CreatedV3]>(
+    (v1) => ({ ...v1, status: "active" as const }), // v1 -> v2
+    (v2) => ({ ...v2, createdAt: new Date(0).toISOString() }), // v2 -> v3
+  ),
+});
+```
+
+The version tuple `[V1, V2, V3]` declares all shapes upfront. Step parameters and return types are derived from the tuple — no manual type annotations needed after the first version.
+
+## Registering Upcasters on an Aggregate
+
+Pass the upcaster map to `defineAggregate` via the optional `upcasters` field:
+
+```typescript
+const BankAccount = defineAggregate<BankAccountTypes>({
+  initialState: { balance: 0, status: "active" },
+  commands: {
+    /* ... */
+  },
+  apply: {
+    // Apply handlers always receive the CURRENT version payload.
+    // Upcasting happens before apply handlers are called.
+    BankAccountCreated: (payload, state) => ({
+      ...state,
+      id: payload.id,
+      owner: payload.owner,
+      status: payload.status, // Always present after upcasting
+    }),
+  },
+  upcasters: bankAccountUpcasters,
+});
+```
+
+## How It Works
+
+During aggregate rehydration (loading events from persistence to rebuild state), the engine applies the upcaster chain to each loaded event before passing it to the apply handler:
+
+1. **Load events** from the event store
+2. **Determine stored version** from `event.metadata.version` (defaults to 1 if absent)
+3. **Apply upcaster steps** from the stored version to the current version
+4. **Pass upcasted payload** to the apply handler
+
+New events produced by command handlers automatically get `metadata.version` set to the current version for their event name.
+
+## Type Safety
+
+The upcaster API provides compile-time safety at multiple levels:
+
+- **Step continuity**: Each step's input type is derived from the previous version in the tuple. If you return the wrong shape, TypeScript catches it.
+- **Output validation**: The chain's final output must match the current event payload type. A mismatch is a compile error.
+- **Event name validation**: `UpcasterMap` only allows keys that exist in your event union.
+- **No arbitrary types**: All payload shapes are declared upfront in the version tuple — no ad-hoc annotations.
+
+## Constraints
+
+Upcaster steps follow the same constraints as apply handlers:
+
+- **Pure**: No side effects, no I/O, no infrastructure access.
+- **Synchronous**: No `async`/`await`.
+- **Deterministic**: Same input always produces the same output.
+
+These constraints ensure that replaying events always produces the same state, regardless of when the replay happens.
+
+## Snapshot Considerations
+
+If you use snapshots with event-sourced aggregates, be aware that adding or modifying upcasters may make existing snapshots stale. The snapshot state was computed under the old schema, and post-snapshot events will be upcasted but the snapshot state itself won't be.
+
+**Recommendation**: Invalidate or clear snapshots when you change event schemas. A simple approach is to increment the snapshot version or clear the snapshot store during deployment.

--- a/docs/content/docs/modeling/meta.json
+++ b/docs/content/docs/modeling/meta.json
@@ -5,6 +5,7 @@
     "command-handlers",
     "state-and-events",
     "routing-and-dispatch",
-    "type-inference"
+    "type-inference",
+    "event-versioning"
   ]
 }

--- a/packages/core/src/__tests__/edd/upcaster.test.ts
+++ b/packages/core/src/__tests__/edd/upcaster.test.ts
@@ -1,0 +1,309 @@
+/* eslint-disable no-unused-vars */
+import { describe, it, expect, expectTypeOf } from "vitest";
+import type {
+  Event,
+  DefineEvents,
+  TypedEventUpcasterChain,
+  StepsFromVersions,
+  Last,
+  UpcasterMap,
+} from "@noddde/core";
+import {
+  upcastEvent,
+  upcastEvents,
+  currentEventVersion,
+  defineEventUpcasterChain,
+  defineUpcasters,
+} from "@noddde/core";
+
+describe("Upcaster (Event Versioning)", () => {
+  describe("upcastEvent with no chain", () => {
+    it("should return the event unchanged when no chain exists for its name", () => {
+      const event: Event = {
+        name: "OrderPlaced",
+        payload: { orderId: "123" },
+      };
+      const result = upcastEvent(event, {});
+      expect(result).toBe(event);
+    });
+  });
+
+  describe("upcastEvent with missing version", () => {
+    type TestEvent = DefineEvents<{ Created: { id: string; status: string } }>;
+
+    it("should treat events without metadata.version as version 1 and apply the chain", () => {
+      const upcasters = defineUpcasters<TestEvent>({
+        Created: defineEventUpcasterChain<
+          [{ id: string }, { id: string; status: string }]
+        >((v1) => ({ ...v1, status: "active" })),
+      });
+
+      const event: Event = { name: "Created", payload: { id: "1" } };
+      const result = upcastEvent(event, upcasters);
+      expect(result.payload).toEqual({ id: "1", status: "active" });
+    });
+
+    it("should treat events with metadata but no version as version 1", () => {
+      const upcasters = defineUpcasters<TestEvent>({
+        Created: defineEventUpcasterChain<
+          [{ id: string }, { id: string; status: string }]
+        >((v1) => ({ ...v1, status: "active" })),
+      });
+
+      const event: Event = {
+        name: "Created",
+        payload: { id: "1" },
+        metadata: {
+          eventId: "evt-1",
+          timestamp: "2024-01-01T00:00:00.000Z",
+          correlationId: "corr-1",
+          causationId: "cmd-1",
+        },
+      };
+      const result = upcastEvent(event, upcasters);
+      expect(result.payload).toEqual({ id: "1", status: "active" });
+    });
+  });
+
+  describe("upcastEvent multi-step chain", () => {
+    type V1 = { id: string };
+    type V2 = { id: string; status: string };
+    type V3 = { id: string; status: string; createdAt: string };
+
+    type TestEvent = DefineEvents<{ Created: V3 }>;
+
+    const upcasters = defineUpcasters<TestEvent>({
+      Created: defineEventUpcasterChain<[V1, V2, V3]>(
+        (v1) => ({ ...v1, status: "active" }),
+        (v2) => ({ ...v2, createdAt: "2024-01-01" }),
+      ),
+    });
+
+    it("should apply all steps for a v1 event", () => {
+      const event: Event = { name: "Created", payload: { id: "1" } };
+      const result = upcastEvent(event, upcasters);
+      expect(result.payload).toEqual({
+        id: "1",
+        status: "active",
+        createdAt: "2024-01-01",
+      });
+    });
+
+    it("should apply only remaining steps for a v2 event", () => {
+      const event: Event = {
+        name: "Created",
+        payload: { id: "1", status: "active" },
+        metadata: {
+          eventId: "evt-1",
+          timestamp: "2024-01-01T00:00:00.000Z",
+          correlationId: "corr-1",
+          causationId: "cmd-1",
+          version: 2,
+        },
+      };
+      const result = upcastEvent(event, upcasters);
+      expect(result.payload).toEqual({
+        id: "1",
+        status: "active",
+        createdAt: "2024-01-01",
+      });
+    });
+  });
+
+  describe("upcastEvent at current version", () => {
+    type TestEvent = DefineEvents<{ Created: { id: string; status: string } }>;
+
+    const upcasters = defineUpcasters<TestEvent>({
+      Created: defineEventUpcasterChain<
+        [{ id: string }, { id: string; status: string }]
+      >((v1) => ({ ...v1, status: "active" })),
+    });
+
+    it("should return the event unchanged when already at current version", () => {
+      const event: Event = {
+        name: "Created",
+        payload: { id: "1", status: "active" },
+        metadata: {
+          eventId: "evt-1",
+          timestamp: "2024-01-01T00:00:00.000Z",
+          correlationId: "corr-1",
+          causationId: "cmd-1",
+          version: 2,
+        },
+      };
+      const result = upcastEvent(event, upcasters);
+      expect(result).toBe(event);
+    });
+  });
+
+  describe("upcastEvent future version", () => {
+    type TestEvent = DefineEvents<{ Created: { id: string; status: string } }>;
+
+    const upcasters = defineUpcasters<TestEvent>({
+      Created: defineEventUpcasterChain<
+        [{ id: string }, { id: string; status: string }]
+      >((v1) => ({ ...v1, status: "active" })),
+    });
+
+    it("should return the event unchanged when version is higher than current", () => {
+      const event: Event = {
+        name: "Created",
+        payload: { id: "1", status: "active", futureField: true },
+        metadata: {
+          eventId: "evt-1",
+          timestamp: "2024-01-01T00:00:00.000Z",
+          correlationId: "corr-1",
+          causationId: "cmd-1",
+          version: 99,
+        },
+      };
+      const result = upcastEvent(event, upcasters);
+      expect(result).toBe(event);
+    });
+  });
+
+  describe("upcastEvent immutability", () => {
+    type TestEvent = DefineEvents<{ Created: { id: string; status: string } }>;
+
+    it("should not mutate the original event or payload", () => {
+      const upcasters = defineUpcasters<TestEvent>({
+        Created: defineEventUpcasterChain<
+          [{ id: string }, { id: string; status: string }]
+        >((v1) => ({ ...v1, status: "active" })),
+      });
+
+      const originalPayload = { id: "1" };
+      const event: Event = { name: "Created", payload: originalPayload };
+      const result = upcastEvent(event, upcasters);
+
+      expect(result).not.toBe(event);
+      expect(result.payload).not.toBe(originalPayload);
+      expect(originalPayload).toEqual({ id: "1" });
+      expect(event.payload).toEqual({ id: "1" });
+    });
+  });
+
+  describe("currentEventVersion", () => {
+    type TestEvent = DefineEvents<{
+      Created: { id: string; status: string; createdAt: string };
+      Updated: { id: string };
+    }>;
+
+    const upcasters = defineUpcasters<TestEvent>({
+      Created: defineEventUpcasterChain<
+        [
+          { id: string },
+          { id: string; status: string },
+          { id: string; status: string; createdAt: string },
+        ]
+      >(
+        (v1) => ({ ...v1, status: "active" }),
+        (v2) => ({ ...v2, createdAt: "2024-01-01" }),
+      ),
+    });
+
+    it("should return chain.length + 1 for events with a chain", () => {
+      expect(currentEventVersion("Created", upcasters)).toBe(3);
+    });
+
+    it("should return 1 for events without a chain", () => {
+      expect(currentEventVersion("Updated", upcasters)).toBe(1);
+    });
+
+    it("should return 1 for unknown event names", () => {
+      expect(currentEventVersion("NonExistent", upcasters)).toBe(1);
+    });
+  });
+
+  describe("upcastEvents", () => {
+    type TestEvent = DefineEvents<{ Created: { id: string; status: string } }>;
+
+    it("should upcast each event in the array", () => {
+      const upcasters = defineUpcasters<TestEvent>({
+        Created: defineEventUpcasterChain<
+          [{ id: string }, { id: string; status: string }]
+        >((v1) => ({ ...v1, status: "active" })),
+      });
+
+      const events: Event[] = [
+        { name: "Created", payload: { id: "1" } },
+        { name: "Created", payload: { id: "2" } },
+        { name: "Unknown", payload: {} },
+      ];
+
+      const results = upcastEvents(events, upcasters);
+      expect(results).toHaveLength(3);
+      expect(results[0]!.payload).toEqual({ id: "1", status: "active" });
+      expect(results[1]!.payload).toEqual({ id: "2", status: "active" });
+      expect(results[2]).toBe(events[2]);
+    });
+  });
+
+  describe("defineEventUpcasterChain type safety", () => {
+    it("should derive step types from version tuple", () => {
+      type V1 = { id: string };
+      type V2 = { id: string; status: string };
+      type Steps = StepsFromVersions<[V1, V2]>;
+      expectTypeOf<Steps>().toEqualTypeOf<[(payload: V1) => V2]>();
+    });
+
+    it("should derive multi-step types from version tuple", () => {
+      type V1 = { id: string };
+      type V2 = { id: string; status: string };
+      type V3 = { id: string; status: string; createdAt: string };
+      type Steps = StepsFromVersions<[V1, V2, V3]>;
+      expectTypeOf<Steps>().toEqualTypeOf<
+        [(payload: V1) => V2, (payload: V2) => V3]
+      >();
+    });
+
+    it("should extract last element of tuple", () => {
+      expectTypeOf<Last<[string, number, boolean]>>().toEqualTypeOf<boolean>();
+      expectTypeOf<Last<[string]>>().toEqualTypeOf<string>();
+    });
+
+    it("should produce empty steps for single-element tuple", () => {
+      type Steps = StepsFromVersions<[{ id: string }]>;
+      expectTypeOf<Steps>().toEqualTypeOf<[]>();
+    });
+
+    it("should constrain UpcasterMap keys to valid event names", () => {
+      type TestEvent = DefineEvents<{
+        Created: { id: string };
+        Updated: { name: string };
+      }>;
+      type Map = UpcasterMap<TestEvent>;
+      expectTypeOf<Map>().toHaveProperty("Created");
+      expectTypeOf<Map>().toHaveProperty("Updated");
+    });
+
+    it("should constrain chain output to match current event payload", () => {
+      type TestEvent = DefineEvents<{
+        Created: { id: string; status: string };
+      }>;
+      type Map = UpcasterMap<TestEvent>;
+
+      // Valid: chain output matches current payload
+      expectTypeOf<
+        TypedEventUpcasterChain<{ id: string; status: string }>
+      >().toMatchTypeOf<NonNullable<Map["Created"]>>();
+    });
+  });
+
+  describe("defineUpcasters", () => {
+    type TestEvent = DefineEvents<{
+      Created: { id: string };
+      Updated: { value: number };
+    }>;
+
+    it("should return the same map with correct typing", () => {
+      const upcasters = defineUpcasters<TestEvent>({});
+      expectTypeOf(upcasters).toMatchTypeOf<UpcasterMap<TestEvent>>();
+    });
+
+    it("should accept an empty map", () => {
+      const upcasters = defineUpcasters<TestEvent>({});
+      expectTypeOf(upcasters).toMatchTypeOf<UpcasterMap<TestEvent>>();
+    });
+  });
+});

--- a/packages/core/src/ddd/aggregate-root.ts
+++ b/packages/core/src/ddd/aggregate-root.ts
@@ -2,6 +2,7 @@
 import type { ID } from "../id";
 import { Event } from "../edd/event";
 import { ApplyHandler } from "../edd/event-sourcing-handler";
+import type { UpcasterMap } from "../edd/upcaster";
 import { AggregateCommand } from "../cqrs/command/command";
 import { Infrastructure } from "../infrastructure";
 
@@ -99,6 +100,15 @@ export interface Aggregate<T extends AggregateTypes = AggregateTypes> {
    * the "evolve" phase: `(payload, state) => newState`. Must be pure.
    */
   apply: ApplyHandlerMap<T>;
+  /**
+   * Optional map of upcaster chains keyed by event name. Each chain
+   * transforms historical event payloads from older schema versions
+   * to the current version during event replay. Only events that have
+   * undergone schema changes need entries.
+   *
+   * @see {@link UpcasterMap}
+   */
+  upcasters?: UpcasterMap<T["events"]>;
 }
 
 /**

--- a/packages/core/src/edd/index.ts
+++ b/packages/core/src/edd/index.ts
@@ -3,3 +3,4 @@ export * from "./event";
 export * from "./event-handler";
 export * from "./event-bus";
 export * from "./event-sourcing-handler";
+export * from "./upcaster";

--- a/packages/core/src/edd/upcaster.ts
+++ b/packages/core/src/edd/upcaster.ts
@@ -1,0 +1,184 @@
+/* eslint-disable no-unused-vars */
+import type { Event } from "./event";
+
+/**
+ * Extracts the last element of a tuple type.
+ *
+ * @example
+ * ```ts
+ * type L = Last<[string, number, boolean]>; // boolean
+ * ```
+ */
+export type Last<T extends any[]> = T extends [...any[], infer L] ? L : never;
+
+/**
+ * Recursive mapped tuple type that generates step function signatures
+ * from a version tuple. Each step transforms from one version to the next.
+ *
+ * @example
+ * ```ts
+ * type S = StepsFromVersions<[V1, V2, V3]>;
+ * // [(payload: V1) => V2, (payload: V2) => V3]
+ * ```
+ */
+export type StepsFromVersions<T extends any[]> = T extends [
+  infer V1,
+  infer V2,
+  ...infer Rest,
+]
+  ? [(payload: V1) => V2, ...StepsFromVersions<[V2, ...Rest]>]
+  : [];
+
+/**
+ * A phantom-branded array type that carries the upcaster chain's final
+ * output type at the type level. At runtime, it is a plain array of
+ * payload transform functions. The phantom `__outputType` field enables
+ * {@link UpcasterMap} to validate that the chain's final output matches
+ * the current event payload type.
+ *
+ * @typeParam TOutput - The payload type produced by the last step in the chain.
+ */
+export type TypedEventUpcasterChain<TOutput> = Array<(payload: any) => any> & {
+  readonly __outputType?: TOutput;
+};
+
+/**
+ * A mapped type that associates event names with their typed upcaster chains.
+ * Keys are constrained to valid event names from `TEvents`, and each chain's
+ * phantom output type must be assignable to the corresponding event's current
+ * payload type.
+ *
+ * Only events that have undergone schema changes need entries; omitted events
+ * are assumed to be at version 1 (never changed).
+ *
+ * @typeParam TEvents - The discriminated union of all event types.
+ */
+export type UpcasterMap<TEvents extends Event = Event> = {
+  [K in TEvents["name"]]?: TypedEventUpcasterChain<
+    Extract<TEvents, { name: K }>["payload"]
+  >;
+};
+
+/**
+ * Creates a typed upcaster chain from a version tuple. The version tuple
+ * declares all payload shapes (historical and current) upfront, and each
+ * step function's input/output types are derived from it.
+ *
+ * The version tuple **must** be explicitly provided as a generic parameter
+ * (TypeScript cannot infer it from the step functions).
+ *
+ * @typeParam TVersions - A tuple of payload types `[V1, V2, ...]` where
+ *   each element represents a schema version. Must have at least 2 elements.
+ * @param steps - Transform functions, one per version transition.
+ * @returns A {@link TypedEventUpcasterChain} branded with the last version type.
+ *
+ * @example
+ * ```ts
+ * type V1 = { id: string };
+ * type V2 = { id: string; status: string };
+ *
+ * const chain = defineEventUpcasterChain<[V1, V2]>(
+ *   (v1) => ({ ...v1, status: "active" }),
+ * );
+ * ```
+ */
+export function defineEventUpcasterChain<
+  TVersions extends [any, any, ...any[]],
+>(
+  ...steps: StepsFromVersions<TVersions>
+): TypedEventUpcasterChain<Last<TVersions>> {
+  return steps as unknown as TypedEventUpcasterChain<Last<TVersions>>;
+}
+
+/**
+ * Identity function for creating type-safe upcaster maps. Provides
+ * type inference and validation that event names and chain output types
+ * match the event union.
+ *
+ * @typeParam TEvents - The discriminated union of all event types.
+ * @param upcasters - The upcaster map to validate.
+ * @returns The same map, fully typed.
+ *
+ * @example
+ * ```ts
+ * const upcasters = defineUpcasters<BankAccountEvent>({
+ *   AccountCreated: defineEventUpcasterChain<[V1, V2]>(
+ *     (v1) => ({ ...v1, status: "active" }),
+ *   ),
+ * });
+ * ```
+ */
+export function defineUpcasters<TEvents extends Event>(
+  upcasters: UpcasterMap<TEvents>,
+): UpcasterMap<TEvents> {
+  return upcasters;
+}
+
+/**
+ * Applies an upcaster chain to a single event, transforming its payload
+ * from the stored version to the current version. Returns a new event
+ * object with the upcasted payload — the input is never mutated.
+ *
+ * If no chain exists for the event's name, or if the event is already
+ * at (or beyond) the current version, the original event is returned
+ * as-is (same reference).
+ *
+ * @param event - The event to upcast.
+ * @param upcasters - The upcaster map containing chains per event name.
+ * @returns A new event with the upcasted payload, or the original event.
+ */
+export function upcastEvent(event: Event, upcasters: UpcasterMap): Event {
+  const chain = upcasters[event.name as keyof typeof upcasters] as
+    | TypedEventUpcasterChain<any>
+    | undefined;
+  if (!chain || chain.length === 0) {
+    return event;
+  }
+
+  const storedVersion = event.metadata?.version ?? 1;
+  const currentVersion = chain.length + 1;
+
+  if (storedVersion >= currentVersion) {
+    return event;
+  }
+
+  let payload = event.payload;
+  for (let i = storedVersion - 1; i < chain.length; i++) {
+    payload = chain[i]!(payload);
+  }
+
+  return { ...event, payload };
+}
+
+/**
+ * Applies upcaster chains to an array of events. Each event is individually
+ * upcasted via {@link upcastEvent}.
+ *
+ * @param events - The events to upcast.
+ * @param upcasters - The upcaster map containing chains per event name.
+ * @returns A new array of upcasted events.
+ */
+export function upcastEvents(events: Event[], upcasters: UpcasterMap): Event[] {
+  return events.map((event) => upcastEvent(event, upcasters));
+}
+
+/**
+ * Returns the current schema version for an event name based on its
+ * upcaster chain. If no chain exists, the current version is 1.
+ *
+ * @param eventName - The event name to look up.
+ * @param upcasters - The upcaster map containing chains per event name.
+ * @returns The current version number (always >= 1).
+ */
+export function currentEventVersion(
+  eventName: string,
+  upcasters: UpcasterMap,
+): number {
+  const chain = upcasters[eventName as keyof typeof upcasters] as
+    | TypedEventUpcasterChain<any>
+    | undefined;
+  if (!chain) {
+    return 1;
+  }
+  return chain.length + 1;
+}

--- a/packages/engine/src/domain.ts
+++ b/packages/engine/src/domain.ts
@@ -520,6 +520,25 @@ export class Domain<
       );
     }
 
+    // Step 5.12: Validate upcaster chains
+    for (const [aggregateName, aggregate] of Object.entries(
+      configuration.writeModel.aggregates,
+    )) {
+      if (aggregate.upcasters) {
+        for (const [eventName, chain] of Object.entries(aggregate.upcasters)) {
+          if (
+            !Array.isArray(chain) ||
+            chain.some((step) => typeof step !== "function")
+          ) {
+            throw new Error(
+              `Invalid upcaster chain for event "${eventName}" on aggregate "${aggregateName}": ` +
+                `chain must be an array of functions.`,
+            );
+          }
+        }
+      }
+    }
+
     const { commandBus, eventBus, queryBus } = this._infrastructure;
 
     // Step 6: Register aggregate command handlers on the command bus

--- a/packages/engine/src/executors/command-lifecycle-executor.ts
+++ b/packages/engine/src/executors/command-lifecycle-executor.ts
@@ -18,6 +18,7 @@ import type {
   UnitOfWork,
   UnitOfWorkFactory,
 } from "@noddde/core";
+import { upcastEvents, currentEventVersion } from "@noddde/core";
 import type { AggregatePersistenceResolver } from "../aggregate-persistence-resolver";
 import type { ConcurrencyStrategy } from "../concurrency-strategy";
 import type { MetadataEnricher } from "./metadata-enricher";
@@ -201,7 +202,10 @@ export class CommandLifecycleExecutor {
         events = (allEvents as Event[]).slice(snapshot.version);
       }
       version = snapshot.version + events.length;
-      currentState = events.reduce((state: any, event: Event) => {
+      const upcastedEvents = aggregate.upcasters
+        ? upcastEvents(events, aggregate.upcasters)
+        : events;
+      currentState = upcastedEvents.reduce((state: any, event: Event) => {
         const applyHandler = aggregate.apply[event.name];
         return applyHandler ? applyHandler(event.payload, state) : state;
       }, snapshot.state);
@@ -217,7 +221,10 @@ export class CommandLifecycleExecutor {
         // Event-sourced: replay events to rebuild state; version = stream length
         const events = loaded as Event[];
         version = events.length;
-        currentState = events.reduce((state: any, event: Event) => {
+        const upcastedEvents = aggregate.upcasters
+          ? upcastEvents(events, aggregate.upcasters)
+          : events;
+        currentState = upcastedEvents.reduce((state: any, event: Event) => {
           const applyHandler = aggregate.apply[event.name];
           return applyHandler ? applyHandler(event.payload, state) : state;
         }, aggregate.initialState);
@@ -253,13 +260,17 @@ export class CommandLifecycleExecutor {
       }
     }
 
-    // Step 4.5: Enrich events with metadata
+    // Step 4.5: Enrich events with metadata (including schema version if upcasters are configured)
+    const eventVersionResolver = aggregate.upcasters
+      ? (name: string) => currentEventVersion(name, aggregate.upcasters!)
+      : undefined;
     const enrichedEvents = this.metadataEnricher.enrich(
       newEvents,
       aggregateName,
       command.targetAggregateId,
       version,
       command.name,
+      eventVersionResolver,
     );
 
     // Step 5: Enlist persistence in UoW with version (deferred until commit)

--- a/packages/engine/src/executors/metadata-enricher.ts
+++ b/packages/engine/src/executors/metadata-enricher.ts
@@ -30,6 +30,8 @@ export class MetadataEnricher {
    * @param aggregateId - The aggregate instance that produced these events.
    * @param version - The aggregate version before these events (used for sequenceNumber).
    * @param causationFallback - Fallback causationId (typically the command name).
+   * @param eventVersionResolver - Optional function that returns the current schema
+   *   version for an event name. When provided, sets `metadata.version` on each event.
    * @returns New event objects with metadata attached.
    */
   enrich(
@@ -38,6 +40,7 @@ export class MetadataEnricher {
     aggregateId: ID,
     version: number,
     causationFallback: string,
+    eventVersionResolver?: (eventName: string) => number,
   ): Event[] {
     const providerCtx = this.metadataProvider?.() ?? {};
     const overrideCtx = this.metadataStorage.getStore() ?? {};
@@ -55,6 +58,7 @@ export class MetadataEnricher {
         correlationId,
         causationId,
         userId: mergedCtx.userId,
+        version: eventVersionResolver?.(event.name),
         aggregateName,
         aggregateId,
         sequenceNumber: version + index + 1,

--- a/specs/core/edd/upcaster.spec.md
+++ b/specs/core/edd/upcaster.spec.md
@@ -1,0 +1,575 @@
+---
+title: "Upcaster (Event Versioning)"
+module: edd/upcaster
+source_file: packages/core/src/edd/upcaster.ts
+status: implemented
+exports:
+  - TypedEventUpcasterChain
+  - UpcasterMap
+  - StepsFromVersions
+  - Last
+  - defineEventUpcasterChain
+  - defineUpcasters
+  - upcastEvent
+  - upcastEvents
+  - currentEventVersion
+depends_on:
+  - edd/event
+  - edd/event-metadata
+docs:
+  - modeling/event-versioning.mdx
+---
+
+# Upcaster (Event Versioning)
+
+> Provides a type-safe, functional API for evolving event schemas over time. Upcasters are pure, synchronous functions that transform event payloads from one schema version to the next, forming ordered chains per event name. When replaying historical events during aggregate rehydration, the engine applies upcaster chains to bring old payloads up to the current version before feeding them to apply handlers.
+
+## Type Contract
+
+### `TypedEventUpcasterChain<TOutput>`
+
+A phantom-branded array type that carries the chain's final output type at the type level:
+
+```typescript
+type TypedEventUpcasterChain<TOutput> = Array<(payload: any) => any> & {
+  readonly __outputType?: TOutput;
+};
+```
+
+- At runtime, a plain `Array<(payload: any) => any>`.
+- The phantom `__outputType` field exists only at the type level to enable `UpcasterMap` to validate that the chain's final output matches the current event payload.
+
+### `UpcasterMap<TEvents extends Event>`
+
+A mapped type that associates event names with their typed upcaster chains:
+
+```typescript
+type UpcasterMap<TEvents extends Event = Event> = {
+  [K in TEvents["name"]]?: TypedEventUpcasterChain<
+    Extract<TEvents, { name: K }>["payload"]
+  >;
+};
+```
+
+- Keys are constrained to valid event names from `TEvents`.
+- Each chain's `TOutput` phantom type must be assignable to the corresponding event's current payload type.
+- Only events that have undergone schema changes need entries; omitted events are assumed to be at version 1.
+
+### `StepsFromVersions<T extends any[]>`
+
+A recursive mapped tuple type that generates step function signatures from a version tuple:
+
+```typescript
+type StepsFromVersions<T extends any[]> = T extends [
+  infer V1,
+  infer V2,
+  ...infer Rest,
+]
+  ? [(payload: V1) => V2, ...StepsFromVersions<[V2, ...Rest]>]
+  : [];
+```
+
+- `StepsFromVersions<[A, B, C]>` expands to `[(payload: A) => B, (payload: B) => C]`.
+- Works for any tuple length (limited only by TypeScript's recursion depth).
+
+### `Last<T extends any[]>`
+
+Extracts the last element of a tuple type:
+
+```typescript
+type Last<T extends any[]> = T extends [...any[], infer L] ? L : never;
+```
+
+### `defineEventUpcasterChain<TVersions>(...steps)`
+
+Creates a typed upcaster chain from a version tuple:
+
+```typescript
+function defineEventUpcasterChain<TVersions extends [any, any, ...any[]]>(
+  ...steps: StepsFromVersions<TVersions>
+): TypedEventUpcasterChain<Last<TVersions>>;
+```
+
+- `TVersions` must be explicitly provided as a generic (TypeScript cannot infer it from the steps).
+- Each step's input type is derived from the corresponding tuple element.
+- Each step's return type is validated against the next tuple element.
+- Returns a `TypedEventUpcasterChain<Last<TVersions>>`, enabling `UpcasterMap` to validate the chain output against the current event payload.
+
+### `defineUpcasters<TEvents>(map)`
+
+Identity function for creating type-safe upcaster maps:
+
+```typescript
+function defineUpcasters<TEvents extends Event>(
+  upcasters: UpcasterMap<TEvents>,
+): UpcasterMap<TEvents>;
+```
+
+### `upcastEvent(event, upcasters)`
+
+Applies an upcaster chain to a single event:
+
+```typescript
+function upcastEvent(event: Event, upcasters: UpcasterMap): Event;
+```
+
+- Returns a new `Event` object with the upcasted payload. Never mutates the input.
+
+### `upcastEvents(events, upcasters)`
+
+Applies upcaster chains to an array of events:
+
+```typescript
+function upcastEvents(events: Event[], upcasters: UpcasterMap): Event[];
+```
+
+### `currentEventVersion(eventName, upcasters)`
+
+Returns the current schema version for an event name:
+
+```typescript
+function currentEventVersion(eventName: string, upcasters: UpcasterMap): number;
+```
+
+## Behavioral Requirements
+
+1. **`upcastEvent` returns the event unchanged when no chain exists** for the event's `name` in the upcaster map.
+2. **`upcastEvent` treats events without `metadata.version` as version 1** — this handles events persisted before versioning was introduced.
+3. **`upcastEvent` applies steps sequentially from `storedVersion - 1` to `chain.length - 1`** — for a version 2 event with a 3-step chain (v1→v2→v3→v4), only steps at index 1 and 2 are applied.
+4. **`upcastEvent` returns the event unchanged when `storedVersion >= currentVersion`** — events already at or beyond the current version need no transformation (forward compatibility).
+5. **`upcastEvent` returns a new event object** — the input event is never mutated; the returned event has the same `name` and `metadata` but a new `payload`.
+6. **`currentEventVersion` returns `chain.length + 1`** for events with a chain, or `1` for events without a chain.
+7. **`upcastEvents` applies `upcastEvent` to each event in the array** in order, returning a new array.
+8. **`defineEventUpcasterChain` enforces step-to-step type safety** — step N's input type is `TVersions[N]` and its return type must be assignable to `TVersions[N+1]`.
+9. **`defineEventUpcasterChain` enforces final-output type safety** — the returned `TypedEventUpcasterChain<Last<TVersions>>` carries the phantom brand so `UpcasterMap` can validate the chain output matches the current event payload.
+10. **`defineUpcasters` enforces event name validation** — only keys that exist in `TEvents["name"]` are allowed.
+11. **Upcaster steps are pure and synchronous** — like apply handlers, they take a payload and return a new payload with no side effects.
+
+## Invariants
+
+- `upcastEvent` always returns an `Event` that is structurally identical to the input except for `payload`.
+- `upcastEvent` never mutates the input event or its payload.
+- For any event, `upcastEvent(event, {})` === the original event (identity for empty map).
+- `currentEventVersion(name, map)` is always >= 1.
+- Version numbering starts at 1, never 0.
+- A chain with 0 steps (`[]`) is equivalent to no chain (current version = 1).
+- `StepsFromVersions<[A]>` produces `[]` (a single-element tuple has no transitions).
+- `StepsFromVersions<[A, B]>` produces `[(payload: A) => B]`.
+
+## Edge Cases
+
+- **Event name not in upcaster map**: `upcastEvent` returns the event unchanged.
+- **Event already at current version**: `upcastEvent` returns the event unchanged.
+- **Future event** (`metadata.version > currentVersion`): returned unchanged (supports rolling deployments where a newer writer may produce events the current version doesn't know about).
+- **Empty upcaster map** (`{}`): all events pass through unchanged.
+- **`metadata` is undefined**: treated as version 1.
+- **`metadata.version` is undefined but `metadata` exists**: treated as version 1.
+- **Chain with zero steps** (`[]`): current version is 1, no transforms applied.
+- **Version 1 event with a 1-step chain**: step at index 0 is applied (transforms v1 to v2).
+
+## Integration Points
+
+- **`Aggregate<T>.upcasters?`** — the optional field on aggregate definitions (in `ddd/aggregate-root.ts`) holds the `UpcasterMap<T["events"]>` for that aggregate's events.
+- **`CommandLifecycleExecutor`** — applies `upcastEvents()` to loaded events before replaying them through apply handlers (both standard and snapshot paths).
+- **`MetadataEnricher`** — uses `currentEventVersion()` to stamp `metadata.version` on newly produced events.
+- **`Domain.init()`** — validates upcaster chains at startup (each chain must be an array of functions).
+
+## Test Scenarios
+
+### upcastEvent returns event unchanged when no chain exists
+
+```ts
+import { describe, it, expect } from "vitest";
+import { upcastEvent } from "@noddde/core";
+import type { Event } from "@noddde/core";
+
+describe("upcastEvent with no chain", () => {
+  it("should return the event unchanged when no chain exists for its name", () => {
+    const event: Event = { name: "OrderPlaced", payload: { orderId: "123" } };
+    const result = upcastEvent(event, {});
+    expect(result).toBe(event);
+  });
+});
+```
+
+### upcastEvent treats missing metadata.version as version 1
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  upcastEvent,
+  defineEventUpcasterChain,
+  defineUpcasters,
+} from "@noddde/core";
+import type { Event, DefineEvents } from "@noddde/core";
+
+describe("upcastEvent with missing version", () => {
+  type TestEvent = DefineEvents<{ Created: { id: string; status: string } }>;
+
+  it("should treat events without metadata.version as version 1 and apply the chain", () => {
+    const upcasters = defineUpcasters<TestEvent>({
+      Created: defineEventUpcasterChain<
+        [{ id: string }, { id: string; status: string }]
+      >((v1) => ({ ...v1, status: "active" })),
+    });
+
+    const event: Event = { name: "Created", payload: { id: "1" } };
+    const result = upcastEvent(event, upcasters);
+    expect(result.payload).toEqual({ id: "1", status: "active" });
+  });
+
+  it("should treat events with metadata but no version as version 1", () => {
+    const upcasters = defineUpcasters<TestEvent>({
+      Created: defineEventUpcasterChain<
+        [{ id: string }, { id: string; status: string }]
+      >((v1) => ({ ...v1, status: "active" })),
+    });
+
+    const event: Event = {
+      name: "Created",
+      payload: { id: "1" },
+      metadata: {
+        eventId: "evt-1",
+        timestamp: "2024-01-01T00:00:00.000Z",
+        correlationId: "corr-1",
+        causationId: "cmd-1",
+      },
+    };
+    const result = upcastEvent(event, upcasters);
+    expect(result.payload).toEqual({ id: "1", status: "active" });
+  });
+});
+```
+
+### upcastEvent applies steps sequentially from stored version
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  upcastEvent,
+  defineEventUpcasterChain,
+  defineUpcasters,
+} from "@noddde/core";
+import type { Event, DefineEvents } from "@noddde/core";
+
+describe("upcastEvent multi-step chain", () => {
+  type V1 = { id: string };
+  type V2 = { id: string; status: string };
+  type V3 = { id: string; status: string; createdAt: string };
+
+  type TestEvent = DefineEvents<{ Created: V3 }>;
+
+  const upcasters = defineUpcasters<TestEvent>({
+    Created: defineEventUpcasterChain<[V1, V2, V3]>(
+      (v1) => ({ ...v1, status: "active" }),
+      (v2) => ({ ...v2, createdAt: "2024-01-01" }),
+    ),
+  });
+
+  it("should apply all steps for a v1 event", () => {
+    const event: Event = { name: "Created", payload: { id: "1" } };
+    const result = upcastEvent(event, upcasters);
+    expect(result.payload).toEqual({
+      id: "1",
+      status: "active",
+      createdAt: "2024-01-01",
+    });
+  });
+
+  it("should apply only remaining steps for a v2 event", () => {
+    const event: Event = {
+      name: "Created",
+      payload: { id: "1", status: "active" },
+      metadata: {
+        eventId: "evt-1",
+        timestamp: "2024-01-01T00:00:00.000Z",
+        correlationId: "corr-1",
+        causationId: "cmd-1",
+        version: 2,
+      },
+    };
+    const result = upcastEvent(event, upcasters);
+    expect(result.payload).toEqual({
+      id: "1",
+      status: "active",
+      createdAt: "2024-01-01",
+    });
+  });
+});
+```
+
+### upcastEvent returns event unchanged when already at current version
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  upcastEvent,
+  defineEventUpcasterChain,
+  defineUpcasters,
+} from "@noddde/core";
+import type { Event, DefineEvents } from "@noddde/core";
+
+describe("upcastEvent at current version", () => {
+  type TestEvent = DefineEvents<{ Created: { id: string; status: string } }>;
+
+  const upcasters = defineUpcasters<TestEvent>({
+    Created: defineEventUpcasterChain<
+      [{ id: string }, { id: string; status: string }]
+    >((v1) => ({ ...v1, status: "active" })),
+  });
+
+  it("should return the event unchanged when already at current version", () => {
+    const event: Event = {
+      name: "Created",
+      payload: { id: "1", status: "active" },
+      metadata: {
+        eventId: "evt-1",
+        timestamp: "2024-01-01T00:00:00.000Z",
+        correlationId: "corr-1",
+        causationId: "cmd-1",
+        version: 2,
+      },
+    };
+    const result = upcastEvent(event, upcasters);
+    expect(result).toBe(event);
+  });
+});
+```
+
+### upcastEvent returns event unchanged for future versions
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  upcastEvent,
+  defineEventUpcasterChain,
+  defineUpcasters,
+} from "@noddde/core";
+import type { Event, DefineEvents } from "@noddde/core";
+
+describe("upcastEvent future version", () => {
+  type TestEvent = DefineEvents<{ Created: { id: string; status: string } }>;
+
+  const upcasters = defineUpcasters<TestEvent>({
+    Created: defineEventUpcasterChain<
+      [{ id: string }, { id: string; status: string }]
+    >((v1) => ({ ...v1, status: "active" })),
+  });
+
+  it("should return the event unchanged when version is higher than current", () => {
+    const event: Event = {
+      name: "Created",
+      payload: { id: "1", status: "active", futureField: true },
+      metadata: {
+        eventId: "evt-1",
+        timestamp: "2024-01-01T00:00:00.000Z",
+        correlationId: "corr-1",
+        causationId: "cmd-1",
+        version: 99,
+      },
+    };
+    const result = upcastEvent(event, upcasters);
+    expect(result).toBe(event);
+  });
+});
+```
+
+### upcastEvent never mutates the input
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  upcastEvent,
+  defineEventUpcasterChain,
+  defineUpcasters,
+} from "@noddde/core";
+import type { Event, DefineEvents } from "@noddde/core";
+
+describe("upcastEvent immutability", () => {
+  type TestEvent = DefineEvents<{ Created: { id: string; status: string } }>;
+
+  it("should not mutate the original event or payload", () => {
+    const upcasters = defineUpcasters<TestEvent>({
+      Created: defineEventUpcasterChain<
+        [{ id: string }, { id: string; status: string }]
+      >((v1) => ({ ...v1, status: "active" })),
+    });
+
+    const originalPayload = { id: "1" };
+    const event: Event = { name: "Created", payload: originalPayload };
+    const result = upcastEvent(event, upcasters);
+
+    expect(result).not.toBe(event);
+    expect(result.payload).not.toBe(originalPayload);
+    expect(originalPayload).toEqual({ id: "1" });
+    expect(event.payload).toEqual({ id: "1" });
+  });
+});
+```
+
+### currentEventVersion returns chain.length + 1 or 1
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  currentEventVersion,
+  defineEventUpcasterChain,
+  defineUpcasters,
+} from "@noddde/core";
+import type { DefineEvents } from "@noddde/core";
+
+describe("currentEventVersion", () => {
+  type TestEvent = DefineEvents<{
+    Created: { id: string; status: string; createdAt: string };
+    Updated: { id: string };
+  }>;
+
+  const upcasters = defineUpcasters<TestEvent>({
+    Created: defineEventUpcasterChain<
+      [
+        { id: string },
+        { id: string; status: string },
+        { id: string; status: string; createdAt: string },
+      ]
+    >(
+      (v1) => ({ ...v1, status: "active" }),
+      (v2) => ({ ...v2, createdAt: "2024-01-01" }),
+    ),
+  });
+
+  it("should return chain.length + 1 for events with a chain", () => {
+    expect(currentEventVersion("Created", upcasters)).toBe(3);
+  });
+
+  it("should return 1 for events without a chain", () => {
+    expect(currentEventVersion("Updated", upcasters)).toBe(1);
+  });
+
+  it("should return 1 for unknown event names", () => {
+    expect(currentEventVersion("NonExistent", upcasters)).toBe(1);
+  });
+});
+```
+
+### upcastEvents applies upcasting to each event in array
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  upcastEvents,
+  defineEventUpcasterChain,
+  defineUpcasters,
+} from "@noddde/core";
+import type { Event, DefineEvents } from "@noddde/core";
+
+describe("upcastEvents", () => {
+  type TestEvent = DefineEvents<{ Created: { id: string; status: string } }>;
+
+  it("should upcast each event in the array", () => {
+    const upcasters = defineUpcasters<TestEvent>({
+      Created: defineEventUpcasterChain<
+        [{ id: string }, { id: string; status: string }]
+      >((v1) => ({ ...v1, status: "active" })),
+    });
+
+    const events: Event[] = [
+      { name: "Created", payload: { id: "1" } },
+      { name: "Created", payload: { id: "2" } },
+      { name: "Unknown", payload: {} },
+    ];
+
+    const results = upcastEvents(events, upcasters);
+    expect(results).toHaveLength(3);
+    expect(results[0]!.payload).toEqual({ id: "1", status: "active" });
+    expect(results[1]!.payload).toEqual({ id: "2", status: "active" });
+    expect(results[2]).toBe(events[2]);
+  });
+});
+```
+
+### defineEventUpcasterChain enforces type safety via version tuple
+
+```ts
+import { describe, it, expectTypeOf } from "vitest";
+import type {
+  TypedEventUpcasterChain,
+  StepsFromVersions,
+  Last,
+  UpcasterMap,
+  DefineEvents,
+} from "@noddde/core";
+
+describe("defineEventUpcasterChain type safety", () => {
+  it("should derive step types from version tuple", () => {
+    type V1 = { id: string };
+    type V2 = { id: string; status: string };
+    type Steps = StepsFromVersions<[V1, V2]>;
+    expectTypeOf<Steps>().toEqualTypeOf<[(payload: V1) => V2]>();
+  });
+
+  it("should derive multi-step types from version tuple", () => {
+    type V1 = { id: string };
+    type V2 = { id: string; status: string };
+    type V3 = { id: string; status: string; createdAt: string };
+    type Steps = StepsFromVersions<[V1, V2, V3]>;
+    expectTypeOf<Steps>().toEqualTypeOf<
+      [(payload: V1) => V2, (payload: V2) => V3]
+    >();
+  });
+
+  it("should extract last element of tuple", () => {
+    expectTypeOf<Last<[string, number, boolean]>>().toEqualTypeOf<boolean>();
+    expectTypeOf<Last<[string]>>().toEqualTypeOf<string>();
+  });
+
+  it("should produce empty steps for single-element tuple", () => {
+    type Steps = StepsFromVersions<[{ id: string }]>;
+    expectTypeOf<Steps>().toEqualTypeOf<[]>();
+  });
+
+  it("should constrain UpcasterMap keys to valid event names", () => {
+    type TestEvent = DefineEvents<{
+      Created: { id: string };
+      Updated: { name: string };
+    }>;
+    type Map = UpcasterMap<TestEvent>;
+    expectTypeOf<Map>().toHaveProperty("Created");
+    expectTypeOf<Map>().toHaveProperty("Updated");
+  });
+
+  it("should constrain chain output to match current event payload", () => {
+    type TestEvent = DefineEvents<{ Created: { id: string; status: string } }>;
+    type Map = UpcasterMap<TestEvent>;
+
+    // Valid: chain output matches current payload
+    expectTypeOf<
+      TypedEventUpcasterChain<{ id: string; status: string }>
+    >().toMatchTypeOf<NonNullable<Map["Created"]>>();
+  });
+});
+```
+
+### defineUpcasters validates event name keys
+
+```ts
+import { describe, it, expectTypeOf } from "vitest";
+import { defineUpcasters } from "@noddde/core";
+import type { DefineEvents, UpcasterMap } from "@noddde/core";
+
+describe("defineUpcasters", () => {
+  type TestEvent = DefineEvents<{
+    Created: { id: string };
+    Updated: { value: number };
+  }>;
+
+  it("should return the same map with correct typing", () => {
+    const upcasters = defineUpcasters<TestEvent>({});
+    expectTypeOf(upcasters).toMatchTypeOf<UpcasterMap<TestEvent>>();
+  });
+
+  it("should accept an empty map", () => {
+    const upcasters = defineUpcasters<TestEvent>({});
+    expectTypeOf(upcasters).toMatchTypeOf<UpcasterMap<TestEvent>>();
+  });
+});
+```


### PR DESCRIPTION
## Summary

- **New Upcaster API** (`@noddde/core`) for evolving event schemas over time — pure, functional, type-safe upcaster chains that transform historical event payloads to the current version during aggregate replay
- **`defineEventUpcasterChain<[V1, V2, ...]>(...)`** uses a version tuple generic with recursive `StepsFromVersions<T>` mapped type — step inputs/outputs are derived from the tuple (no arbitrary typing), and a phantom-branded output type ensures the chain's final result matches the current event payload
- **Engine integration**: `CommandLifecycleExecutor` applies upcasting during event replay (both standard and snapshot paths), and `MetadataEnricher` stamps `metadata.version` on new events

## Test plan

- [x] `packages/core` — unit tests for `upcastEvent`, `upcastEvents`, `currentEventVersion`, `defineEventUpcasterChain`, `defineUpcasters` (type-level and runtime)
- [x] `packages/core` — verify `tsc --noEmit` passes with new types and `Aggregate.upcasters?` field
- [x] `packages/engine` — verify existing tests still pass (additive change, no breaking changes)
- [x] `packages/engine` — verify lint passes across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)