### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,73 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in noddde
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Define an aggregate with ...
+        2. Dispatch command ...
+        3. Observe error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened. Include error messages or stack traces if applicable.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      description: Which package is affected?
+      options:
+        - "@noddde/core"
+        - "@noddde/engine"
+        - "@noddde/testing"
+        - "@noddde/adapters (Drizzle/Prisma/TypeORM)"
+        - Multiple packages
+        - Other / Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Package Version
+      description: The version of the affected package.
+      placeholder: e.g., 0.5.2
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Node version, OS, ORM adapter, and any other relevant details.
+      placeholder: "Node 22.x, macOS, Drizzle + PostgreSQL"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussion
+    url: https://github.com/dogganidhal/noddde/discussions
+    about: Ask questions or start a discussion about noddde
+  - name: Spec System
+    url: https://github.com/dogganidhal/noddde/tree/main/specs
+    about: Browse existing behavioral specs before proposing new ones

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,69 @@
+name: Feature Request
+description: Propose a new feature or enhancement for noddde
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: What problem does this feature solve? Why is it needed?
+      placeholder: Describe the pain point or use case that motivates this feature.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the approach, API surface, or behavior you envision.
+      placeholder: |
+        Describe the solution you'd like. Include code snippets or API examples if helpful.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What must be true for this feature to be considered done?
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation-hints
+    attributes:
+      label: Implementation Hints
+      description: Key files, patterns, or architectural considerations.
+      placeholder: |
+        - Key files: `packages/engine/src/domain.ts`
+        - Reuse existing pattern X from Y
+    validations:
+      required: false
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of Scope
+      description: What this feature explicitly does NOT include.
+      placeholder: List anything that should be deferred to a follow-up issue.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      description: Which package does this feature primarily affect?
+      options:
+        - "@noddde/core"
+        - "@noddde/engine"
+        - "@noddde/testing"
+        - "@noddde/cli"
+        - "@noddde/adapters (Drizzle/Prisma/TypeORM)"
+        - Multiple packages
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/spec-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/spec-proposal.yml
@@ -1,0 +1,55 @@
+name: Spec Proposal
+description: Propose a new behavioral spec for discussion before implementation
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-paragraph description of the proposed behavior.
+      placeholder: Describe what this spec covers and why it is needed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Behavioral Requirements
+      description: Numbered list of requirements this spec must enforce.
+      placeholder: |
+        1. The system MUST ...
+        2. When X happens, the system MUST ...
+        3. The system MUST NOT ...
+    validations:
+      required: true
+
+  - type: input
+    id: spec-path
+    attributes:
+      label: Spec Path
+      description: Target path in the `specs/` directory following the mirror convention.
+      placeholder: "specs/engine/domain-shutdown.spec.md"
+    validations:
+      required: true
+
+  - type: textarea
+    id: related-specs
+    attributes:
+      label: Related Specs
+      description: Links to existing specs this interacts with or depends on.
+      placeholder: |
+        - `specs/engine/outbox-relay.spec.md`
+        - `specs/core/persistence/unit-of-work.spec.md`
+    validations:
+      required: false
+
+  - type: textarea
+    id: test-scenarios
+    attributes:
+      label: Test Scenarios
+      description: Initial test ideas or Given-When-Then scenarios.
+      placeholder: |
+        - Given a running domain, when SIGTERM is received, then in-flight commands complete before shutdown
+        - Given an idle domain, when shutdown() is called twice, then the second call is a no-op
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Add 3 YAML form issue templates: feature request, bug report, spec proposal
- Add `config.yml` to disable blank issues and link to discussions/specs
- Enforces consistent issue formatting across the project

## Test plan
- [ ] Verify templates render correctly on GitHub (New Issue page)
- [ ] Confirm blank issues are disabled
- [ ] Test each template form submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>