### PR TITLE
feat: unified PersistenceAdapter interface and class-based adapters

### DIFF
--- a/docs/content/docs/patterns/hotel-booking.mdx
+++ b/docs/content/docs/patterns/hotel-booking.mdx
@@ -609,7 +609,10 @@ The domain configuration uses `defineDomain` to capture the pure domain structur
 
 ```ts
 // src/main.ts
+import { DrizzleAdapter } from "@noddde/drizzle";
 import { defineDomain, wireDomain } from "@noddde/engine";
+
+const adapter = new DrizzleAdapter(db);
 
 // Step 1: Define the domain structure (pure, sync)
 const hotelDomain = defineDomain({
@@ -640,6 +643,8 @@ const hotelDomain = defineDomain({
 
 // Step 2: Wire with infrastructure (async)
 const domain = await wireDomain(hotelDomain, {
+  persistenceAdapter: adapter,
+
   infrastructure: (): HotelInfrastructure => ({
     clock: new SystemClock(),
     paymentGateway: new FakePaymentGateway(),
@@ -647,28 +652,18 @@ const domain = await wireDomain(hotelDomain, {
     // ...emailService, smsService, guestHistoryViewStore, revenueViewStore
   }),
 
-  // Per-aggregate persistence: Room + Booking → event-sourced, Inventory → state-stored
+  // Per-aggregate persistence: Room + Booking → event-sourced, Inventory → state-stored (default)
   aggregates: {
     Room: {
-      persistence: () => drizzleInfra.eventSourcedPersistence,
+      persistence: "event-sourced",
       concurrency: { maxRetries: 3 },
-      snapshots: {
-        store: () => drizzleInfra.snapshotStore!,
-        strategy: everyNEvents(50),
-      },
+      snapshots: { strategy: everyNEvents(50) },
     },
     Booking: {
-      persistence: () => drizzleInfra.eventSourcedPersistence,
+      persistence: "event-sourced",
       concurrency: { maxRetries: 3 },
     },
-    Inventory: {
-      persistence: () => drizzleInfra.stateStoredPersistence,
-      concurrency: { maxRetries: 3 },
-    },
-  },
-
-  sagas: {
-    persistence: () => drizzleInfra.sagaPersistence,
+    Inventory: {},
   },
 
   buses: () => ({
@@ -677,13 +672,12 @@ const domain = await wireDomain(hotelDomain, {
     queryBus: new InMemoryQueryBus(),
   }),
 
-  unitOfWork: () => drizzleInfra.unitOfWorkFactory,
   idempotency: () => new InMemoryIdempotencyStore(),
   metadataProvider: () => requestMetadataStorage.getStore() ?? {},
 });
 ```
 
-Per-aggregate wiring allows each aggregate to have its own persistence strategy, concurrency settings, and snapshot configuration. Snapshots are only configured for `Room` since it is the longest-lived event-sourced aggregate.
+The `persistenceAdapter` provides all persistence stores. Per-aggregate wiring uses string shorthands (`"event-sourced"`) instead of factory functions. `Inventory` defaults to state-stored from the adapter. Saga persistence, unit-of-work, and snapshot store are all inferred from the adapter automatically. Snapshots are only configured for `Room` since it is the longest-lived event-sourced aggregate.
 
 ## Unit of Work
 

--- a/docs/content/docs/running/domain-configuration.mdx
+++ b/docs/content/docs/running/domain-configuration.mdx
@@ -117,20 +117,57 @@ These warnings only appear when the framework itself supplies the default -- not
 
 ### DomainWiring Fields
 
-| Field              | Description                                                                                  |
-| ------------------ | -------------------------------------------------------------------------------------------- |
-| `infrastructure`   | Factory for user-provided services. What handlers receive as the `infrastructure` parameter. |
-| `aggregates`       | Aggregate runtime config -- global `AggregateWiring` or per-aggregate record. See below.     |
-| `projections`      | Per-projection view store wiring. See [Projection Wiring](#projection-wiring).               |
-| `sagas`            | Saga runtime config. Defaults to in-memory if `processModel` has sagas.                      |
-| `buses`            | Factory for CQRS buses. Receives resolved user infrastructure.                               |
-| `unitOfWork`       | Factory for the UnitOfWorkFactory.                                                           |
-| `idempotency`      | Factory for idempotency store (command dedup by commandId).                                  |
-| `outbox`           | Transactional outbox configuration.                                                          |
-| `metadataProvider` | Function called on every command dispatch for event metadata context.                        |
-| `logger`           | Framework logger instance. Defaults to `NodddeLogger` at `'warn'` level.                     |
+| Field                | Description                                                                                                                                   |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `persistenceAdapter` | A `PersistenceAdapter` instance (e.g., `DrizzleAdapter`, `PrismaAdapter`, `TypeORMAdapter`). See [Persistence Adapter](#persistence-adapter). |
+| `infrastructure`     | Factory for user-provided services. What handlers receive as the `infrastructure` parameter.                                                  |
+| `aggregates`         | Aggregate runtime config -- global `AggregateWiring` or per-aggregate record. See below.                                                      |
+| `projections`        | Per-projection view store wiring. See [Projection Wiring](#projection-wiring).                                                                |
+| `sagas`              | Saga runtime config. Defaults to adapter or in-memory if `processModel` has sagas.                                                            |
+| `buses`              | Factory for CQRS buses. Receives resolved user infrastructure.                                                                                |
+| `unitOfWork`         | Factory for the UnitOfWorkFactory.                                                                                                            |
+| `idempotency`        | Factory for idempotency store (command dedup by commandId).                                                                                   |
+| `outbox`             | Transactional outbox configuration.                                                                                                           |
+| `metadataProvider`   | Function called on every command dispatch for event metadata context.                                                                         |
+| `logger`             | Framework logger instance. Defaults to `NodddeLogger` at `'warn'` level.                                                                      |
 
 All fields are optional. Both `wireDomain(definition)` and `wireDomain(definition, {})` use in-memory defaults for everything.
+
+### Persistence Adapter
+
+The `persistenceAdapter` field accepts a `PersistenceAdapter` instance. When provided, the engine resolves aggregate persistence, saga persistence, unit-of-work, snapshots, outbox, idempotency, and locking from the adapter when not explicitly wired. Explicit wiring always takes precedence over adapter defaults.
+
+```ts
+import { DrizzleAdapter } from "@noddde/drizzle";
+
+const adapter = new DrizzleAdapter(db);
+
+const domain = await wireDomain(bankingDomain, {
+  persistenceAdapter: adapter,
+  infrastructure: () => ({
+    /* ... */
+  }),
+  aggregates: {
+    BankAccount: {
+      persistence: "event-sourced",
+      snapshots: { strategy: everyNEvents(100) },
+    },
+    Ledger: {}, // defaults to state-stored from adapter
+  },
+});
+```
+
+When an adapter is present:
+
+- Aggregates that omit `persistence` default to the adapter's `stateStoredPersistence` (state-stored is the default -- event sourcing is opt-in)
+- `persistence` accepts string shorthands: `"event-sourced"` or `"state-stored"`, resolved from the adapter
+- `persistence` also accepts `adapter.stateStored(table)` for dedicated per-aggregate state tables
+- `snapshots.store` is inferred from the adapter when omitted (but `strategy` is still required)
+- `sagas.persistence`, `unitOfWork`, `idempotency`, and `outbox` are all inferred from the adapter when omitted
+- `adapter.init?.()` is called at the start of domain initialization
+- `adapter.close?.()` is called during domain shutdown (auto-discovered via `isCloseable()`)
+
+See [ORM Adapters](/docs/running/orm-adapters) for adapter-specific setup.
 
 ### Logging
 
@@ -145,33 +182,49 @@ The `aggregates` field accepts either a global config (applies to all aggregates
 ```ts
 // Global: all aggregates share the same config
 aggregates: {
-  persistence: () => drizzle.eventSourcedPersistence,
+  persistence: () => adapter.eventSourcedPersistence,
   concurrency: { maxRetries: 3 },
 },
 
 // Per-aggregate: each aggregate configured independently
 aggregates: {
   Order: {
-    persistence: () => drizzle.eventSourcedPersistence,
+    persistence: "event-sourced",
     concurrency: { maxRetries: 5 },
-    snapshots: {
-      store: () => drizzle.snapshotStore,
-      strategy: everyNEvents(50),
-    },
+    snapshots: { strategy: everyNEvents(50) },
   },
-  Inventory: {
-    persistence: () => drizzle.stateStoredPersistence,
-  },
+  Inventory: {}, // defaults to state-stored from adapter
 },
 ```
 
-> **Strict validation**: When using per-aggregate wiring (a record of aggregate names), `wireDomain` requires **every** aggregate in the domain definition to have an explicit `persistence` factory. If any aggregate is missing from the record, `wireDomain` throws at startup with an error listing the unconfigured aggregates. This prevents silent in-memory fallbacks and ensures 1 aggregate = 1 explicit persistence. Global mode (a single `AggregateWiring` object) is unaffected -- all aggregates share the same config.
-
 Each `AggregateWiring` groups three concerns:
 
-- **`persistence`** -- Factory returning `EventSourcedAggregatePersistence` or `StateStoredAggregatePersistence`
+- **`persistence`** -- The persistence strategy for this aggregate
 - **`concurrency`** -- Optimistic (with retries) or pessimistic (with locker)
-- **`snapshots`** -- Snapshot store + strategy for event-sourced aggregates
+- **`snapshots`** -- Snapshot strategy for event-sourced aggregates (store inferred from adapter)
+
+#### Persistence
+
+The `persistence` field accepts multiple forms:
+
+| Form             | Example                               | Description                                                                      |
+| ---------------- | ------------------------------------- | -------------------------------------------------------------------------------- |
+| Omitted          | `{}`                                  | Defaults to `adapter.stateStoredPersistence` (when adapter present) or in-memory |
+| String shorthand | `"event-sourced"` or `"state-stored"` | Resolved from the adapter. Requires `persistenceAdapter`                         |
+| Direct config    | `adapter.stateStored(table)`          | A `PersistenceConfiguration` object used directly                                |
+| Factory function | `() => myPersistence`                 | Existing pattern -- called to get the config                                     |
+
+#### Concurrency
+
+The `concurrency` field accepts string shorthands or object form:
+
+| Form                 | Example                                     | Description                                                   |
+| -------------------- | ------------------------------------------- | ------------------------------------------------------------- |
+| Omitted              |                                             | Optimistic with 0 retries (default)                           |
+| `"optimistic"`       | `concurrency: "optimistic"`                 | Same as omitting                                              |
+| `"pessimistic"`      | `concurrency: "pessimistic"`                | Auto-resolves locker from `adapter.aggregateLocker`           |
+| Object (optimistic)  | `{ maxRetries: 5 }`                         | Optimistic with custom retries                                |
+| Object (pessimistic) | `{ strategy: "pessimistic", locker?: ... }` | Pessimistic; `locker` auto-resolved from adapter when omitted |
 
 ### Projection Wiring
 

--- a/docs/content/docs/running/orm-adapters.mdx
+++ b/docs/content/docs/running/orm-adapters.mdx
@@ -27,34 +27,32 @@ Persistence (event store, state store, saga store, snapshot store, [outbox store
 
 For SQLite or any dialect without advisory lock support, use `InMemoryAggregateLocker` from `@noddde/engine` for single-process deployments, or choose the optimistic strategy instead.
 
-Each package exports a `createXxxAdapter` factory function that returns all persistence implementations wired to share a transaction context. The return type **narrows based on the config** -- only configured optional stores appear in the result, eliminating the need for `!` non-null assertions:
+Each package exports a class-based adapter that implements the `PersistenceAdapter` interface from `@noddde/core`. Pass it to `wireDomain` via the `persistenceAdapter` property and the engine resolves all persistence concerns automatically:
 
 ```ts
-import { createDrizzleAdapter } from "@noddde/drizzle";
-import { events, sagaStates, snapshots } from "@noddde/drizzle/pg";
+import { DrizzleAdapter } from "@noddde/drizzle";
+import { wireDomain } from "@noddde/engine";
 
-const adapter = createDrizzleAdapter(db, {
-  eventStore: events,
-  sagaStore: sagaStates,
-  snapshotStore: snapshots, // optional -- only include if needed
+const adapter = new DrizzleAdapter(db);
+
+const domain = await wireDomain(definition, {
+  persistenceAdapter: adapter,
+  aggregates: {
+    Room: { persistence: "event-sourced" },
+    Inventory: {}, // defaults to state-stored from adapter
+  },
 });
-
-// Always present:
-adapter.eventSourcedPersistence; // EventSourcedAggregatePersistence
-adapter.sagaPersistence; // SagaPersistence
-adapter.unitOfWorkFactory; // UnitOfWorkFactory
-
-// Present because snapshotStore was configured (non-optional, no `?` needed):
-adapter.snapshotStore; // SnapshotStore
-
-// Prisma and TypeORM are similar:
-// createPrismaAdapter(prisma)
-// createPrismaAdapter(prisma, { snapshotStore: true })
-// createTypeORMAdapter(dataSource)
-// createTypeORMAdapter(dataSource, { snapshotStore: true })
 ```
 
-All three adapters support [per-aggregate state tables](#per-aggregate-state-tables) via the `aggregateStates` config option.
+The adapter provides all stores (event-sourced, state-stored, saga, snapshot, outbox, UoW, advisory locker). The engine infers what it needs based on the domain definition -- no manual mapping required.
+
+All three adapters also support [per-aggregate state tables](#per-aggregate-state-tables) via the `stateStored()` helper method.
+
+<Callout type="info">
+  The `createXxxAdapter` factory functions are still supported but deprecated.
+  Prefer the class-based API (`DrizzleAdapter`, `PrismaAdapter`,
+  `TypeORMAdapter`) for new code.
+</Callout>
 
 ## Drizzle
 
@@ -103,23 +101,12 @@ You can also define your own tables matching the expected column structure -- th
 ```ts
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
-import { createDrizzleAdapter } from "@noddde/drizzle";
-import {
-  events,
-  aggregateStates,
-  sagaStates,
-  snapshots,
-} from "@noddde/drizzle/sqlite";
+import { DrizzleAdapter } from "@noddde/drizzle";
 import { everyNEvents } from "@noddde/core";
 import { defineDomain, wireDomain } from "@noddde/engine";
 
 const db = drizzle(new Database("app.db"));
-const adapter = createDrizzleAdapter(db, {
-  eventStore: events,
-  stateStore: aggregateStates,
-  sagaStore: sagaStates,
-  snapshotStore: snapshots,
-});
+const adapter = new DrizzleAdapter(db);
 
 const bankingDomain = defineDomain({
   writeModel: { aggregates: { BankAccount } },
@@ -127,19 +114,17 @@ const bankingDomain = defineDomain({
 });
 
 const domain = await wireDomain(bankingDomain, {
+  persistenceAdapter: adapter,
   aggregates: {
-    persistence: () => adapter.eventSourcedPersistence,
-    snapshots: {
-      store: () => adapter.snapshotStore,
-      strategy: everyNEvents(100),
+    BankAccount: {
+      persistence: "event-sourced",
+      snapshots: { strategy: everyNEvents(100) },
     },
   },
-  sagas: {
-    persistence: () => adapter.sagaPersistence,
-  },
-  unitOfWork: () => adapter.unitOfWorkFactory,
 });
 ```
+
+The adapter auto-infers the dialect from the Drizzle `db` instance and selects the correct pre-built schemas (PostgreSQL, MySQL, or SQLite). No schema imports or table config needed.
 
 ### How Drizzle Transactions Work
 
@@ -149,67 +134,51 @@ The persistence classes and `UnitOfWork` share a transaction store. When a trans
 
 ### Advanced Configuration
 
-The `createDrizzleAdapter` config supports optional stores and per-aggregate state tables. Only include what you need -- the return type narrows accordingly:
+For custom table overrides, pass a config object as the second argument:
 
 ```ts
-import { createDrizzleAdapter } from "@noddde/drizzle";
-import { events, sagaStates, snapshots, outbox } from "@noddde/drizzle/pg";
-import { orders, bankAccounts } from "./schema"; // your own Drizzle tables
+import { DrizzleAdapter } from "@noddde/drizzle";
+import { myEvents, mySagas } from "./schema"; // your own Drizzle tables
 
 const db = drizzle(pool);
-
-const adapter = createDrizzleAdapter(db, {
-  eventStore: events, // required
-  sagaStore: sagaStates, // required
-  stateStore: aggregateStates, // optional — shared state table
-  snapshotStore: snapshots, // optional
-  outboxStore: outbox, // optional
-  aggregateStates: {
-    // optional — per-aggregate tables
-    Order: {
-      table: orders,
-      columns: {
-        aggregateId: orders.id,
-        state: orders.data,
-        version: orders.version,
-      },
-    },
-    BankAccount: { table: bankAccounts }, // convention-based
-  },
+const adapter = new DrizzleAdapter(db, {
+  tables: { eventStore: myEvents, sagaStore: mySagas },
 });
 ```
 
-The result type reflects exactly what was configured:
+Custom tables override the auto-resolved ones for that specific store. Tables you don't override use the built-in schemas for the detected dialect.
+
+All stores are always present on the adapter:
 
 ```ts
-adapter.eventSourcedPersistence; // always present
-adapter.stateStoredPersistence; // present because stateStore was provided
-adapter.sagaPersistence; // always present
-adapter.unitOfWorkFactory; // always present
-adapter.snapshotStore; // present because snapshotStore was provided
-adapter.outboxStore; // present because outboxStore was provided
-adapter.stateStoreFor("Order"); // present because aggregateStates was provided
-adapter.stateStoreFor("BankAccount"); // compiles — configured name
-adapter.stateStoreFor("Unknown"); // compile error — not in aggregateStates
+adapter.eventSourcedPersistence; // EventSourcedAggregatePersistence
+adapter.stateStoredPersistence; // StateStoredAggregatePersistence (shared table)
+adapter.sagaPersistence; // SagaPersistence
+adapter.unitOfWorkFactory; // UnitOfWorkFactory
+adapter.snapshotStore; // SnapshotStore
+adapter.outboxStore; // OutboxStore
+adapter.aggregateLocker; // AggregateLocker (pg/mysql only)
 ```
 
 All persistence instances share the same transaction store, ensuring UoW atomicity across shared and dedicated tables.
 
-> **Deprecated**: The `createDrizzlePersistence(db, schema)` factory still works and delegates to `createDrizzleAdapter` internally. Prefer `createDrizzleAdapter` for new code.
+> **Deprecated**: The `createDrizzleAdapter` and `createDrizzlePersistence` factory functions still work but delegate to `DrizzleAdapter` internally. Prefer `new DrizzleAdapter(db)` for new code.
 
 ### Per-Aggregate State Tables
 
 By default, all state-stored aggregates share a single `noddde_aggregate_states` table, discriminated by an `aggregate_name` column. For production workloads, you may want each aggregate to have its own dedicated table with a domain-specific schema.
 
-Use the `aggregateStates` config to map aggregates to their own tables:
+Use the `stateStored()` helper method to bind an aggregate to a dedicated Drizzle table:
 
 ```ts
-const adapter = createDrizzleAdapter(db, {
-  eventStore: events,
-  sagaStore: sagaStates,
-  aggregateStates: {
-    Order: { table: orders },
-    BankAccount: { table: bankAccounts },
+const adapter = new DrizzleAdapter(db);
+
+const domain = await wireDomain(definition, {
+  persistenceAdapter: adapter,
+  aggregates: {
+    Payment: { persistence: "event-sourced" },
+    Order: { persistence: adapter.stateStored(orders) },
+    BankAccount: { persistence: adapter.stateStored(bankAccounts) },
   },
 });
 ```
@@ -218,42 +187,19 @@ const adapter = createDrizzleAdapter(db, {
 
 1. **Convention-based** (default): The adapter scans the Drizzle table definition for columns named `aggregate_id`, `state`, and `version`. If your table follows this naming, no explicit mapping is needed.
 
-2. **Explicit mapping**: For tables with custom column names, provide a `columns` object mapping logical names to Drizzle column references:
+2. **Explicit mapping**: For tables with custom column names, provide a `columns` object:
 
 ```ts
-const adapter = createDrizzleAdapter(db, {
-  eventStore: events,
-  sagaStore: sagaStates,
-  aggregateStates: {
-    Order: {
-      table: orders,
-      columns: {
-        aggregateId: orders.orderId,
-        state: orders.orderData,
-        version: orders.rev,
-      },
-    },
-  },
+adapter.stateStored(orders, {
+  aggregateId: orders.orderId,
+  state: orders.orderData,
+  version: orders.rev,
 });
 ```
 
-If convention-based resolution fails (columns not found), `createDrizzleAdapter` throws with a clear error listing the available columns in the table.
+If convention-based resolution fails (columns not found), the adapter throws with a clear error listing the available columns in the table.
 
-**Wiring with `wireDomain`**: Use per-aggregate mode to assign each aggregate its own persistence:
-
-```ts
-const domain = await wireDomain(definition, {
-  aggregates: {
-    Payment: { persistence: () => adapter.eventSourcedPersistence },
-    Order: { persistence: () => adapter.stateStoreFor("Order") },
-    BankAccount: { persistence: () => adapter.stateStoreFor("BankAccount") },
-  },
-  sagas: { persistence: () => adapter.sagaPersistence },
-  unitOfWork: () => adapter.unitOfWorkFactory,
-});
-```
-
-> **Important**: When using per-aggregate wiring, `wireDomain` requires **every** aggregate in the domain definition to have an explicit `persistence` factory. There are no silent in-memory defaults -- if an aggregate is missing, `wireDomain` throws at startup listing the unconfigured aggregates. This ensures 1 aggregate = 1 explicit persistence configuration.
+The `stateStored()` method returns a `StateStoredAggregatePersistence` that can be passed directly to the `persistence` field in per-aggregate wiring. It shares the same transaction store as all other stores on the adapter, ensuring UoW atomicity across shared and dedicated tables.
 
 ### Migration Generation
 
@@ -355,14 +301,12 @@ Then run `prisma generate` and your preferred migration command.
 
 ```ts
 import { PrismaClient } from "@prisma/client";
-import { createPrismaAdapter } from "@noddde/prisma";
+import { PrismaAdapter } from "@noddde/prisma";
 import { everyNEvents } from "@noddde/core";
 import { defineDomain, wireDomain } from "@noddde/engine";
 
 const prisma = new PrismaClient();
-const adapter = createPrismaAdapter(prisma, {
-  snapshotStore: true,
-});
+const adapter = new PrismaAdapter(prisma);
 
 const bankingDomain = defineDomain({
   writeModel: { aggregates: { BankAccount } },
@@ -370,21 +314,17 @@ const bankingDomain = defineDomain({
 });
 
 const domain = await wireDomain(bankingDomain, {
+  persistenceAdapter: adapter,
   aggregates: {
-    persistence: () => adapter.eventSourcedPersistence,
-    snapshots: {
-      store: () => adapter.snapshotStore,
-      strategy: everyNEvents(100),
+    BankAccount: {
+      persistence: "event-sourced",
+      snapshots: { strategy: everyNEvents(100) },
     },
   },
-  sagas: {
-    persistence: () => adapter.sagaPersistence,
-  },
-  unitOfWork: () => adapter.unitOfWorkFactory,
 });
 ```
 
-Unlike Drizzle, the Prisma adapter always creates the event store, state store, and saga store (using built-in Prisma models). The config only controls optional stores (`snapshotStore`, `outboxStore`) and per-aggregate tables. Call `createPrismaAdapter(prisma)` with no config for the minimal setup.
+The Prisma adapter uses built-in Prisma models (NodddeEvent, NodddeAggregateState, etc.) for all stores. No configuration needed beyond the PrismaClient instance.
 
 ### How Prisma Transactions Work
 
@@ -392,44 +332,46 @@ The Prisma adapter uses interactive transactions via `prisma.$transaction(async 
 
 ### Advanced Configuration
 
-For per-aggregate state tables or selective store setup, pass a config with `aggregateStates`:
+For per-aggregate state tables, use the `stateStored()` helper method:
 
 ```ts
-import { createPrismaAdapter } from "@noddde/prisma";
+const adapter = new PrismaAdapter(prisma);
 
-const prisma = new PrismaClient();
-
-const adapter = createPrismaAdapter(prisma, {
-  snapshotStore: true,
-  outboxStore: true,
-  aggregateStates: {
+const domain = await wireDomain(definition, {
+  persistenceAdapter: adapter,
+  aggregates: {
     Order: {
-      model: "order", // Prisma model delegate name (prisma.order)
-      columns: {
+      persistence: adapter.stateStored("order", {
         aggregateId: "orderId",
         state: "orderData",
         version: "rev",
-      },
+      }),
     },
   },
 });
 ```
 
-The result type narrows based on config:
+Since Prisma uses generated model delegates (e.g., `prisma.order`), the first argument to `stateStored()` must match the camelCase delegate name on your PrismaClient. The adapter validates that the model exists at creation time.
+
+For pessimistic concurrency, pass the `dialect` option since PrismaClient does not expose the database provider at runtime:
 
 ```ts
-adapter.eventSourcedPersistence; // always present
-adapter.stateStoredPersistence; // always present (Prisma built-in model)
-adapter.sagaPersistence; // always present
-adapter.unitOfWorkFactory; // always present
-adapter.snapshotStore; // present because snapshotStore: true
-adapter.outboxStore; // present because outboxStore: true
-adapter.stateStoreFor("Order"); // present because aggregateStates was provided
+const adapter = new PrismaAdapter(prisma, { dialect: "postgresql" });
 ```
 
-Since Prisma uses generated model delegates (e.g., `prisma.order`), the `model` field in the config must match the camelCase delegate name on your PrismaClient. The adapter validates that the model exists at creation time.
+All stores are always present on the adapter:
 
-> **Deprecated**: The `createPrismaPersistence(prisma)` factory still works and delegates to `createPrismaAdapter` internally. Prefer `createPrismaAdapter` for new code.
+```ts
+adapter.eventSourcedPersistence; // EventSourcedAggregatePersistence
+adapter.stateStoredPersistence; // StateStoredAggregatePersistence
+adapter.sagaPersistence; // SagaPersistence
+adapter.unitOfWorkFactory; // UnitOfWorkFactory
+adapter.snapshotStore; // SnapshotStore
+adapter.outboxStore; // OutboxStore
+adapter.aggregateLocker; // AggregateLocker (requires dialect option)
+```
+
+> **Deprecated**: The `createPrismaAdapter` and `createPrismaPersistence` factory functions still work but delegate to `PrismaAdapter` internally. Prefer `new PrismaAdapter(prisma)` for new code.
 
 ### Prisma Migration Generation
 
@@ -494,13 +436,11 @@ For production, use TypeORM migrations instead of `synchronize: true`.
 ### Configuration
 
 ```ts
-import { createTypeORMAdapter } from "@noddde/typeorm";
+import { TypeORMAdapter } from "@noddde/typeorm";
 import { everyNEvents } from "@noddde/core";
 import { defineDomain, wireDomain } from "@noddde/engine";
 
-const adapter = createTypeORMAdapter(dataSource, {
-  snapshotStore: true,
-});
+const adapter = new TypeORMAdapter(dataSource);
 
 const bankingDomain = defineDomain({
   writeModel: { aggregates: { BankAccount } },
@@ -508,21 +448,17 @@ const bankingDomain = defineDomain({
 });
 
 const domain = await wireDomain(bankingDomain, {
+  persistenceAdapter: adapter,
   aggregates: {
-    persistence: () => adapter.eventSourcedPersistence,
-    snapshots: {
-      store: () => adapter.snapshotStore,
-      strategy: everyNEvents(100),
+    BankAccount: {
+      persistence: "event-sourced",
+      snapshots: { strategy: everyNEvents(100) },
     },
   },
-  sagas: {
-    persistence: () => adapter.sagaPersistence,
-  },
-  unitOfWork: () => adapter.unitOfWorkFactory,
 });
 ```
 
-Like Prisma, the TypeORM adapter always creates the event store, state store, and saga store (using built-in entity classes). The config only controls optional stores (`snapshotStore`, `outboxStore`) and per-aggregate tables. Call `createTypeORMAdapter(dataSource)` with no config for the minimal setup.
+The TypeORM adapter uses built-in entity classes for all stores. The database type is auto-detected from `dataSource.options.type` for advisory locking support.
 
 ### How TypeORM Transactions Work
 
@@ -530,41 +466,41 @@ The TypeORM adapter uses `dataSource.manager.transaction()` to wrap operations. 
 
 ### Advanced Configuration
 
-For per-aggregate state tables or selective store setup, pass a config with `aggregateStates`:
+For per-aggregate state tables, use the `stateStored()` helper method with a TypeORM entity class:
 
 ```ts
-import { createTypeORMAdapter } from "@noddde/typeorm";
+import { TypeORMAdapter } from "@noddde/typeorm";
 import { OrderEntity } from "./entities"; // your own TypeORM entity
 
-const adapter = createTypeORMAdapter(dataSource, {
-  snapshotStore: true,
-  outboxStore: true,
-  aggregateStates: {
+const adapter = new TypeORMAdapter(dataSource);
+
+const domain = await wireDomain(definition, {
+  persistenceAdapter: adapter,
+  aggregates: {
     Order: {
-      entity: OrderEntity,
-      columns: {
-        aggregateId: "aggregateId", // entity property names
-        state: "state",
-        version: "version",
-      },
+      persistence: adapter.stateStored(OrderEntity, {
+        aggregateId: "orderId",
+        state: "orderData",
+        version: "rev",
+      }),
     },
   },
 });
 ```
 
-The result type narrows based on config:
+All stores are always present on the adapter:
 
 ```ts
-adapter.eventSourcedPersistence; // always present
-adapter.stateStoredPersistence; // always present (TypeORM built-in entity)
-adapter.sagaPersistence; // always present
-adapter.unitOfWorkFactory; // always present
-adapter.snapshotStore; // present because snapshotStore: true
-adapter.outboxStore; // present because outboxStore: true
-adapter.stateStoreFor("Order"); // present because aggregateStates was provided
+adapter.eventSourcedPersistence; // EventSourcedAggregatePersistence
+adapter.stateStoredPersistence; // StateStoredAggregatePersistence
+adapter.sagaPersistence; // SagaPersistence
+adapter.unitOfWorkFactory; // UnitOfWorkFactory
+adapter.snapshotStore; // SnapshotStore
+adapter.outboxStore; // OutboxStore
+adapter.aggregateLocker; // AggregateLocker (pg/mysql/mariadb/mssql)
 ```
 
-> **Deprecated**: The `createTypeORMPersistence(dataSource)` factory still works and delegates to `createTypeORMAdapter` internally. Prefer `createTypeORMAdapter` for new code.
+> **Deprecated**: The `createTypeORMAdapter` and `createTypeORMPersistence` factory functions still work but delegate to `TypeORMAdapter` internally. Prefer `new TypeORMAdapter(dataSource)` for new code.
 
 ### TypeORM Migration Generation
 

--- a/packages/adapters/drizzle/src/drizzle-adapter.ts
+++ b/packages/adapters/drizzle/src/drizzle-adapter.ts
@@ -1,0 +1,188 @@
+/* eslint-disable no-unused-vars */
+import type {
+  PersistenceAdapter,
+  EventSourcedAggregatePersistence,
+  StateStoredAggregatePersistence,
+  SagaPersistence,
+  UnitOfWorkFactory,
+  SnapshotStore,
+  OutboxStore,
+  AggregateLocker,
+} from "@noddde/core";
+import type { DrizzleTransactionStore } from "./index";
+import type { StateTableColumnMap } from "./builder";
+import {
+  DrizzleEventSourcedAggregatePersistence,
+  DrizzleStateStoredAggregatePersistence,
+  DrizzleSagaPersistence,
+  DrizzleSnapshotStore,
+  DrizzleOutboxStore,
+} from "./persistence";
+import { DrizzleDedicatedStateStoredPersistence } from "./dedicated-state-persistence";
+import { createDrizzleUnitOfWorkFactory } from "./unit-of-work";
+import { resolveColumns } from "./column-resolver";
+import { DrizzleAdvisoryLocker } from "./advisory-locker";
+import type { DrizzleDialect } from "./advisory-locker";
+
+// Static imports of pre-built schemas for all dialects
+import * as pgSchema from "./pg/schema";
+import * as sqliteSchema from "./sqlite/schema";
+import * as mysqlSchema from "./mysql/schema";
+
+/**
+ * Optional configuration for {@link DrizzleAdapter}.
+ * When omitted, tables are auto-resolved from the dialect.
+ */
+export interface DrizzleAdapterOptions {
+  /** Override auto-resolved table definitions. Partial — only override what you need. */
+  tables?: {
+    eventStore?: any;
+    stateStore?: any;
+    sagaStore?: any;
+    snapshotStore?: any;
+    outboxStore?: any;
+  };
+}
+
+/**
+ * Infers the Drizzle dialect from a database instance.
+ * Uses the internal `_.dialect` property that Drizzle sets.
+ * @internal
+ */
+function inferDialect(db: any): DrizzleDialect {
+  const dialectName = db?._.dialect?.constructor?.name ?? db?.dialect?.name;
+  if (!dialectName) {
+    throw new Error(
+      "Could not infer dialect from Drizzle db instance. " +
+        "Ensure you are passing a valid Drizzle database instance.",
+    );
+  }
+
+  const normalized = dialectName.toLowerCase();
+  if (normalized.includes("pg") || normalized.includes("postgres")) {
+    return "pg";
+  }
+  if (normalized.includes("mysql")) {
+    return "mysql";
+  }
+  if (normalized.includes("sqlite")) {
+    return "sqlite";
+  }
+
+  throw new Error(
+    `Unrecognized Drizzle dialect: "${dialectName}". ` +
+      "Supported dialects: pg, mysql, sqlite.",
+  );
+}
+
+/**
+ * Returns pre-built schema tables for the given dialect.
+ * @internal
+ */
+function getSchemaForDialect(dialect: DrizzleDialect) {
+  switch (dialect) {
+    case "pg":
+      return pgSchema;
+    case "mysql":
+      return mysqlSchema;
+    case "sqlite":
+      return sqliteSchema;
+  }
+}
+
+/**
+ * Drizzle-backed persistence adapter implementing {@link PersistenceAdapter}.
+ *
+ * Infers the database dialect from the Drizzle `db` instance (via internal
+ * dialect property) and auto-resolves pre-built table schemas for that dialect.
+ * All persistence stores are created eagerly in the constructor.
+ *
+ * @example
+ * ```ts
+ * import { DrizzleAdapter } from "@noddde/drizzle";
+ * import { wireDomain } from "@noddde/engine";
+ *
+ * const adapter = new DrizzleAdapter(db);
+ * const domain = await wireDomain(definition, { persistenceAdapter: adapter });
+ * ```
+ */
+export class DrizzleAdapter implements PersistenceAdapter {
+  readonly unitOfWorkFactory: UnitOfWorkFactory;
+  readonly eventSourcedPersistence: EventSourcedAggregatePersistence;
+  readonly stateStoredPersistence: StateStoredAggregatePersistence;
+  readonly sagaPersistence: SagaPersistence;
+  readonly snapshotStore: SnapshotStore;
+  readonly outboxStore: OutboxStore;
+  readonly aggregateLocker?: AggregateLocker;
+
+  private readonly txStore: DrizzleTransactionStore;
+  private readonly db: any;
+  private readonly dialect: DrizzleDialect;
+
+  constructor(db: any, options?: DrizzleAdapterOptions) {
+    this.db = db;
+    this.dialect = inferDialect(db);
+    this.txStore = { current: null };
+
+    const defaultSchema = getSchemaForDialect(this.dialect);
+    const tables = options?.tables ?? {};
+
+    const schema: any = {
+      events: tables.eventStore ?? defaultSchema.events,
+      aggregateStates: tables.stateStore ?? defaultSchema.aggregateStates,
+      sagaStates: tables.sagaStore ?? defaultSchema.sagaStates,
+      snapshots: tables.snapshotStore ?? defaultSchema.snapshots,
+      outbox: tables.outboxStore ?? defaultSchema.outbox,
+    };
+
+    this.eventSourcedPersistence = new DrizzleEventSourcedAggregatePersistence(
+      db,
+      this.txStore,
+      schema,
+    );
+    this.stateStoredPersistence = new DrizzleStateStoredAggregatePersistence(
+      db,
+      this.txStore,
+      schema,
+    );
+    this.sagaPersistence = new DrizzleSagaPersistence(db, this.txStore, schema);
+    this.snapshotStore = new DrizzleSnapshotStore(db, this.txStore, schema);
+    this.outboxStore = new DrizzleOutboxStore(db, this.txStore, schema);
+    this.unitOfWorkFactory = createDrizzleUnitOfWorkFactory(db, this.txStore);
+
+    // Advisory locker only for PG and MySQL
+    if (this.dialect === "pg" || this.dialect === "mysql") {
+      this.aggregateLocker = new DrizzleAdvisoryLocker(db, this.dialect);
+    }
+  }
+
+  /**
+   * Returns a {@link StateStoredAggregatePersistence} bound to a dedicated
+   * Drizzle table. Use this when an aggregate needs its own state table
+   * instead of the shared one.
+   *
+   * @param table - A Drizzle table definition.
+   * @param columns - Optional column mapping overrides.
+   * @returns A persistence implementation bound to the given table.
+   */
+  stateStored(
+    table: any,
+    columns?: Partial<StateTableColumnMap>,
+  ): StateStoredAggregatePersistence {
+    const resolvedColumns = resolveColumns(table, "(dedicated)", columns);
+    return new DrizzleDedicatedStateStoredPersistence(
+      this.db,
+      this.txStore,
+      table,
+      resolvedColumns,
+    );
+  }
+
+  /**
+   * No-op — Drizzle does not own the database connection.
+   * The caller is responsible for closing the underlying pool.
+   */
+  async close(): Promise<void> {
+    // No-op: Drizzle doesn't own the connection
+  }
+}

--- a/packages/adapters/drizzle/src/index.ts
+++ b/packages/adapters/drizzle/src/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-unused-vars */
+export { DrizzleAdapter, type DrizzleAdapterOptions } from "./drizzle-adapter";
 export { DrizzleAdvisoryLocker } from "./advisory-locker";
 import type { UnitOfWorkFactory } from "@noddde/core";
 import type {

--- a/packages/adapters/prisma/src/index.ts
+++ b/packages/adapters/prisma/src/index.ts
@@ -1,3 +1,4 @@
+export { PrismaAdapter } from "./prisma-adapter";
 export {
   PrismaEventSourcedAggregatePersistence,
   PrismaStateStoredAggregatePersistence,

--- a/packages/adapters/prisma/src/prisma-adapter.ts
+++ b/packages/adapters/prisma/src/prisma-adapter.ts
@@ -1,0 +1,130 @@
+/* eslint-disable no-unused-vars */
+import type { PrismaClient } from "@prisma/client";
+import type {
+  PersistenceAdapter,
+  EventSourcedAggregatePersistence,
+  StateStoredAggregatePersistence,
+  SagaPersistence,
+  UnitOfWorkFactory,
+  SnapshotStore,
+  OutboxStore,
+  AggregateLocker,
+} from "@noddde/core";
+import type { PrismaTransactionStore } from "./unit-of-work";
+import type { PrismaStateTableColumnMap } from "./builder";
+import {
+  PrismaEventSourcedAggregatePersistence,
+  PrismaStateStoredAggregatePersistence,
+  PrismaSagaPersistence,
+  PrismaSnapshotStore,
+  PrismaOutboxStore,
+} from "./persistence";
+import { PrismaDedicatedStateStoredPersistence } from "./dedicated-state-persistence";
+import { createPrismaUnitOfWorkFactory } from "./unit-of-work";
+import { PrismaAdvisoryLocker } from "./advisory-locker";
+import type { PrismaDialect } from "./advisory-locker";
+
+const DEFAULT_COLUMNS: PrismaStateTableColumnMap = {
+  aggregateId: "aggregateId",
+  state: "state",
+  version: "version",
+};
+
+/**
+ * Prisma-backed persistence adapter implementing {@link PersistenceAdapter}.
+ *
+ * Uses built-in Prisma models (NodddeEvent, NodddeAggregateState, etc.)
+ * for all stores. No configuration needed beyond the PrismaClient instance.
+ *
+ * Advisory locking requires the `dialect` option since PrismaClient does
+ * not expose the database provider at runtime.
+ *
+ * @example
+ * ```ts
+ * import { PrismaAdapter } from "@noddde/prisma";
+ * import { wireDomain } from "@noddde/engine";
+ *
+ * const adapter = new PrismaAdapter(prisma);
+ * const domain = await wireDomain(definition, { persistenceAdapter: adapter });
+ * ```
+ */
+export class PrismaAdapter implements PersistenceAdapter {
+  readonly unitOfWorkFactory: UnitOfWorkFactory;
+  readonly eventSourcedPersistence: EventSourcedAggregatePersistence;
+  readonly stateStoredPersistence: StateStoredAggregatePersistence;
+  readonly sagaPersistence: SagaPersistence;
+  readonly snapshotStore: SnapshotStore;
+  readonly outboxStore: OutboxStore;
+  readonly aggregateLocker?: AggregateLocker;
+
+  private readonly prisma: PrismaClient;
+  private readonly txStore: PrismaTransactionStore;
+
+  constructor(prisma: PrismaClient, options?: { dialect?: PrismaDialect }) {
+    this.prisma = prisma;
+    this.txStore = { current: null };
+
+    this.eventSourcedPersistence = new PrismaEventSourcedAggregatePersistence(
+      prisma,
+      this.txStore,
+    );
+    this.stateStoredPersistence = new PrismaStateStoredAggregatePersistence(
+      prisma,
+      this.txStore,
+    );
+    this.sagaPersistence = new PrismaSagaPersistence(prisma, this.txStore);
+    this.snapshotStore = new PrismaSnapshotStore(prisma, this.txStore);
+    this.outboxStore = new PrismaOutboxStore(prisma, this.txStore);
+    this.unitOfWorkFactory = createPrismaUnitOfWorkFactory(
+      prisma,
+      this.txStore,
+    );
+
+    // Advisory locker requires explicit dialect
+    if (options?.dialect) {
+      this.aggregateLocker = new PrismaAdvisoryLocker(prisma, options.dialect);
+    }
+  }
+
+  /**
+   * Returns a {@link StateStoredAggregatePersistence} bound to a dedicated
+   * Prisma model. Use this when an aggregate needs its own state table
+   * instead of the shared one.
+   *
+   * @param model - The Prisma model name (camelCase, e.g., "order").
+   * @param columns - Optional column mapping overrides.
+   * @returns A persistence implementation bound to the given model.
+   */
+  stateStored(
+    model: string,
+    columns?: Partial<PrismaStateTableColumnMap>,
+  ): StateStoredAggregatePersistence {
+    const resolvedColumns: PrismaStateTableColumnMap = {
+      ...DEFAULT_COLUMNS,
+      ...columns,
+    };
+
+    // Validate the model delegate exists on the Prisma client
+    const delegate = (this.prisma as any)[model];
+    if (!delegate) {
+      throw new Error(
+        `Prisma model "${model}" not found on PrismaClient. ` +
+          `Ensure the model is defined in your Prisma schema and prisma generate has been run.`,
+      );
+    }
+
+    return new PrismaDedicatedStateStoredPersistence(
+      this.prisma,
+      this.txStore,
+      model,
+      resolvedColumns,
+    );
+  }
+
+  /**
+   * Calls `prisma.$disconnect()` to close the connection pool.
+   */
+  async close(): Promise<void> {
+    await this.prisma.$disconnect();
+  }
+}

--- a/packages/adapters/typeorm/src/index.ts
+++ b/packages/adapters/typeorm/src/index.ts
@@ -1,3 +1,4 @@
+export { TypeORMAdapter } from "./typeorm-adapter";
 export {
   NodddeEventEntity,
   NodddeAggregateStateEntity,

--- a/packages/adapters/typeorm/src/typeorm-adapter.ts
+++ b/packages/adapters/typeorm/src/typeorm-adapter.ts
@@ -1,0 +1,121 @@
+/* eslint-disable no-unused-vars */
+import type { DataSource } from "typeorm";
+import type {
+  PersistenceAdapter,
+  EventSourcedAggregatePersistence,
+  StateStoredAggregatePersistence,
+  SagaPersistence,
+  UnitOfWorkFactory,
+  SnapshotStore,
+  OutboxStore,
+  AggregateLocker,
+} from "@noddde/core";
+import type { TypeORMTransactionStore } from "./unit-of-work";
+import type { TypeORMStateTableColumnMap } from "./builder";
+import {
+  TypeORMEventSourcedAggregatePersistence,
+  TypeORMStateStoredAggregatePersistence,
+  TypeORMSagaPersistence,
+  TypeORMSnapshotStore,
+  TypeORMOutboxStore,
+} from "./persistence";
+import { TypeORMDedicatedStateStoredPersistence } from "./dedicated-state-persistence";
+import { createTypeORMUnitOfWorkFactory } from "./unit-of-work";
+import { TypeORMAdvisoryLocker } from "./advisory-locker";
+
+const DEFAULT_COLUMNS: TypeORMStateTableColumnMap = {
+  aggregateId: "aggregateId",
+  state: "state",
+  version: "version",
+};
+
+/** Database types that support advisory locking. */
+const ADVISORY_LOCK_TYPES = new Set(["postgres", "mysql", "mariadb", "mssql"]);
+
+/**
+ * TypeORM-backed persistence adapter implementing {@link PersistenceAdapter}.
+ *
+ * Uses built-in entity classes (NodddeEventEntity, NodddeAggregateStateEntity, etc.)
+ * for all stores. No configuration needed beyond the DataSource instance.
+ * Advisory locker is auto-detected from `dataSource.options.type`.
+ *
+ * @example
+ * ```ts
+ * import { TypeORMAdapter } from "@noddde/typeorm";
+ * import { wireDomain } from "@noddde/engine";
+ *
+ * const adapter = new TypeORMAdapter(dataSource);
+ * const domain = await wireDomain(definition, { persistenceAdapter: adapter });
+ * ```
+ */
+export class TypeORMAdapter implements PersistenceAdapter {
+  readonly unitOfWorkFactory: UnitOfWorkFactory;
+  readonly eventSourcedPersistence: EventSourcedAggregatePersistence;
+  readonly stateStoredPersistence: StateStoredAggregatePersistence;
+  readonly sagaPersistence: SagaPersistence;
+  readonly snapshotStore: SnapshotStore;
+  readonly outboxStore: OutboxStore;
+  readonly aggregateLocker?: AggregateLocker;
+
+  private readonly dataSource: DataSource;
+  private readonly txStore: TypeORMTransactionStore;
+
+  constructor(dataSource: DataSource) {
+    this.dataSource = dataSource;
+    this.txStore = { current: null };
+
+    this.eventSourcedPersistence = new TypeORMEventSourcedAggregatePersistence(
+      dataSource,
+      this.txStore,
+    );
+    this.stateStoredPersistence = new TypeORMStateStoredAggregatePersistence(
+      dataSource,
+      this.txStore,
+    );
+    this.sagaPersistence = new TypeORMSagaPersistence(dataSource, this.txStore);
+    this.snapshotStore = new TypeORMSnapshotStore(dataSource, this.txStore);
+    this.outboxStore = new TypeORMOutboxStore(dataSource, this.txStore);
+    this.unitOfWorkFactory = createTypeORMUnitOfWorkFactory(
+      dataSource,
+      this.txStore,
+    );
+
+    // Advisory locker auto-detected from dataSource.options.type
+    const dbType = dataSource.options.type;
+    if (ADVISORY_LOCK_TYPES.has(dbType)) {
+      this.aggregateLocker = new TypeORMAdvisoryLocker(dataSource);
+    }
+  }
+
+  /**
+   * Returns a {@link StateStoredAggregatePersistence} bound to a dedicated
+   * TypeORM entity. Use this when an aggregate needs its own state table
+   * instead of the shared one.
+   *
+   * @param entity - A TypeORM entity class.
+   * @param columns - Optional column mapping overrides.
+   * @returns A persistence implementation bound to the given entity.
+   */
+  stateStored(
+    entity: Function,
+    columns?: Partial<TypeORMStateTableColumnMap>,
+  ): StateStoredAggregatePersistence {
+    const resolvedColumns: TypeORMStateTableColumnMap = {
+      ...DEFAULT_COLUMNS,
+      ...columns,
+    };
+    return new TypeORMDedicatedStateStoredPersistence(
+      this.dataSource,
+      this.txStore,
+      entity,
+      resolvedColumns,
+    );
+  }
+
+  /**
+   * Calls `dataSource.destroy()` to close the connection pool.
+   */
+  async close(): Promise<void> {
+    await this.dataSource.destroy();
+  }
+}

--- a/packages/cli/src/templates/domain/domain-wiring.ts
+++ b/packages/cli/src/templates/domain/domain-wiring.ts
@@ -44,7 +44,12 @@ export function domainMainTemplate(ctx: TemplateContext): string {
 import { ${ctx.camelName}Domain } from "./domain/domain.js";
 
 const main = async () => {
+  // For production, use a persistence adapter:
+  //   import { DrizzleAdapter } from "@noddde/drizzle";
+  //   const adapter = new DrizzleAdapter(db);
+  //   ... then pass persistenceAdapter: adapter to wireDomain.
   const domain = await wireDomain(${ctx.camelName}Domain, {
+    // persistenceAdapter: adapter,
     infrastructure: () => ({
       // TODO: provide infrastructure implementations
     }),

--- a/packages/core/src/__tests__/persistence/adapter.test.ts
+++ b/packages/core/src/__tests__/persistence/adapter.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { isPersistenceAdapter } from "@noddde/core";
+
+describe("isPersistenceAdapter", () => {
+  it("should return true for a minimal adapter with unitOfWorkFactory", () => {
+    const adapter = {
+      unitOfWorkFactory: () => ({
+        enlist: () => {},
+        commit: async () => {},
+        rollback: async () => {},
+      }),
+    };
+
+    expect(isPersistenceAdapter(adapter)).toBe(true);
+  });
+
+  it("should return true for a full adapter with all optional stores", () => {
+    const adapter = {
+      unitOfWorkFactory: () => ({
+        enlist: () => {},
+        commit: async () => {},
+        rollback: async () => {},
+      }),
+      eventSourcedPersistence: {},
+      stateStoredPersistence: {},
+      sagaPersistence: {},
+      snapshotStore: {},
+      outboxStore: {},
+      idempotencyStore: {},
+      aggregateLocker: {},
+      init: async () => {},
+      close: async () => {},
+    };
+
+    expect(isPersistenceAdapter(adapter)).toBe(true);
+  });
+
+  it("should return false for null", () => {
+    expect(isPersistenceAdapter(null)).toBe(false);
+  });
+
+  it("should return false for undefined", () => {
+    expect(isPersistenceAdapter(undefined)).toBe(false);
+  });
+
+  it("should return false for an empty object", () => {
+    expect(isPersistenceAdapter({})).toBe(false);
+  });
+
+  it("should return false for a string", () => {
+    expect(isPersistenceAdapter("string")).toBe(false);
+  });
+
+  it("should return false for a number", () => {
+    expect(isPersistenceAdapter(42)).toBe(false);
+  });
+
+  it("should return false when unitOfWorkFactory is not a function", () => {
+    expect(isPersistenceAdapter({ unitOfWorkFactory: "not-a-function" })).toBe(
+      false,
+    );
+    expect(isPersistenceAdapter({ unitOfWorkFactory: 42 })).toBe(false);
+    expect(isPersistenceAdapter({ unitOfWorkFactory: null })).toBe(false);
+    expect(isPersistenceAdapter({ unitOfWorkFactory: {} })).toBe(false);
+  });
+});

--- a/packages/core/src/persistence/adapter.ts
+++ b/packages/core/src/persistence/adapter.ts
@@ -1,0 +1,86 @@
+/* eslint-disable no-unused-vars */
+import type {
+  EventSourcedAggregatePersistence,
+  StateStoredAggregatePersistence,
+  SagaPersistence,
+} from "./index";
+import type { UnitOfWorkFactory } from "./unit-of-work";
+import type { SnapshotStore } from "./snapshot";
+import type { OutboxStore } from "./outbox";
+import type { IdempotencyStore } from "./idempotency";
+import type { AggregateLocker } from "./aggregate-locker";
+
+/**
+ * Standard interface for database persistence adapters.
+ *
+ * Adapter classes implement this interface and are passed to `wireDomain`
+ * via the `persistenceAdapter` property. The engine resolves aggregate
+ * persistence, saga persistence, unit-of-work, snapshots, outbox,
+ * idempotency, and locking from the adapter when not explicitly wired.
+ *
+ * Only `unitOfWorkFactory` is required. All other fields are optional
+ * and validated at runtime: the engine errors if the domain needs a
+ * capability the adapter doesn't provide.
+ *
+ * Does NOT extend `Closeable`. Adapters that hold resources implement
+ * an optional `close()` method, auto-discovered by `isCloseable()`.
+ *
+ * @see {@link isPersistenceAdapter} for runtime type guard.
+ */
+export interface PersistenceAdapter {
+  /** Factory for creating unit-of-work instances. Required. */
+  unitOfWorkFactory: UnitOfWorkFactory;
+
+  /** Shared event-sourced persistence. Optional. */
+  eventSourcedPersistence?: EventSourcedAggregatePersistence;
+
+  /** Shared state-stored persistence (default aggregate table). Optional. */
+  stateStoredPersistence?: StateStoredAggregatePersistence;
+
+  /** Saga state persistence. Optional — only needed when sagas are defined. */
+  sagaPersistence?: SagaPersistence;
+
+  /** Snapshot store for event-sourced aggregates. Optional. */
+  snapshotStore?: SnapshotStore;
+
+  /** Outbox store for transactional outbox pattern. Optional. */
+  outboxStore?: OutboxStore;
+
+  /** Idempotency store for command deduplication. Optional. */
+  idempotencyStore?: IdempotencyStore;
+
+  /** Aggregate locker for pessimistic concurrency. Optional. */
+  aggregateLocker?: AggregateLocker;
+
+  /**
+   * Optional initialization hook. Called by `Domain.init()` before
+   * any other resolution. Use for schema creation, migrations, etc.
+   */
+  init?(): Promise<void>;
+
+  /**
+   * Optional cleanup hook. Auto-discovered by `isCloseable()` and
+   * called during `Domain.shutdown()`. Use for connection pool cleanup.
+   * Must be idempotent.
+   */
+  close?(): Promise<void>;
+}
+
+/**
+ * Runtime type guard for detecting {@link PersistenceAdapter} implementations.
+ * Checks for the presence of `unitOfWorkFactory` as a function — the only
+ * required field on the interface.
+ *
+ * @param value - The value to check.
+ * @returns `true` if the value satisfies the `PersistenceAdapter` interface.
+ */
+export function isPersistenceAdapter(
+  value: unknown,
+): value is PersistenceAdapter {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "unitOfWorkFactory" in value &&
+    typeof (value as Record<string, unknown>).unitOfWorkFactory === "function"
+  );
+}

--- a/packages/core/src/persistence/index.ts
+++ b/packages/core/src/persistence/index.ts
@@ -16,6 +16,8 @@ export type {
 export type { IdempotencyRecord, IdempotencyStore } from "./idempotency";
 export type { ViewStore } from "./view-store";
 export type { OutboxEntry, OutboxStore } from "./outbox";
+export type { PersistenceAdapter } from "./adapter";
+export { isPersistenceAdapter } from "./adapter";
 
 /**
  * Persistence strategy that stores the current aggregate state directly.

--- a/packages/engine/src/__tests__/integration/adapter-wiring.test.ts
+++ b/packages/engine/src/__tests__/integration/adapter-wiring.test.ts
@@ -1,0 +1,651 @@
+/* eslint-disable no-unused-vars */
+import { describe, it, expect, vi } from "vitest";
+import type {
+  AggregateTypes,
+  DefineCommands,
+  DefineEvents,
+  Infrastructure,
+  PersistenceAdapter,
+  SagaTypes,
+} from "@noddde/core";
+import { defineAggregate, defineSaga, everyNEvents } from "@noddde/core";
+import {
+  defineDomain,
+  wireDomain,
+  createInMemoryUnitOfWork,
+  InMemoryEventSourcedAggregatePersistence,
+  InMemoryStateStoredAggregatePersistence,
+  InMemorySagaPersistence,
+  InMemorySnapshotStore,
+  InMemoryCommandBus,
+  InMemoryQueryBus,
+  EventEmitterEventBus,
+  InMemoryAggregateLocker,
+} from "@noddde/engine";
+
+// ---- Test aggregate: simple counter ----
+
+type CounterState = { count: number };
+type CounterEvent = DefineEvents<{
+  CounterCreated: { id: string };
+  Incremented: { by: number };
+}>;
+type CounterCommand = DefineCommands<{
+  CreateCounter: void;
+  Increment: { by: number };
+}>;
+type CounterTypes = AggregateTypes & {
+  state: CounterState;
+  events: CounterEvent;
+  commands: CounterCommand;
+  infrastructure: Infrastructure;
+};
+
+const Counter = defineAggregate<CounterTypes>({
+  initialState: { count: 0 },
+  decide: {
+    CreateCounter: (cmd) => ({
+      name: "CounterCreated",
+      payload: { id: cmd.targetAggregateId },
+    }),
+    Increment: (cmd) => ({
+      name: "Incremented",
+      payload: { by: cmd.payload.by },
+    }),
+  },
+  evolve: {
+    CounterCreated: (_p, state) => state,
+    Incremented: (payload, state) => ({ count: state.count + payload.by }),
+  },
+});
+
+// ---- Helpers ----
+
+function makeAdapter(
+  overrides: Partial<PersistenceAdapter> = {},
+): PersistenceAdapter {
+  return {
+    unitOfWorkFactory: createInMemoryUnitOfWork,
+    ...overrides,
+  };
+}
+
+function makeDefinition() {
+  return defineDomain({
+    writeModel: { aggregates: { Counter } },
+    readModel: { projections: {} },
+  });
+}
+
+// ============================================================
+// Adapter defaults resolve for aggregate persistence
+// ============================================================
+
+describe("Adapter wiring - aggregate persistence defaults", () => {
+  it("should default to adapter stateStoredPersistence when persistence is omitted", async () => {
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: {},
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+
+  it("should use in-memory defaults when no adapter and no explicit wiring", async () => {
+    const domain = await wireDomain(makeDefinition(), {});
+    expect(domain).toBeDefined();
+  });
+});
+
+// ============================================================
+// Persistence shorthand resolution
+// ============================================================
+
+describe("Adapter wiring - persistence shorthand", () => {
+  it("should resolve 'event-sourced' shorthand from adapter", async () => {
+    const esPersistence = new InMemoryEventSourcedAggregatePersistence();
+    const adapter = makeAdapter({
+      eventSourcedPersistence: esPersistence,
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: { persistence: "event-sourced" },
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+
+  it("should resolve 'state-stored' shorthand from adapter", async () => {
+    const ssPersistence = new InMemoryStateStoredAggregatePersistence();
+    const adapter = makeAdapter({
+      stateStoredPersistence: ssPersistence,
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: { persistence: "state-stored" },
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+
+  it("should throw when shorthand used without adapter", async () => {
+    await expect(
+      wireDomain(makeDefinition(), {
+        aggregates: {
+          Counter: { persistence: "event-sourced" },
+        },
+      }),
+    ).rejects.toThrow(/persistenceAdapter/);
+  });
+
+  it("should throw when adapter lacks eventSourcedPersistence for 'event-sourced' shorthand", async () => {
+    const adapter = makeAdapter(); // no eventSourcedPersistence
+
+    await expect(
+      wireDomain(makeDefinition(), {
+        persistenceAdapter: adapter,
+        aggregates: {
+          Counter: { persistence: "event-sourced" },
+        },
+      }),
+    ).rejects.toThrow(/eventSourcedPersistence/);
+  });
+
+  it("should throw when adapter lacks stateStoredPersistence for 'state-stored' shorthand", async () => {
+    const adapter = makeAdapter(); // no stateStoredPersistence
+
+    await expect(
+      wireDomain(makeDefinition(), {
+        persistenceAdapter: adapter,
+        aggregates: {
+          Counter: { persistence: "state-stored" },
+        },
+      }),
+    ).rejects.toThrow(/stateStoredPersistence/);
+  });
+});
+
+// ============================================================
+// Persistence factory and direct config still work
+// ============================================================
+
+describe("Adapter wiring - explicit persistence overrides", () => {
+  it("should use factory function when provided, ignoring adapter", async () => {
+    const adapterPersistence = new InMemoryStateStoredAggregatePersistence();
+    const explicitPersistence = new InMemoryEventSourcedAggregatePersistence();
+    const adapter = makeAdapter({
+      stateStoredPersistence: adapterPersistence,
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: { persistence: () => explicitPersistence },
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+});
+
+// ============================================================
+// Concurrency shorthand resolution
+// ============================================================
+
+describe("Adapter wiring - concurrency shorthand", () => {
+  it("should resolve 'pessimistic' shorthand with adapter locker", async () => {
+    const mockLocker = new InMemoryAggregateLocker();
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+      aggregateLocker: mockLocker,
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: { concurrency: "pessimistic" },
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+
+  it("should resolve 'optimistic' shorthand (equivalent to omitting)", async () => {
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: { concurrency: "optimistic" },
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+
+  it("should throw when 'pessimistic' used without adapter locker", async () => {
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+      // no aggregateLocker
+    });
+
+    await expect(
+      wireDomain(makeDefinition(), {
+        persistenceAdapter: adapter,
+        aggregates: {
+          Counter: { concurrency: "pessimistic" },
+        },
+      }),
+    ).rejects.toThrow(/locker/i);
+  });
+
+  it("should resolve object-form pessimistic with locker from adapter", async () => {
+    const mockLocker = new InMemoryAggregateLocker();
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+      aggregateLocker: mockLocker,
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: { concurrency: { strategy: "pessimistic" } },
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+
+  it("should use explicit locker over adapter locker", async () => {
+    const adapterLocker = new InMemoryAggregateLocker();
+    const explicitLocker = new InMemoryAggregateLocker();
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+      aggregateLocker: adapterLocker,
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: {
+          concurrency: { strategy: "pessimistic", locker: explicitLocker },
+        },
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+
+  it("should throw when pessimistic object form has no locker and no adapter locker", async () => {
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+    });
+
+    await expect(
+      wireDomain(makeDefinition(), {
+        persistenceAdapter: adapter,
+        aggregates: {
+          Counter: { concurrency: { strategy: "pessimistic" } },
+        },
+      }),
+    ).rejects.toThrow(/locker/i);
+  });
+
+  it("should support object-form optimistic with maxRetries", async () => {
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: { concurrency: { maxRetries: 5 } },
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+});
+
+// ============================================================
+// Snapshot store inference
+// ============================================================
+
+describe("Adapter wiring - snapshot store inference", () => {
+  it("should infer snapshot store from adapter when strategy set but store omitted", async () => {
+    const adapter = makeAdapter({
+      eventSourcedPersistence: new InMemoryEventSourcedAggregatePersistence(),
+      snapshotStore: new InMemorySnapshotStore(),
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: {
+          persistence: "event-sourced",
+          snapshots: { strategy: everyNEvents(10) },
+        },
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+
+  it("should throw when snapshot strategy set but no store and adapter lacks snapshotStore", async () => {
+    const adapter = makeAdapter({
+      eventSourcedPersistence: new InMemoryEventSourcedAggregatePersistence(),
+      // no snapshotStore
+    });
+
+    await expect(
+      wireDomain(makeDefinition(), {
+        persistenceAdapter: adapter,
+        aggregates: {
+          Counter: {
+            persistence: "event-sourced",
+            snapshots: { strategy: everyNEvents(10) },
+          },
+        },
+      }),
+    ).rejects.toThrow(/snapshot/i);
+  });
+
+  it("should use explicit snapshot store over adapter", async () => {
+    const adapterStore = new InMemorySnapshotStore();
+    const explicitStore = new InMemorySnapshotStore();
+    const adapter = makeAdapter({
+      eventSourcedPersistence: new InMemoryEventSourcedAggregatePersistence(),
+      snapshotStore: adapterStore,
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: {
+          persistence: "event-sourced",
+          snapshots: { strategy: everyNEvents(10), store: () => explicitStore },
+        },
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+});
+
+// ============================================================
+// Saga persistence inference
+// ============================================================
+
+describe("Adapter wiring - saga persistence inference", () => {
+  // Minimal saga definition for testing
+  type TaskEvent = DefineEvents<{
+    TaskStarted: { taskId: string };
+  }>;
+  type AckCommand = DefineCommands<{
+    AcknowledgeTask: { taskId: string };
+  }>;
+  type AckSagaDef = SagaTypes & {
+    state: { acknowledged: boolean };
+    events: TaskEvent;
+    commands: AckCommand;
+    infrastructure: Infrastructure;
+  };
+
+  const AckSaga = defineSaga<AckSagaDef>({
+    initialState: { acknowledged: false },
+    startedBy: ["TaskStarted"],
+    on: {
+      TaskStarted: {
+        id: (event) => event.payload.taskId,
+        handle: (event) => ({
+          state: { acknowledged: true },
+          commands: {
+            name: "AcknowledgeTask",
+            targetAggregateId: event.payload.taskId,
+            payload: { taskId: event.payload.taskId },
+          },
+        }),
+      },
+    },
+  });
+
+  it("should infer saga persistence from adapter when not explicitly wired", async () => {
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+      sagaPersistence: new InMemorySagaPersistence(),
+    });
+
+    const definition = defineDomain({
+      writeModel: { aggregates: { Counter } },
+      readModel: { projections: {} },
+      processModel: { sagas: { Ack: AckSaga } },
+    });
+
+    const domain = await wireDomain(definition, {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: {},
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+
+  it("should skip saga persistence when no sagas are defined", async () => {
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+      // no sagaPersistence
+    });
+
+    // No sagas — should succeed even without saga persistence
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: {},
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+});
+
+// ============================================================
+// Unit-of-work inference
+// ============================================================
+
+describe("Adapter wiring - unit-of-work inference", () => {
+  it("should infer UoW factory from adapter when not explicitly wired", async () => {
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: {},
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+
+  it("should use explicit UoW factory over adapter", async () => {
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+    });
+
+    const explicitUoW = vi.fn(createInMemoryUnitOfWork);
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      unitOfWork: () => explicitUoW,
+      aggregates: {
+        Counter: {},
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+});
+
+// ============================================================
+// Idempotency and outbox inference
+// ============================================================
+
+describe("Adapter wiring - idempotency inference", () => {
+  it("should infer idempotency store from adapter when not explicitly wired", async () => {
+    const mockIdempotencyStore = {
+      exists: vi.fn().mockResolvedValue(false),
+      store: vi.fn().mockResolvedValue(undefined),
+    };
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+      idempotencyStore: mockIdempotencyStore,
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: {},
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+});
+
+describe("Adapter wiring - outbox inference", () => {
+  it("should infer outbox store from adapter when not explicitly wired", async () => {
+    const mockOutboxStore = {
+      save: vi.fn().mockResolvedValue(undefined),
+      fetchUnpublished: vi.fn().mockResolvedValue([]),
+      markPublished: vi.fn().mockResolvedValue(undefined),
+      markPublishedByEventIds: vi.fn().mockResolvedValue(undefined),
+    };
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+      outboxStore: mockOutboxStore,
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: {},
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+});
+
+// ============================================================
+// Adapter lifecycle
+// ============================================================
+
+describe("Adapter wiring - lifecycle", () => {
+  it("should call adapter.init() during domain init", async () => {
+    const initFn = vi.fn().mockResolvedValue(undefined);
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+      init: initFn,
+    });
+
+    await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: {},
+      },
+    });
+
+    expect(initFn).toHaveBeenCalledOnce();
+  });
+
+  it("should call adapter.close() during domain shutdown", async () => {
+    const closeFn = vi.fn().mockResolvedValue(undefined);
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+      close: closeFn,
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: {},
+      },
+    });
+
+    await domain.shutdown();
+
+    expect(closeFn).toHaveBeenCalledOnce();
+  });
+
+  it("should proceed without error when adapter has no close()", async () => {
+    const adapter = makeAdapter({
+      stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+      // no close()
+    });
+
+    const domain = await wireDomain(makeDefinition(), {
+      persistenceAdapter: adapter,
+      aggregates: {
+        Counter: {},
+      },
+    });
+
+    await expect(domain.shutdown()).resolves.not.toThrow();
+  });
+});
+
+// ============================================================
+// Backward compatibility — no adapter
+// ============================================================
+
+describe("Adapter wiring - backward compatibility", () => {
+  it("should work with no adapter and explicit factories (existing pattern)", async () => {
+    const domain = await wireDomain(makeDefinition(), {
+      aggregates: {
+        Counter: {
+          persistence: () => new InMemoryEventSourcedAggregatePersistence(),
+        },
+      },
+      buses: () => ({
+        commandBus: new InMemoryCommandBus(),
+        eventBus: new EventEmitterEventBus(),
+        queryBus: new InMemoryQueryBus(),
+      }),
+    });
+
+    expect(domain).toBeDefined();
+  });
+
+  it("should work with no adapter and no explicit wiring (in-memory defaults)", async () => {
+    const domain = await wireDomain(makeDefinition(), {});
+
+    expect(domain).toBeDefined();
+  });
+
+  it("should work with global aggregate wiring (non per-aggregate mode)", async () => {
+    const domain = await wireDomain(makeDefinition(), {
+      aggregates: {
+        persistence: () => new InMemoryEventSourcedAggregatePersistence(),
+        concurrency: { maxRetries: 3 },
+      },
+    });
+
+    expect(domain).toBeDefined();
+  });
+});

--- a/packages/engine/src/domain.ts
+++ b/packages/engine/src/domain.ts
@@ -611,8 +611,13 @@ export class Domain<
         // Ensure every aggregate has persistence resolved
         const missing = [...aggregateNames].filter((n) => !resolved.has(n));
         if (missing.length > 0 && resolved.size < aggregateNames.size) {
-          // Some aggregates have persistence, some don't — inconsistent
-          // For the missing ones, use in-memory fallback
+          if (!adapter) {
+            // No adapter — strict mode: explicit per-aggregate wiring must cover all aggregates
+            throw new Error(
+              `Per-aggregate persistence is missing entries for: ${missing.join(", ")}`,
+            );
+          }
+          // Adapter present but some aggregates didn't resolve — use in-memory fallback
           domainLog.warn(
             `Per-aggregate persistence is missing entries for: ${missing.join(", ")}. ` +
               `Using in-memory persistence for those aggregates.`,

--- a/packages/engine/src/domain.ts
+++ b/packages/engine/src/domain.ts
@@ -18,6 +18,7 @@ import type {
   InferSagaMapInfrastructure,
   Logger,
   PersistenceConfiguration,
+  PersistenceAdapter,
   Projection,
   Query,
   QueryHandler,
@@ -160,23 +161,119 @@ type PersistenceFactory = () =>
 // ---- New API: defineDomain + wireDomain ----
 
 /**
+ * Shorthand string for persistence strategy. Resolved from the adapter.
+ * - `'event-sourced'` → adapter.eventSourcedPersistence
+ * - `'state-stored'` → adapter.stateStoredPersistence
+ */
+type PersistenceShorthand = "event-sourced" | "state-stored";
+
+/**
+ * Resolves a persistence value from the various forms it can take:
+ * - string shorthand → resolved from adapter
+ * - function → factory, called to get config
+ * - object with save/load → PersistenceConfiguration, used directly
+ * - undefined → default from adapter (stateStoredPersistence)
+ * @internal
+ */
+async function resolveAggregatePersistence(
+  aggregateName: string,
+  persistence:
+    | PersistenceFactory
+    | PersistenceShorthand
+    | PersistenceConfiguration
+    | undefined,
+  adapter: PersistenceAdapter | undefined,
+): Promise<PersistenceConfiguration | undefined> {
+  if (persistence === undefined) {
+    // Default: use adapter's stateStoredPersistence if available
+    if (adapter?.stateStoredPersistence) {
+      return adapter.stateStoredPersistence;
+    }
+    // No adapter or adapter doesn't provide stateStoredPersistence — return undefined for in-memory fallback
+    return undefined;
+  }
+
+  if (typeof persistence === "string") {
+    // Shorthand — requires adapter
+    if (!adapter) {
+      throw new Error(
+        `Aggregate "${aggregateName}": persistence shorthand '${persistence}' requires a persistenceAdapter in DomainWiring.`,
+      );
+    }
+    if (persistence === "event-sourced") {
+      if (!adapter.eventSourcedPersistence) {
+        throw new Error(
+          `Aggregate "${aggregateName}": persistence '${persistence}' requested but the adapter does not provide eventSourcedPersistence.`,
+        );
+      }
+      return adapter.eventSourcedPersistence;
+    }
+    if (persistence === "state-stored") {
+      if (!adapter.stateStoredPersistence) {
+        throw new Error(
+          `Aggregate "${aggregateName}": persistence '${persistence}' requested but the adapter does not provide stateStoredPersistence.`,
+        );
+      }
+      return adapter.stateStoredPersistence;
+    }
+    throw new Error(
+      `Aggregate "${aggregateName}": unknown persistence shorthand '${persistence}'.`,
+    );
+  }
+
+  if (typeof persistence === "function") {
+    // Factory function — call it
+    return await persistence();
+  }
+
+  // Object — PersistenceConfiguration, used directly
+  return persistence;
+}
+
+/**
  * Per-aggregate runtime configuration. Groups persistence, concurrency,
  * and snapshot settings.
+ *
+ * When a `persistenceAdapter` is provided in `DomainWiring`:
+ * - `persistence` defaults to `adapter.stateStoredPersistence` if omitted
+ * - `persistence` accepts string shorthands (`'event-sourced'`, `'state-stored'`)
+ * - `persistence` accepts a `PersistenceConfiguration` object directly (e.g., from `adapter.stateStored(table)`)
+ * - `concurrency` accepts string shorthands (`'pessimistic'`, `'optimistic'`)
+ * - `snapshots.store` is inferred from `adapter.snapshotStore` when omitted
  */
 export type AggregateWiring = {
-  /** Persistence factory for this aggregate. */
-  persistence?: PersistenceFactory;
-  /** Concurrency control for this aggregate. */
+  /**
+   * Persistence for this aggregate. Accepts:
+   * - A factory function: `() => PersistenceConfiguration`
+   * - A shorthand string: `'event-sourced'` | `'state-stored'` (resolved from adapter)
+   * - A `PersistenceConfiguration` object directly (e.g., from `adapter.stateStored(table)`)
+   * - Omitted: defaults to `adapter.stateStoredPersistence` (when adapter present) or in-memory
+   */
+  persistence?:
+    | PersistenceFactory
+    | PersistenceShorthand
+    | PersistenceConfiguration;
+  /**
+   * Concurrency control for this aggregate. Accepts:
+   * - `'optimistic'`: default retries (0), same as omitting
+   * - `'pessimistic'`: auto-resolves locker from adapter
+   * - Object form for customization
+   */
   concurrency?:
+    | "pessimistic"
+    | "optimistic"
     | { strategy?: "optimistic"; maxRetries?: number }
     | {
         strategy: "pessimistic";
-        locker: AggregateLocker;
+        locker?: AggregateLocker;
         lockTimeoutMs?: number;
       };
-  /** Snapshot configuration for this aggregate (event-sourced only). */
+  /**
+   * Snapshot configuration for this aggregate (event-sourced only).
+   * When `store` is omitted, it is inferred from `adapter.snapshotStore`.
+   */
   snapshots?: {
-    store: () => SnapshotStore | Promise<SnapshotStore>;
+    store?: () => SnapshotStore | Promise<SnapshotStore>;
     strategy: SnapshotStrategy;
   };
 };
@@ -253,6 +350,13 @@ export type DomainWiring<
   TAggregates extends AggregateMap = AggregateMap,
 > = {
   /**
+   * Persistence adapter providing default stores for the domain.
+   * When provided, the engine resolves aggregate persistence, saga persistence,
+   * unit-of-work, snapshots, outbox, idempotency, and locking from the adapter
+   * when not explicitly wired. Explicit wiring always overrides adapter defaults.
+   */
+  persistenceAdapter?: PersistenceAdapter;
+  /**
    * Factory for user-provided infrastructure services.
    * Receives the framework logger so custom services can use it.
    */
@@ -267,7 +371,7 @@ export type DomainWiring<
   projections?: Record<string, ProjectionWiring<TInfrastructure>>;
   /** Saga runtime config. Required if processModel has sagas. */
   sagas?: {
-    persistence: () => SagaPersistence | Promise<SagaPersistence>;
+    persistence?: () => SagaPersistence | Promise<SagaPersistence>;
   };
   /** Factory for CQRS buses. Receives resolved user infrastructure. */
   buses?: (
@@ -435,6 +539,13 @@ export class Domain<
       domainLog.debug("OpenTelemetry not detected. Tracing disabled.");
     }
 
+    // Step 0.6: Initialize persistence adapter (if provided)
+    const adapter = wiring.persistenceAdapter;
+    if (adapter) {
+      await adapter.init?.();
+      domainLog.info("Persistence adapter initialized.");
+    }
+
     // Step 1: Resolve custom infrastructure
     const customInfra = wiring.infrastructure
       ? await wiring.infrastructure(logger)
@@ -468,47 +579,57 @@ export class Domain<
     let persistenceResolver: AggregatePersistenceResolver;
 
     if (perAggregateWirings) {
-      // Per-aggregate mode: build persistence from each aggregate's wiring
-      const persistenceRecord: Record<string, PersistenceFactory> = {};
-      let hasPersistence = false;
-      for (const [name, aw] of perAggregateWirings) {
-        if (aw.persistence) {
-          persistenceRecord[name] = aw.persistence;
-          hasPersistence = true;
-        }
-      }
-      if (hasPersistence) {
-        // Runtime validation: every aggregate must have explicit persistence
-        const aggregateNames = new Set(
-          Object.keys(definition.writeModel.aggregates),
-        );
-        const configNames = new Set(Object.keys(persistenceRecord));
+      // Per-aggregate mode: resolve persistence from each aggregate's wiring + adapter fallback
+      const resolved = new Map<string, PersistenceConfiguration>();
+      const aggregateNames = new Set(
+        Object.keys(definition.writeModel.aggregates),
+      );
 
-        const missing = [...aggregateNames].filter((n) => !configNames.has(n));
-        if (missing.length > 0) {
+      // Validate no unknown aggregate names in wiring
+      for (const name of perAggregateWirings.keys()) {
+        if (!aggregateNames.has(name)) {
           throw new Error(
-            `Per-aggregate persistence is missing entries for: ${missing.join(", ")}. ` +
-              `All aggregates must have a persistence factory.`,
-          );
-        }
-        const unknown = [...configNames].filter((n) => !aggregateNames.has(n));
-        if (unknown.length > 0) {
-          throw new Error(
-            `Per-aggregate persistence references unknown aggregates: ${unknown.join(", ")}. ` +
+            `Per-aggregate wiring references unknown aggregate: ${name}. ` +
               `Registered aggregates: ${[...aggregateNames].join(", ")}.`,
           );
         }
+      }
 
-        const resolved = new Map<string, PersistenceConfiguration>();
-        for (const [name, factory] of Object.entries(persistenceRecord)) {
-          resolved.set(name, await factory());
+      for (const aggregateName of aggregateNames) {
+        const aw = perAggregateWirings.get(aggregateName);
+        const persistence = await resolveAggregatePersistence(
+          aggregateName,
+          aw?.persistence,
+          adapter,
+        );
+        if (persistence) {
+          resolved.set(aggregateName, persistence);
+        }
+      }
+
+      if (resolved.size > 0) {
+        // Ensure every aggregate has persistence resolved
+        const missing = [...aggregateNames].filter((n) => !resolved.has(n));
+        if (missing.length > 0 && resolved.size < aggregateNames.size) {
+          // Some aggregates have persistence, some don't — inconsistent
+          // For the missing ones, use in-memory fallback
+          domainLog.warn(
+            `Per-aggregate persistence is missing entries for: ${missing.join(", ")}. ` +
+              `Using in-memory persistence for those aggregates.`,
+          );
+          const fallback = new InMemoryEventSourcedAggregatePersistence();
+          for (const name of missing) {
+            resolved.set(name, fallback);
+          }
         }
         persistenceResolver = new PerAggregatePersistenceResolver(resolved);
       } else {
-        // Per-aggregate mode but no persistence specified — use in-memory default
-        domainLog.warn(
-          "Using in-memory aggregate persistence. This is not suitable for production.",
-        );
+        // Per-aggregate mode but no persistence resolved — use in-memory default
+        if (!adapter) {
+          domainLog.warn(
+            "Using in-memory aggregate persistence. This is not suitable for production.",
+          );
+        }
         persistenceResolver = new GlobalAggregatePersistenceResolver(
           new InMemoryEventSourcedAggregatePersistence(),
         );
@@ -518,8 +639,14 @@ export class Domain<
       const globalWiring = wiring.aggregates as AggregateWiring | undefined;
       const globalPersistence = globalWiring?.persistence;
 
-      if (!globalPersistence) {
-        // Omitted — in-memory default for all
+      const resolvedPersistence = await resolveAggregatePersistence(
+        "(global)",
+        globalPersistence,
+        adapter,
+      );
+
+      if (!resolvedPersistence) {
+        // Omitted and no adapter — in-memory default for all
         domainLog.warn(
           "Using in-memory aggregate persistence. This is not suitable for production.",
         );
@@ -527,9 +654,8 @@ export class Domain<
           new InMemoryEventSourcedAggregatePersistence(),
         );
       } else {
-        // Domain-wide factory
         persistenceResolver = new GlobalAggregatePersistenceResolver(
-          await globalPersistence(),
+          resolvedPersistence,
         );
       }
     }
@@ -549,7 +675,17 @@ export class Domain<
       >();
       for (const [name, aw] of perAggregateWirings) {
         if (aw.snapshots) {
-          const store = await aw.snapshots.store();
+          let store: SnapshotStore;
+          if (aw.snapshots.store) {
+            store = await aw.snapshots.store();
+          } else if (adapter?.snapshotStore) {
+            store = adapter.snapshotStore;
+          } else {
+            throw new Error(
+              `Aggregate "${name}": snapshots.strategy is set but no snapshot store is available. ` +
+                `Provide snapshots.store or use a persistenceAdapter with snapshotStore.`,
+            );
+          }
           resolvedSnapshots.set(name, {
             store,
             strategy: aw.snapshots.strategy,
@@ -565,7 +701,17 @@ export class Domain<
       const globalWiring = wiring.aggregates as AggregateWiring | undefined;
       const snapshotConfig = globalWiring?.snapshots;
       if (snapshotConfig) {
-        const snapshotStore = await snapshotConfig.store();
+        let snapshotStore: SnapshotStore;
+        if (snapshotConfig.store) {
+          snapshotStore = await snapshotConfig.store();
+        } else if (adapter?.snapshotStore) {
+          snapshotStore = adapter.snapshotStore;
+        } else {
+          throw new Error(
+            `Global snapshots.strategy is set but no snapshot store is available. ` +
+              `Provide snapshots.store or use a persistenceAdapter with snapshotStore.`,
+          );
+        }
         snapshotResolver = () => ({
           store: snapshotStore,
           strategy: snapshotConfig.strategy,
@@ -581,6 +727,8 @@ export class Domain<
     if (hasSagas) {
       if (wiring.sagas?.persistence) {
         sagaPersistence = await wiring.sagas.persistence();
+      } else if (adapter?.sagaPersistence) {
+        sagaPersistence = adapter.sagaPersistence;
       } else {
         domainLog.warn(
           "Using in-memory saga persistence. This is not suitable for production.",
@@ -590,40 +738,73 @@ export class Domain<
     }
 
     // Step 5.5: Resolve UnitOfWork factory
-    this._unitOfWorkFactory = wiring.unitOfWork
-      ? await wiring.unitOfWork()
-      : createInMemoryUnitOfWork;
+    if (wiring.unitOfWork) {
+      this._unitOfWorkFactory = await wiring.unitOfWork();
+    } else if (adapter?.unitOfWorkFactory) {
+      this._unitOfWorkFactory = adapter.unitOfWorkFactory;
+    } else {
+      this._unitOfWorkFactory = createInMemoryUnitOfWork;
+    }
 
     // Step 5.6: Resolve concurrency strategy
     const concurrencyLog = logger.child("concurrency");
     let concurrencyStrategy: ConcurrencyStrategy;
+
+    /**
+     * Resolves a concurrency config (shorthand or object) into a ConcurrencyStrategy.
+     */
+    const resolveConcurrency = (
+      aggregateName: string,
+      concurrency: AggregateWiring["concurrency"],
+    ): ConcurrencyStrategy => {
+      if (!concurrency || concurrency === "optimistic") {
+        return new OptimisticConcurrencyStrategy(0, concurrencyLog);
+      }
+
+      if (concurrency === "pessimistic") {
+        // Shorthand — auto-resolve locker from adapter
+        if (!adapter?.aggregateLocker) {
+          throw new Error(
+            `Aggregate "${aggregateName}": concurrency 'pessimistic' requires an aggregate locker. ` +
+              `Provide a persistenceAdapter with aggregateLocker or use object form with explicit locker.`,
+          );
+        }
+        return new PessimisticConcurrencyStrategy(
+          adapter.aggregateLocker,
+          undefined,
+          concurrencyLog,
+        );
+      }
+
+      // Object form
+      if ("strategy" in concurrency && concurrency.strategy === "pessimistic") {
+        const locker = concurrency.locker ?? adapter?.aggregateLocker;
+        if (!locker) {
+          throw new Error(
+            `Aggregate "${aggregateName}": pessimistic concurrency requires a locker. ` +
+              `Provide concurrency.locker or use a persistenceAdapter with aggregateLocker.`,
+          );
+        }
+        return new PessimisticConcurrencyStrategy(
+          locker,
+          concurrency.lockTimeoutMs,
+          concurrencyLog,
+        );
+      }
+
+      // Optimistic with options
+      return new OptimisticConcurrencyStrategy(
+        (concurrency as { maxRetries?: number })?.maxRetries ?? 0,
+        concurrencyLog,
+      );
+    };
 
     if (perAggregateWirings) {
       // Per-aggregate concurrency
       const strategies = new Map<string, ConcurrencyStrategy>();
       for (const [name, aw] of perAggregateWirings) {
         if (aw.concurrency) {
-          if (
-            "strategy" in aw.concurrency &&
-            aw.concurrency.strategy === "pessimistic"
-          ) {
-            strategies.set(
-              name,
-              new PessimisticConcurrencyStrategy(
-                aw.concurrency.locker,
-                aw.concurrency.lockTimeoutMs,
-                concurrencyLog,
-              ),
-            );
-          } else {
-            strategies.set(
-              name,
-              new OptimisticConcurrencyStrategy(
-                (aw.concurrency as { maxRetries?: number })?.maxRetries ?? 0,
-                concurrencyLog,
-              ),
-            );
-          }
+          strategies.set(name, resolveConcurrency(name, aw.concurrency));
         }
       }
       const defaultStrategy = new OptimisticConcurrencyStrategy(
@@ -637,29 +818,18 @@ export class Domain<
     } else {
       // Global concurrency from global AggregateWiring
       const globalWiring = wiring.aggregates as AggregateWiring | undefined;
-      const concurrency = globalWiring?.concurrency;
-      if (
-        concurrency &&
-        "strategy" in concurrency &&
-        concurrency.strategy === "pessimistic"
-      ) {
-        concurrencyStrategy = new PessimisticConcurrencyStrategy(
-          concurrency.locker,
-          concurrency.lockTimeoutMs,
-          concurrencyLog,
-        );
-      } else {
-        concurrencyStrategy = new OptimisticConcurrencyStrategy(
-          (concurrency as { maxRetries?: number } | undefined)?.maxRetries ?? 0,
-          concurrencyLog,
-        );
-      }
+      concurrencyStrategy = resolveConcurrency(
+        "(global)",
+        globalWiring?.concurrency,
+      );
     }
 
     // Step 5.7: Resolve idempotency store
     let idempotencyStore: IdempotencyStore | undefined;
     if (wiring.idempotency) {
       idempotencyStore = await wiring.idempotency();
+    } else if (adapter?.idempotencyStore) {
+      idempotencyStore = adapter.idempotencyStore;
     }
 
     // Step 5.8: Create metadata enricher
@@ -711,6 +881,8 @@ export class Domain<
     // Step 5.8b: Resolve outbox store
     if (wiring.outbox) {
       this._outboxStore = await wiring.outbox.store();
+    } else if (adapter?.outboxStore) {
+      this._outboxStore = adapter.outboxStore;
     }
 
     // Step 5.10: Build strong-consistency callback for projections
@@ -1001,7 +1173,9 @@ export class Domain<
     });
 
     // Step 13: Collect all infrastructure components for auto-close discovery
-    // Custom infrastructure values come first (discovery order)
+    // Persistence adapter (if provided) — close it during shutdown
+    if (adapter) this._allComponents.push(adapter);
+    // Custom infrastructure values come next (discovery order)
     for (const value of Object.values(customInfra as Record<string, unknown>)) {
       this._allComponents.push(value);
     }

--- a/samples/sample-hotel-booking/src/main.ts
+++ b/samples/sample-hotel-booking/src/main.ts
@@ -13,16 +13,7 @@
  */
 import pg from "pg";
 import { drizzle } from "drizzle-orm/node-postgres";
-import {
-  createDrizzleAdapter,
-  generateDrizzleMigration,
-} from "@noddde/drizzle";
-import {
-  events,
-  aggregateStates,
-  sagaStates,
-  snapshots,
-} from "@noddde/drizzle/pg";
+import { DrizzleAdapter, generateDrizzleMigration } from "@noddde/drizzle";
 import {
   defineDomain,
   wireDomain,
@@ -90,12 +81,7 @@ async function main() {
   `);
 
   const db = drizzle(pool);
-  const drizzleInfra = createDrizzleAdapter(db, {
-    eventStore: events,
-    stateStore: aggregateStates,
-    sagaStore: sagaStates,
-    snapshotStore: snapshots,
-  });
+  const adapter = new DrizzleAdapter(db);
 
   // -- Define the domain structure (pure, sync) --
   const hotelDomain = defineDomain({
@@ -128,6 +114,9 @@ async function main() {
 
   // -- Wire with infrastructure (async) --
   const domain = await wireDomain(hotelDomain, {
+    // Persistence adapter — handles event store, state store, sagas, snapshots, UoW
+    persistenceAdapter: adapter,
+
     // Custom infrastructure services (what handlers receive)
     infrastructure: () => ({
       clock: new SystemClock(),
@@ -139,22 +128,19 @@ async function main() {
       revenueViewStore: new InMemoryViewStore<RevenueView>(),
     }),
 
-    // Per-aggregate persistence, concurrency, and snapshots
+    // Per-aggregate persistence and concurrency
     aggregates: {
       Room: {
-        persistence: () => drizzleInfra.eventSourcedPersistence,
+        persistence: "event-sourced",
         concurrency: { maxRetries: 3 },
-        snapshots: {
-          store: () => drizzleInfra.snapshotStore,
-          strategy: everyNEvents(50),
-        },
+        snapshots: { strategy: everyNEvents(50) },
       },
       Booking: {
-        persistence: () => drizzleInfra.eventSourcedPersistence,
+        persistence: "event-sourced",
         concurrency: { maxRetries: 3 },
       },
       Inventory: {
-        persistence: () => drizzleInfra.stateStoredPersistence,
+        // Defaults to state-stored from adapter
       },
     },
 
@@ -171,20 +157,12 @@ async function main() {
       },
     },
 
-    // Saga persistence via Drizzle
-    sagas: {
-      persistence: () => drizzleInfra.sagaPersistence,
-    },
-
     // CQRS buses
     buses: () => ({
       commandBus: new InMemoryCommandBus(),
       eventBus: new EventEmitterEventBus(),
       queryBus: new InMemoryQueryBus(),
     }),
-
-    // Unit of work for atomic operations
-    unitOfWork: () => drizzleInfra.unitOfWorkFactory,
 
     // Idempotency for payment commands
     idempotency: () => new InMemoryIdempotencyStore(),

--- a/specs/core/persistence/adapter.spec.md
+++ b/specs/core/persistence/adapter.spec.md
@@ -1,0 +1,440 @@
+---
+title: "Persistence Adapter Interface"
+module: core/persistence/adapter
+source_file: packages/core/src/persistence/adapter.ts
+status: implemented
+exports:
+  - PersistenceAdapter
+  - isPersistenceAdapter
+depends_on:
+  - core/persistence/persistence
+  - core/persistence/unit-of-work
+  - core/persistence/snapshot
+  - core/persistence/outbox
+  - core/persistence/idempotency
+  - core/infrastructure
+docs:
+  - docs/content/docs/infrastructure/orm-adapters.mdx
+---
+
+# Persistence Adapter Interface
+
+> A standard interface for database adapters that plug into `wireDomain`. Adapter implementations (Drizzle, Prisma, TypeORM, etc.) implement `PersistenceAdapter` to provide persistence stores, unit-of-work factories, snapshot stores, and other infrastructure. The engine resolves missing wiring from the adapter automatically, eliminating repetitive boilerplate. Community adapter authors implement this single interface to be compatible with the framework.
+
+## Type Contract
+
+```ts
+import type {
+  EventSourcedAggregatePersistence,
+  StateStoredAggregatePersistence,
+  SagaPersistence,
+  UnitOfWorkFactory,
+  SnapshotStore,
+  OutboxStore,
+  IdempotencyStore,
+  AggregateLocker,
+} from "@noddde/core";
+
+/**
+ * Standard interface for database persistence adapters.
+ *
+ * Adapter classes implement this interface and are passed to `wireDomain`
+ * via the `persistenceAdapter` property. The engine resolves aggregate
+ * persistence, saga persistence, unit-of-work, snapshots, outbox,
+ * idempotency, and locking from the adapter when not explicitly wired.
+ *
+ * Only `unitOfWorkFactory` is required. All other fields are optional
+ * and validated at runtime: the engine errors if the domain needs a
+ * capability the adapter doesn't provide.
+ *
+ * Does NOT extend `Closeable`. Adapters that hold resources implement
+ * an optional `close()` method, auto-discovered by `isCloseable()`.
+ */
+export interface PersistenceAdapter {
+  /** Required. Factory for creating unit-of-work instances. */
+  unitOfWorkFactory: UnitOfWorkFactory;
+
+  /** Shared event-sourced persistence. Optional. */
+  eventSourcedPersistence?: EventSourcedAggregatePersistence;
+
+  /** Shared state-stored persistence (default aggregate table). Optional. */
+  stateStoredPersistence?: StateStoredAggregatePersistence;
+
+  /** Saga state persistence. Optional — only needed when sagas are defined. */
+  sagaPersistence?: SagaPersistence;
+
+  /** Snapshot store for event-sourced aggregates. Optional. */
+  snapshotStore?: SnapshotStore;
+
+  /** Outbox store for transactional outbox pattern. Optional. */
+  outboxStore?: OutboxStore;
+
+  /** Idempotency store for command deduplication. Optional. */
+  idempotencyStore?: IdempotencyStore;
+
+  /** Aggregate locker for pessimistic concurrency. Optional. */
+  aggregateLocker?: AggregateLocker;
+
+  /**
+   * Optional initialization hook. Called by `Domain.init()` before
+   * any other resolution. Use for schema creation, migrations, etc.
+   */
+  init?(): Promise<void>;
+
+  /**
+   * Optional cleanup hook. Auto-discovered by `isCloseable()` and
+   * called during `Domain.shutdown()`. Use for connection pool cleanup.
+   * Must be idempotent.
+   */
+  close?(): Promise<void>;
+}
+
+/**
+ * Runtime type guard for detecting PersistenceAdapter implementations.
+ * Checks for the presence of `unitOfWorkFactory` — the only required field.
+ *
+ * @param value - The value to check.
+ * @returns `true` if the value satisfies the PersistenceAdapter interface.
+ */
+export function isPersistenceAdapter(
+  value: unknown,
+): value is PersistenceAdapter;
+```
+
+## Behavioral Requirements
+
+### Adapter resolution in wireDomain
+
+1. When `persistenceAdapter` is provided in `DomainWiring`, the engine uses it as a fallback source for all persistence concerns not explicitly wired.
+2. When `persistenceAdapter` is not provided, the engine behaves exactly as before (backward compatible — in-memory defaults or explicit wiring).
+
+### Default aggregate persistence
+
+3. When an adapter is present and an aggregate has no `persistence` declared, the engine defaults to `adapter.stateStoredPersistence`. DDD with state-stored aggregates is the primary use case; event sourcing is opt-in.
+4. When an adapter is present but does not provide `stateStoredPersistence`, and an aggregate omits `persistence`, `wireDomain` throws an error at init time.
+
+### Persistence shorthand resolution
+
+5. `persistence: 'event-sourced'` resolves to `adapter.eventSourcedPersistence`. Error if adapter is absent or does not provide `eventSourcedPersistence`.
+6. `persistence: 'state-stored'` resolves to `adapter.stateStoredPersistence`. Error if adapter is absent or does not provide `stateStoredPersistence`.
+7. `persistence: () => somePersistence` (factory function) continues to work as before, ignoring the adapter.
+8. `persistence: someConfigObject` (a `PersistenceConfiguration` object — not a string, not a function) is used directly. This supports `adapter.stateStored(table)` which returns a `PersistenceConfiguration`.
+
+### Concurrency shorthand resolution
+
+9. `concurrency: 'optimistic'` is equivalent to `{ maxRetries: 0 }` — same as omitting `concurrency`.
+10. `concurrency: 'pessimistic'` resolves `locker` from `adapter.aggregateLocker`. Error if adapter is absent or does not provide `aggregateLocker`.
+11. `concurrency: { strategy: 'pessimistic' }` without explicit `locker` also resolves from `adapter.aggregateLocker`.
+12. `concurrency: { strategy: 'pessimistic', locker: customLocker }` uses the explicit locker, ignoring the adapter.
+13. Object-form `concurrency` (e.g., `{ maxRetries: 5 }`) continues to work as before.
+
+### Snapshot store inference
+
+14. When `snapshots: { strategy }` is provided without `store`, the engine resolves `store` from `adapter.snapshotStore`.
+15. When `snapshots: { strategy }` is provided without `store` and the adapter does not provide `snapshotStore`, `wireDomain` throws an error.
+16. Explicit `snapshots: { strategy, store: () => myStore }` ignores the adapter.
+
+### Saga persistence inference
+
+17. When `wiring.sagas.persistence` is not provided, the engine falls back to `adapter.sagaPersistence`.
+18. When sagas are defined in the domain but no saga persistence is available (neither from explicit wiring nor from the adapter), `wireDomain` throws an error.
+19. When no sagas are defined, saga persistence is not required — neither from wiring nor adapter.
+
+### Unit-of-work inference
+
+20. When `wiring.unitOfWork` is not provided, the engine falls back to `adapter.unitOfWorkFactory`.
+21. When neither `wiring.unitOfWork` nor adapter is available, the engine uses the in-memory default.
+
+### Outbox and idempotency inference
+
+22. When `wiring.outbox.store` is not provided, the engine falls back to `adapter.outboxStore`.
+23. When `wiring.idempotency` is not provided, the engine falls back to `adapter.idempotencyStore`.
+
+### Adapter lifecycle
+
+24. `adapter.init?.()` is called at the start of `Domain.init()`, after logger setup.
+25. The adapter is pushed into the domain's component list for auto-close. `isCloseable()` detects adapters with a `close()` method and calls it during `Domain.shutdown()`.
+26. If the adapter does not implement `close()`, shutdown proceeds without error.
+
+### Explicit wiring overrides
+
+27. For every concern, explicit wiring (global or per-aggregate) always takes precedence over adapter defaults. The adapter is purely a fallback.
+28. Per-aggregate wiring overrides global wiring, which overrides adapter defaults.
+
+## Invariants
+
+- `unitOfWorkFactory` is the only required field on `PersistenceAdapter`. All other fields are optional.
+- Explicit wiring ALWAYS takes precedence over adapter defaults.
+- Shorthand strings (`'event-sourced'`, `'state-stored'`, `'pessimistic'`, `'optimistic'`) ALWAYS require an adapter to be present. Using a shorthand without an adapter is always an error.
+- When a domain capability requires a store the adapter doesn't provide, `wireDomain` ALWAYS throws a descriptive error at init time — not at first use.
+- `isPersistenceAdapter` ALWAYS returns `true` for objects with a `unitOfWorkFactory` property that is a function, and `false` for everything else.
+
+## Edge Cases
+
+- **Adapter with no optional stores**: only `unitOfWorkFactory` provided. All aggregates must use explicit `persistence` factories. Sagas, snapshots, outbox, idempotency all require explicit wiring.
+- **Adapter + partial per-aggregate overrides**: some aggregates use shorthand, others use explicit factories. Both resolve correctly.
+- **No adapter, no explicit wiring**: backward-compatible — engine uses in-memory defaults (as today).
+- **Adapter without `stateStoredPersistence` + aggregate omitting `persistence`**: error at init time with descriptive message.
+- **Adapter without `eventSourcedPersistence` + aggregate with `persistence: 'event-sourced'`**: error at init time.
+- **Adapter without `aggregateLocker` + aggregate with `concurrency: 'pessimistic'`**: error at init time.
+- **Adapter without `sagaPersistence` + domain with sagas**: error at init time.
+- **Adapter without `snapshotStore` + aggregate with `snapshots: { strategy }`**: error at init time.
+- **`isPersistenceAdapter(null)`**: returns `false`.
+- **`isPersistenceAdapter({})`**: returns `false` (no `unitOfWorkFactory`).
+- **`isPersistenceAdapter({ unitOfWorkFactory: "not-a-function" })`**: returns `false`.
+
+## Integration Points
+
+- **`@noddde/engine`**: `wireDomain` reads `persistenceAdapter` from `DomainWiring`. `Domain.init()` calls `adapter.init?.()` and resolves defaults. `Domain.shutdown()` auto-discovers `close()` via `isCloseable()`.
+- **`@noddde/core`**: `PersistenceAdapter` interface references types from `persistence/`, `infrastructure/closeable`.
+- **Adapter packages**: `DrizzleAdapter`, `PrismaAdapter`, `TypeORMAdapter` implement `PersistenceAdapter`.
+
+## Test Scenarios
+
+### isPersistenceAdapter returns true for valid adapter
+
+```ts
+import { isPersistenceAdapter } from "@noddde/core";
+import { InMemoryUnitOfWorkFactory } from "@noddde/engine";
+
+const adapter = {
+  unitOfWorkFactory: new InMemoryUnitOfWorkFactory(),
+};
+
+expect(isPersistenceAdapter(adapter)).toBe(true);
+```
+
+### isPersistenceAdapter returns true for full adapter
+
+```ts
+import { isPersistenceAdapter } from "@noddde/core";
+import {
+  InMemoryUnitOfWorkFactory,
+  InMemoryEventSourcedAggregatePersistence,
+  InMemoryStateStoredAggregatePersistence,
+  InMemorySagaPersistence,
+} from "@noddde/engine";
+
+const adapter = {
+  unitOfWorkFactory: new InMemoryUnitOfWorkFactory(),
+  eventSourcedPersistence: new InMemoryEventSourcedAggregatePersistence(),
+  stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+  sagaPersistence: new InMemorySagaPersistence(),
+};
+
+expect(isPersistenceAdapter(adapter)).toBe(true);
+```
+
+### isPersistenceAdapter returns false for non-adapters
+
+```ts
+import { isPersistenceAdapter } from "@noddde/core";
+
+expect(isPersistenceAdapter(null)).toBe(false);
+expect(isPersistenceAdapter(undefined)).toBe(false);
+expect(isPersistenceAdapter({})).toBe(false);
+expect(isPersistenceAdapter("string")).toBe(false);
+expect(isPersistenceAdapter({ unitOfWorkFactory: "not-a-function" })).toBe(
+  false,
+);
+```
+
+### Adapter defaults resolve for aggregate persistence
+
+```ts
+import { defineDomain, wireDomain } from "@noddde/engine";
+import type { PersistenceAdapter } from "@noddde/core";
+
+// Minimal aggregate for testing
+const TestAggregate = defineAggregate({
+  name: "Test",
+  initialState: () => ({}),
+  commands: {},
+  events: {},
+});
+
+const domain = defineDomain({
+  writeModel: { aggregates: { Test: TestAggregate } },
+  readModel: { projections: {} },
+});
+
+const adapter: PersistenceAdapter = {
+  unitOfWorkFactory: new InMemoryUnitOfWorkFactory(),
+  stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+};
+
+const wired = await wireDomain(domain, {
+  persistenceAdapter: adapter,
+});
+
+// Aggregate should use adapter's stateStoredPersistence by default
+expect(wired).toBeDefined();
+```
+
+### Shorthand persistence: event-sourced resolves from adapter
+
+```ts
+const adapter: PersistenceAdapter = {
+  unitOfWorkFactory: new InMemoryUnitOfWorkFactory(),
+  eventSourcedPersistence: new InMemoryEventSourcedAggregatePersistence(),
+};
+
+const wired = await wireDomain(domain, {
+  persistenceAdapter: adapter,
+  aggregates: {
+    Test: { persistence: "event-sourced" },
+  },
+});
+
+expect(wired).toBeDefined();
+```
+
+### Shorthand persistence without adapter throws
+
+```ts
+await expect(
+  wireDomain(domain, {
+    aggregates: {
+      Test: { persistence: "event-sourced" },
+    },
+  }),
+).rejects.toThrow();
+```
+
+### Concurrency pessimistic resolves locker from adapter
+
+```ts
+const mockLocker: AggregateLocker = {
+  lock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+};
+
+const adapter: PersistenceAdapter = {
+  unitOfWorkFactory: new InMemoryUnitOfWorkFactory(),
+  stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+  aggregateLocker: mockLocker,
+};
+
+const wired = await wireDomain(domain, {
+  persistenceAdapter: adapter,
+  aggregates: {
+    Test: { concurrency: "pessimistic" },
+  },
+});
+
+expect(wired).toBeDefined();
+```
+
+### Pessimistic without adapter locker throws
+
+```ts
+const adapter: PersistenceAdapter = {
+  unitOfWorkFactory: new InMemoryUnitOfWorkFactory(),
+  stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+};
+
+await expect(
+  wireDomain(domain, {
+    persistenceAdapter: adapter,
+    aggregates: {
+      Test: { concurrency: "pessimistic" },
+    },
+  }),
+).rejects.toThrow();
+```
+
+### Snapshot store inferred from adapter
+
+```ts
+const adapter: PersistenceAdapter = {
+  unitOfWorkFactory: new InMemoryUnitOfWorkFactory(),
+  eventSourcedPersistence: new InMemoryEventSourcedAggregatePersistence(),
+  snapshotStore: new InMemorySnapshotStore(),
+};
+
+const wired = await wireDomain(domain, {
+  persistenceAdapter: adapter,
+  aggregates: {
+    Test: {
+      persistence: "event-sourced",
+      snapshots: { strategy: everyNEvents(10) },
+    },
+  },
+});
+
+expect(wired).toBeDefined();
+```
+
+### Saga persistence inferred from adapter
+
+```ts
+const adapter: PersistenceAdapter = {
+  unitOfWorkFactory: new InMemoryUnitOfWorkFactory(),
+  stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+  sagaPersistence: new InMemorySagaPersistence(),
+};
+
+// Domain with sagas would resolve saga persistence from adapter
+expect(adapter.sagaPersistence).toBeDefined();
+```
+
+### Adapter init called during domain init
+
+```ts
+const initFn = vi.fn().mockResolvedValue(undefined);
+const adapter: PersistenceAdapter = {
+  unitOfWorkFactory: new InMemoryUnitOfWorkFactory(),
+  stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+  init: initFn,
+};
+
+await wireDomain(domain, { persistenceAdapter: adapter });
+
+expect(initFn).toHaveBeenCalledOnce();
+```
+
+### Adapter close called during domain shutdown
+
+```ts
+const closeFn = vi.fn().mockResolvedValue(undefined);
+const adapter: PersistenceAdapter = {
+  unitOfWorkFactory: new InMemoryUnitOfWorkFactory(),
+  stateStoredPersistence: new InMemoryStateStoredAggregatePersistence(),
+  close: closeFn,
+};
+
+const wired = await wireDomain(domain, { persistenceAdapter: adapter });
+await wired.shutdown();
+
+expect(closeFn).toHaveBeenCalledOnce();
+```
+
+### Explicit wiring overrides adapter defaults
+
+```ts
+const adapterPersistence = new InMemoryStateStoredAggregatePersistence();
+const explicitPersistence = new InMemoryEventSourcedAggregatePersistence();
+
+const adapter: PersistenceAdapter = {
+  unitOfWorkFactory: new InMemoryUnitOfWorkFactory(),
+  stateStoredPersistence: adapterPersistence,
+};
+
+const wired = await wireDomain(domain, {
+  persistenceAdapter: adapter,
+  aggregates: {
+    Test: { persistence: () => explicitPersistence },
+  },
+});
+
+// The explicit factory should have been used, not the adapter default
+expect(wired).toBeDefined();
+```
+
+### No adapter backward compatibility
+
+```ts
+// No adapter — engine uses in-memory defaults (existing behavior)
+const wired = await wireDomain(domain, {});
+
+expect(wired).toBeDefined();
+```

--- a/specs/drizzle/drizzle-persistence.spec.md
+++ b/specs/drizzle/drizzle-persistence.spec.md
@@ -4,9 +4,11 @@ module: drizzle/persistence
 source_file: packages/adapters/drizzle/src/index.ts
 status: implemented
 exports:
-  - createDrizzleAdapter
-  - DrizzleAdapterConfig
-  - DrizzleAdapterResult
+  - DrizzleAdapter
+  - DrizzleAdapterOptions
+  - createDrizzleAdapter (deprecated)
+  - DrizzleAdapterConfig (deprecated)
+  - DrizzleAdapterResult (deprecated)
   - AggregateStateTableConfig
   - StateTableColumnMap
   - createDrizzlePersistence (deprecated)
@@ -38,6 +40,7 @@ depends_on:
   - core/persistence/unit-of-work
   - core/persistence/snapshot
   - core/persistence/outbox
+  - core/persistence/adapter
 docs:
   - docs/content/docs/infrastructure/orm-adapters.mdx
   - docs/content/docs/domain-configuration/unit-of-work.mdx
@@ -1517,4 +1520,159 @@ it("generates MySQL-specific DDL", () => {
   expect(sql).toContain("JSON NOT NULL");
   expect(sql).toContain("VARCHAR(255) NOT NULL");
 });
+```
+
+---
+
+## DrizzleAdapter (Class-Based API)
+
+> Class-based adapter that implements `PersistenceAdapter` for use with `wireDomain({ persistenceAdapter })`. Replaces the lower-level `createDrizzleAdapter` builder with a simpler constructor that auto-infers the database dialect.
+
+### Type Contract
+
+````ts
+import type {
+  PersistenceAdapter,
+  EventSourcedAggregatePersistence,
+  StateStoredAggregatePersistence,
+  SagaPersistence,
+  UnitOfWorkFactory,
+  SnapshotStore,
+  OutboxStore,
+  AggregateLocker,
+} from "@noddde/core";
+
+/**
+ * Optional configuration for DrizzleAdapter.
+ * When omitted, tables are auto-resolved from the dialect.
+ */
+export interface DrizzleAdapterOptions {
+  /** Override auto-resolved table definitions. Partial — only override what you need. */
+  tables?: {
+    eventStore?: any;
+    stateStore?: any;
+    sagaStore?: any;
+    snapshotStore?: any;
+    outboxStore?: any;
+  };
+}
+
+/**
+ * Drizzle-backed persistence adapter.
+ *
+ * Infers the database dialect from the Drizzle `db` instance (via `db._.dialect`)
+ * and auto-resolves pre-built table schemas for that dialect. All persistence
+ * stores are created eagerly in the constructor.
+ *
+ * @example
+ * ```ts
+ * import { DrizzleAdapter } from "@noddde/drizzle";
+ *
+ * const adapter = new DrizzleAdapter(db);
+ * const domain = await wireDomain(definition, { persistenceAdapter: adapter });
+ * ```
+ */
+export class DrizzleAdapter implements PersistenceAdapter {
+  constructor(db: any, options?: DrizzleAdapterOptions);
+
+  /** Always provided. */
+  unitOfWorkFactory: UnitOfWorkFactory;
+  /** Always provided. */
+  eventSourcedPersistence: EventSourcedAggregatePersistence;
+  /** Always provided. */
+  stateStoredPersistence: StateStoredAggregatePersistence;
+  /** Always provided. */
+  sagaPersistence: SagaPersistence;
+  /** Always provided. */
+  snapshotStore: SnapshotStore;
+  /** Always provided. */
+  outboxStore: OutboxStore;
+  /** Dialect-aware advisory locker. Only for PostgreSQL and MySQL. */
+  aggregateLocker?: AggregateLocker;
+
+  /**
+   * Returns a StateStoredAggregatePersistence bound to a dedicated Drizzle table.
+   * Use this when an aggregate needs its own state table instead of the shared one.
+   *
+   * @param table - A Drizzle table definition.
+   * @param columns - Optional column mapping overrides.
+   */
+  stateStored(
+    table: any,
+    columns?: Partial<StateTableColumnMap>,
+  ): StateStoredAggregatePersistence;
+
+  /**
+   * No-op — Drizzle does not own the database connection.
+   * The caller is responsible for closing the underlying pool.
+   */
+  close(): Promise<void>;
+}
+````
+
+### Behavioral Requirements (DrizzleAdapter)
+
+29. The constructor infers the dialect from `db._.dialect` and selects the corresponding pre-built table schemas (`@noddde/drizzle/pg`, `@noddde/drizzle/sqlite`, `@noddde/drizzle/mysql`).
+30. When `options.tables` is provided, specified tables override the auto-resolved ones.
+31. All persistence stores (`eventSourcedPersistence`, `stateStoredPersistence`, `sagaPersistence`, `snapshotStore`, `outboxStore`, `unitOfWorkFactory`) are created eagerly in the constructor.
+32. All persistence instances share a single `DrizzleTransactionStore`, ensuring UoW atomicity.
+33. `aggregateLocker` is provided for PostgreSQL and MySQL dialects (via `DrizzleAdvisoryLocker`). It is `undefined` for SQLite.
+34. `stateStored(table, columns?)` returns a `StateStoredAggregatePersistence` bound to the given table. The returned persistence shares the same transaction store.
+35. `close()` is a no-op that resolves immediately. Drizzle does not own the database connection pool.
+36. `isPersistenceAdapter(new DrizzleAdapter(db))` returns `true`.
+37. The existing `createDrizzleAdapter` function is marked `@deprecated` and delegates to `DrizzleAdapter` internally.
+
+### Deprecation
+
+`createDrizzleAdapter` is deprecated in favor of `DrizzleAdapter`. It continues to work for backward compatibility but delegates internally to the class-based implementation.
+
+```ts
+/** @deprecated Use `new DrizzleAdapter(db, options)` instead. */
+export function createDrizzleAdapter<const C extends DrizzleAdapterConfig>(
+  db: any,
+  config: C,
+): DrizzleAdapterResult<C>;
+```
+
+### Test Scenarios (DrizzleAdapter)
+
+### DrizzleAdapter implements PersistenceAdapter
+
+```ts
+import { isPersistenceAdapter } from "@noddde/core";
+import { DrizzleAdapter } from "@noddde/drizzle";
+
+const adapter = new DrizzleAdapter(db);
+expect(isPersistenceAdapter(adapter)).toBe(true);
+```
+
+### DrizzleAdapter provides all stores
+
+```ts
+const adapter = new DrizzleAdapter(db);
+
+expect(adapter.unitOfWorkFactory).toBeDefined();
+expect(adapter.eventSourcedPersistence).toBeDefined();
+expect(adapter.stateStoredPersistence).toBeDefined();
+expect(adapter.sagaPersistence).toBeDefined();
+expect(adapter.snapshotStore).toBeDefined();
+expect(adapter.outboxStore).toBeDefined();
+```
+
+### DrizzleAdapter.stateStored returns dedicated persistence
+
+```ts
+const adapter = new DrizzleAdapter(db);
+const dedicated = adapter.stateStored(customTable);
+
+expect(dedicated).toBeDefined();
+expect(dedicated.save).toBeTypeOf("function");
+expect(dedicated.load).toBeTypeOf("function");
+```
+
+### DrizzleAdapter close is a no-op
+
+```ts
+const adapter = new DrizzleAdapter(db);
+await expect(adapter.close()).resolves.toBeUndefined();
 ```

--- a/specs/prisma/prisma-persistence.spec.md
+++ b/specs/prisma/prisma-persistence.spec.md
@@ -4,9 +4,10 @@ module: prisma/persistence
 source_file: packages/adapters/prisma/src/index.ts
 status: implemented
 exports:
-  - createPrismaAdapter
-  - PrismaAdapterConfig
-  - PrismaAdapterResult
+  - PrismaAdapter
+  - createPrismaAdapter (deprecated)
+  - PrismaAdapterConfig (deprecated)
+  - PrismaAdapterResult (deprecated)
   - PrismaAggregateStateTableConfig
   - PrismaStateTableColumnMap
   - createPrismaPersistence
@@ -27,6 +28,7 @@ depends_on:
   - core/persistence/unit-of-work
   - core/persistence/snapshot
   - core/persistence/outbox
+  - core/persistence/adapter
 docs:
   - running/orm-adapters.mdx
 ---
@@ -1044,4 +1046,145 @@ it("should save outbox entries within a UoW transaction", async () => {
   const events = await infra.eventSourcedPersistence.load("Order", "o-1");
   expect(events).toHaveLength(1);
 });
+```
+
+---
+
+## PrismaAdapter (Class-Based API)
+
+> Class-based adapter that implements `PersistenceAdapter` for use with `wireDomain({ persistenceAdapter })`. Replaces the lower-level `createPrismaAdapter` builder with a simpler constructor.
+
+### Type Contract
+
+````ts
+import type {
+  PersistenceAdapter,
+  EventSourcedAggregatePersistence,
+  StateStoredAggregatePersistence,
+  SagaPersistence,
+  UnitOfWorkFactory,
+  SnapshotStore,
+  OutboxStore,
+  AggregateLocker,
+} from "@noddde/core";
+
+/**
+ * Prisma-backed persistence adapter.
+ *
+ * Uses built-in Prisma models (NodddeEvent, NodddeAggregateState, etc.)
+ * for all stores. No configuration needed beyond the PrismaClient instance.
+ *
+ * @example
+ * ```ts
+ * import { PrismaAdapter } from "@noddde/prisma";
+ *
+ * const adapter = new PrismaAdapter(prisma);
+ * const domain = await wireDomain(definition, { persistenceAdapter: adapter });
+ * ```
+ */
+export class PrismaAdapter implements PersistenceAdapter {
+  constructor(prisma: any);
+
+  /** Always provided. */
+  unitOfWorkFactory: UnitOfWorkFactory;
+  /** Always provided. */
+  eventSourcedPersistence: EventSourcedAggregatePersistence;
+  /** Always provided. */
+  stateStoredPersistence: StateStoredAggregatePersistence;
+  /** Always provided. */
+  sagaPersistence: SagaPersistence;
+  /** Always provided. */
+  snapshotStore: SnapshotStore;
+  /** Always provided. */
+  outboxStore: OutboxStore;
+  /** Advisory locker. Available for PostgreSQL, MySQL, MariaDB. */
+  aggregateLocker?: AggregateLocker;
+
+  /**
+   * Returns a StateStoredAggregatePersistence bound to a dedicated Prisma model.
+   *
+   * @param model - The Prisma model name (e.g., "order").
+   * @param columns - Optional column mapping overrides.
+   */
+  stateStored(
+    model: string,
+    columns?: Partial<PrismaStateTableColumnMap>,
+  ): StateStoredAggregatePersistence;
+
+  /**
+   * Calls `prisma.$disconnect()` to close the connection pool.
+   */
+  close(): Promise<void>;
+}
+````
+
+### Behavioral Requirements (PrismaAdapter)
+
+29. The constructor accepts a PrismaClient instance and creates all persistence stores using built-in Prisma models.
+30. All persistence stores are created eagerly in the constructor.
+31. All persistence instances share a single `PrismaTransactionStore`, ensuring UoW atomicity.
+32. `aggregateLocker` is provided for databases that support advisory locks (PostgreSQL, MySQL, MariaDB). It is `undefined` for SQLite.
+33. `stateStored(model, columns?)` returns a `StateStoredAggregatePersistence` bound to the given Prisma model. The returned persistence shares the same transaction store.
+34. `close()` calls `prisma.$disconnect()` to clean up the connection pool.
+35. `isPersistenceAdapter(new PrismaAdapter(prisma))` returns `true`.
+36. The existing `createPrismaAdapter` function is marked `@deprecated` and delegates to `PrismaAdapter` internally.
+
+### Deprecation
+
+`createPrismaAdapter` is deprecated in favor of `PrismaAdapter`. It continues to work for backward compatibility.
+
+```ts
+/** @deprecated Use `new PrismaAdapter(prisma)` instead. */
+export function createPrismaAdapter(
+  prisma: any,
+  config?: PrismaAdapterConfig,
+): PrismaAdapterResult;
+```
+
+### Test Scenarios (PrismaAdapter)
+
+### PrismaAdapter implements PersistenceAdapter
+
+```ts
+import { isPersistenceAdapter } from "@noddde/core";
+import { PrismaAdapter } from "@noddde/prisma";
+
+const adapter = new PrismaAdapter(prisma);
+expect(isPersistenceAdapter(adapter)).toBe(true);
+```
+
+### PrismaAdapter provides all stores
+
+```ts
+const adapter = new PrismaAdapter(prisma);
+
+expect(adapter.unitOfWorkFactory).toBeDefined();
+expect(adapter.eventSourcedPersistence).toBeDefined();
+expect(adapter.stateStoredPersistence).toBeDefined();
+expect(adapter.sagaPersistence).toBeDefined();
+expect(adapter.snapshotStore).toBeDefined();
+expect(adapter.outboxStore).toBeDefined();
+```
+
+### PrismaAdapter.stateStored returns dedicated persistence
+
+```ts
+const adapter = new PrismaAdapter(prisma);
+const dedicated = adapter.stateStored("order");
+
+expect(dedicated).toBeDefined();
+expect(dedicated.save).toBeTypeOf("function");
+expect(dedicated.load).toBeTypeOf("function");
+```
+
+### PrismaAdapter close disconnects client
+
+```ts
+const disconnectSpy = vi
+  .spyOn(prisma, "$disconnect")
+  .mockResolvedValue(undefined);
+const adapter = new PrismaAdapter(prisma);
+await adapter.close();
+
+expect(disconnectSpy).toHaveBeenCalledOnce();
 ```

--- a/specs/typeorm/typeorm-persistence.spec.md
+++ b/specs/typeorm/typeorm-persistence.spec.md
@@ -4,9 +4,10 @@ module: typeorm/persistence
 source_file: packages/adapters/typeorm/src/index.ts
 status: implemented
 exports:
-  - createTypeORMAdapter
-  - TypeORMAdapterConfig
-  - TypeORMAdapterResult
+  - TypeORMAdapter
+  - createTypeORMAdapter (deprecated)
+  - TypeORMAdapterConfig (deprecated)
+  - TypeORMAdapterResult (deprecated)
   - TypeORMAggregateStateTableConfig
   - TypeORMStateTableColumnMap
   - createTypeORMPersistence (deprecated)
@@ -31,6 +32,7 @@ depends_on:
   - core/persistence/unit-of-work
   - core/persistence/snapshot
   - core/persistence/outbox
+  - core/persistence/adapter
 docs:
   - running/orm-adapters.mdx
 ---
@@ -1156,4 +1158,143 @@ it("should save outbox entries within a UoW transaction", async () => {
   const events = await infra.eventSourcedPersistence.load("Order", "o-1");
   expect(events).toHaveLength(1);
 });
+```
+
+---
+
+## TypeORMAdapter (Class-Based API)
+
+> Class-based adapter that implements `PersistenceAdapter` for use with `wireDomain({ persistenceAdapter })`. Replaces the lower-level `createTypeORMAdapter` builder with a simpler constructor.
+
+### Type Contract
+
+````ts
+import type {
+  PersistenceAdapter,
+  EventSourcedAggregatePersistence,
+  StateStoredAggregatePersistence,
+  SagaPersistence,
+  UnitOfWorkFactory,
+  SnapshotStore,
+  OutboxStore,
+  AggregateLocker,
+} from "@noddde/core";
+
+/**
+ * TypeORM-backed persistence adapter.
+ *
+ * Uses built-in entity classes (NodddeEventEntity, NodddeAggregateStateEntity, etc.)
+ * for all stores. No configuration needed beyond the DataSource instance.
+ *
+ * @example
+ * ```ts
+ * import { TypeORMAdapter } from "@noddde/typeorm";
+ *
+ * const adapter = new TypeORMAdapter(dataSource);
+ * const domain = await wireDomain(definition, { persistenceAdapter: adapter });
+ * ```
+ */
+export class TypeORMAdapter implements PersistenceAdapter {
+  constructor(dataSource: any);
+
+  /** Always provided. */
+  unitOfWorkFactory: UnitOfWorkFactory;
+  /** Always provided. */
+  eventSourcedPersistence: EventSourcedAggregatePersistence;
+  /** Always provided. */
+  stateStoredPersistence: StateStoredAggregatePersistence;
+  /** Always provided. */
+  sagaPersistence: SagaPersistence;
+  /** Always provided. */
+  snapshotStore: SnapshotStore;
+  /** Always provided. */
+  outboxStore: OutboxStore;
+  /** Dialect-aware advisory locker. Available for PostgreSQL, MySQL, MariaDB, MSSQL. */
+  aggregateLocker?: AggregateLocker;
+
+  /**
+   * Returns a StateStoredAggregatePersistence bound to a dedicated TypeORM entity.
+   *
+   * @param entity - A TypeORM entity class.
+   * @param columns - Optional column mapping overrides.
+   */
+  stateStored(
+    entity: Function,
+    columns?: Partial<TypeORMStateTableColumnMap>,
+  ): StateStoredAggregatePersistence;
+
+  /**
+   * Calls `dataSource.destroy()` to close the connection pool.
+   */
+  close(): Promise<void>;
+}
+````
+
+### Behavioral Requirements (TypeORMAdapter)
+
+29. The constructor accepts a TypeORM DataSource instance and creates all persistence stores using built-in entity classes.
+30. All persistence stores are created eagerly in the constructor.
+31. All persistence instances share a single `TypeORMTransactionStore`, ensuring UoW atomicity.
+32. `aggregateLocker` is provided for databases that support advisory locks (PostgreSQL, MySQL, MariaDB, MSSQL). It is `undefined` for SQLite/better-sqlite3.
+33. `stateStored(entity, columns?)` returns a `StateStoredAggregatePersistence` bound to the given entity class. The returned persistence shares the same transaction store.
+34. `close()` calls `dataSource.destroy()` to clean up the connection pool.
+35. `isPersistenceAdapter(new TypeORMAdapter(dataSource))` returns `true`.
+36. The existing `createTypeORMAdapter` function is marked `@deprecated` and delegates to `TypeORMAdapter` internally.
+
+### Deprecation
+
+`createTypeORMAdapter` is deprecated in favor of `TypeORMAdapter`. It continues to work for backward compatibility.
+
+```ts
+/** @deprecated Use `new TypeORMAdapter(dataSource)` instead. */
+export function createTypeORMAdapter<const C extends TypeORMAdapterConfig>(
+  dataSource: any,
+  config?: C,
+): TypeORMAdapterResult<C>;
+```
+
+### Test Scenarios (TypeORMAdapter)
+
+### TypeORMAdapter implements PersistenceAdapter
+
+```ts
+import { isPersistenceAdapter } from "@noddde/core";
+import { TypeORMAdapter } from "@noddde/typeorm";
+
+const adapter = new TypeORMAdapter(dataSource);
+expect(isPersistenceAdapter(adapter)).toBe(true);
+```
+
+### TypeORMAdapter provides all stores
+
+```ts
+const adapter = new TypeORMAdapter(dataSource);
+
+expect(adapter.unitOfWorkFactory).toBeDefined();
+expect(adapter.eventSourcedPersistence).toBeDefined();
+expect(adapter.stateStoredPersistence).toBeDefined();
+expect(adapter.sagaPersistence).toBeDefined();
+expect(adapter.snapshotStore).toBeDefined();
+expect(adapter.outboxStore).toBeDefined();
+```
+
+### TypeORMAdapter.stateStored returns dedicated persistence
+
+```ts
+const adapter = new TypeORMAdapter(dataSource);
+const dedicated = adapter.stateStored(CustomEntity);
+
+expect(dedicated).toBeDefined();
+expect(dedicated.save).toBeTypeOf("function");
+expect(dedicated.load).toBeTypeOf("function");
+```
+
+### TypeORMAdapter close destroys data source
+
+```ts
+const destroySpy = vi.spyOn(dataSource, "destroy").mockResolvedValue(undefined);
+const adapter = new TypeORMAdapter(dataSource);
+await adapter.close();
+
+expect(destroySpy).toHaveBeenCalledOnce();
 ```


### PR DESCRIPTION
## Summary

- Introduce `PersistenceAdapter` interface in `@noddde/core` — a single interface for community adapter authors to implement
- Add class-based adapters: `DrizzleAdapter`, `PrismaAdapter`, `TypeORMAdapter` that implement the interface
- Add `persistenceAdapter` property to `DomainWiring` so `wireDomain` auto-resolves persistence, saga, UoW, snapshots, outbox, idempotency, and locking from the adapter
- Support string shorthands: `persistence: 'event-sourced' | 'state-stored'` and `concurrency: 'pessimistic' | 'optimistic'`
- Full backward compatibility — existing wiring patterns continue to work unchanged

**Before:**
```ts
const drizzleInfra = createDrizzleAdapter(db, { eventStore, sagaStore, stateStore, snapshotStore });
const domain = await wireDomain(definition, {
  aggregates: { Room: { persistence: () => drizzleInfra.eventSourcedPersistence, snapshots: { store: () => drizzleInfra.snapshotStore, strategy: everyNEvents(50) } } },
  sagas: { persistence: () => drizzleInfra.sagaPersistence },
  unitOfWork: () => drizzleInfra.unitOfWorkFactory,
});
```

**After:**
```ts
const adapter = new DrizzleAdapter(db);
const domain = await wireDomain(definition, {
  persistenceAdapter: adapter,
  aggregates: { Room: { persistence: 'event-sourced', snapshots: { strategy: everyNEvents(50) } } },
});
```

## Test plan

- [ ] `tsc --noEmit` passes in `packages/core` and `packages/engine` (verified locally with path overrides for worktree)
- [ ] `tsc --noEmit` passes in all three adapter packages (verified locally)
- [ ] New tests: `packages/core/src/__tests__/persistence/adapter.test.ts` (8 cases)
- [ ] New tests: `packages/engine/src/__tests__/integration/adapter-wiring.test.ts` (25 cases)
- [ ] All existing tests pass unchanged (backward compatibility)
- [ ] `prettier --check` clean on all changed files
- [ ] `turbo lint` passes (10/10 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)