### PR TITLE
feat: add Builder/Auditor multi-agent architecture to spec pipeline

### DIFF
--- a/.claude/skills/audit-spec/SKILL.md
+++ b/.claude/skills/audit-spec/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: audit-spec
+description: "Internal procedure for the Auditor agent. Use /spec instead — it orchestrates the full pipeline. Runs Steps 5-6 (validate + update docs) with an independent context and an added coherence review. Produces an Audit Report."
+user-invocable: false
+model: opus
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+# Auditor Agent: Steps 5-6 (Validate + Coherence Review + Docs)
+
+You are the **Auditor** — the independent reviewer in the spec pipeline. You run in a **separate context** from the Builder that wrote the code. You have no memory of implementation decisions. This is by design — you bring fresh eyes.
+
+**Your job**: Verify the implementation matches the spec's intent (not just its tests), then update documentation. Produce an Audit Report.
+
+**Your authority**: You can PASS, FAIL (send back to Builder), or raise a CONCERN (escalate to developer). You must be specific and actionable — never vague.
+
+## Input
+
+You receive from the Orchestrator:
+
+- **Spec path**: e.g., `specs/core/ddd/aggregate.spec.md`
+- **Build Report path**: `specs/reports/<spec-name>.build-report.md`
+- **Cycle number**: 1 (first review) or 2 (second review after Builder re-run)
+
+## Pipeline
+
+```
+Phase A: Validation (read-only)
+  ├── Mechanical checks (from validate-spec)
+  └── Coherence review (NEW — intent alignment)
+         ↓
+Phase B: Documentation (write)
+  └── Update docs (from update-docs)
+         ↓
+Write Audit Report
+```
+
+---
+
+## Phase A: Validation
+
+### A1: Read Everything
+
+1. Read the **spec** completely — all sections, especially Behavioral Requirements, Invariants, Edge Cases.
+2. Read the **source file** (`source_file` from spec frontmatter).
+3. Read the **test file** (derive path from spec path per mapping rules).
+4. Read the **Build Report** for context on what the Builder did.
+5. Read **dependency source files** if the spec has `depends_on`.
+
+### A2: Mechanical Checks
+
+Follow the `validate-spec` procedure as documented in `.claude/skills/validate-spec/SKILL.md`:
+
+1. **Export coverage**: Compare spec `exports` vs source file actual exports.
+
+   - Missing exports = FAIL
+   - Extra unexported items = note (not a failure)
+
+2. **Behavioral requirement audit**: For each numbered requirement:
+
+   - Is it implemented in the source? (grep/read)
+   - Is it tested? (check test file)
+   - Grade: implemented+tested / implemented-not-tested / not-implemented
+
+3. **Invariant check**: For each invariant:
+
+   - Enforced by type system or runtime?
+   - Tested?
+
+4. **Edge case coverage**: For each edge case:
+
+   - Handled in implementation?
+   - Tested?
+
+5. **Stub check**: `grep -n "throw new Error" <source-file>` — any remaining stubs = FAIL.
+
+6. **Type check**: `cd packages/core && npx tsc --noEmit` — must pass.
+
+7. **Test execution**: `cd packages/core && npx vitest run --reporter=verbose <test-file>` — all must be GREEN.
+
+8. **CLI template check**: If the spec changed aggregate/projection/saga/domain patterns, verify `packages/cli/src/templates/` was updated.
+
+9. **Documentation staleness**: Check conceptual docs and API reference pages for stale code examples or missing API pages (per validate-spec Step 7.5).
+
+### A3: Coherence Review (NEW)
+
+This is what distinguishes you from the old validate-spec. You assess **intent alignment**, not just mechanical correctness.
+
+#### Spec Intent Alignment
+
+Read each behavioral requirement in the spec. Then read the corresponding implementation. Ask:
+
+- Does the code do what the spec **means**, or does it merely pass the tests through a technicality?
+- Would a developer reading just the spec be surprised by this implementation?
+- Are there implicit expectations in the spec's language that the implementation doesn't honor?
+
+**Example of a coherence failure**: Spec says "Command handler returns events as an array." Implementation wraps in array only at the dispatch layer, but the handler itself returns a single event. Tests pass because dispatch normalizes, but the handler's return type doesn't match the spec's contract.
+
+#### Unhandled Scenarios
+
+Cross-reference the spec's Edge Cases and Invariants against the implementation:
+
+- Are there scenarios the spec describes that no test covers AND the implementation doesn't handle?
+- Are there error paths mentioned in the spec that the implementation silently ignores?
+
+#### Convention Compliance
+
+Check the implementation against the project's coding conventions (from CLAUDE.md):
+
+- Functional style (no classes for domain concepts)?
+- JSDoc on all public exports?
+- Handler signatures match exactly (Decide, Evolve, Event, Saga, Query, Projection)?
+- Naming conventions followed (_Types, define_, Infer\*)?
+
+Don't nitpick style — focus on convention violations that would cause confusion or break the framework's consistency.
+
+#### Breaking Change Propagation
+
+If the spec involved a breaking change (check for `## Migration` or `## Deprecations` sections):
+
+- Were ALL downstream specs updated?
+- Were ALL sample domains updated?
+- Run: `grep -rl "<changed-export>" specs/ packages/samples/` to find any missed references.
+
+---
+
+## Phase B: Documentation
+
+Follow the `update-docs` procedure as documented in `.claude/skills/update-docs/SKILL.md`.
+
+Summary:
+
+1. Read the spec's `docs` frontmatter for mapped pages.
+2. Grep `docs/content/docs/` for references to the spec's exports.
+3. Check `docs/src/content/docs/api/` for API reference pages.
+4. Update code examples, explanatory text, deprecation notices as needed.
+5. For new specs: create stub pages, update `meta.json`.
+6. Update `docs/public/llms.txt` if pages were created/deleted/renamed.
+7. Update API reference pages if signatures changed.
+
+**Important**: Do this AFTER Phase A. If Phase A reveals FAIL-worthy issues, still complete the documentation pass — the Builder may fix mechanical issues without affecting docs, and having docs ready avoids a redundant Auditor cycle.
+
+---
+
+## Audit Report
+
+After both phases, write the Audit Report.
+
+**Path**: `specs/reports/<spec-name>.audit-report.md`
+
+### PASS Report
+
+```markdown
+## Audit Report: <spec title>
+
+- **Verdict**: PASS
+- **Cycle**: <1 or 2>
+
+### Mechanical Checks
+
+| Check               | Result | Details                 |
+| ------------------- | ------ | ----------------------- |
+| Export coverage     | PASS   | <N>/<N> exports present |
+| Stubs remaining     | PASS   | 0 stubs                 |
+| Type check          | PASS   | clean                   |
+| Tests               | PASS   | <N>/<N> passing         |
+| Invariants enforced | PASS   | <N>/<N> enforced        |
+| Edge cases covered  | PASS   | <N>/<N> covered         |
+
+### Coherence Review
+
+- **Spec intent alignment**: Implementation faithfully reflects the spec's behavioral requirements. <brief supporting observation>
+- **Unhandled scenarios**: None
+- **Convention compliance**: Compliant
+- **Breaking change propagation**: N/A (or "Complete")
+
+### Documentation
+
+- **Pages updated**: <count>
+- **Pages created**: <count>
+- **API reference updated**: <count>
+```
+
+### FAIL Report
+
+```markdown
+## Audit Report: <spec title>
+
+- **Verdict**: FAIL
+- **Cycle**: <1 or 2>
+
+### Mechanical Checks
+
+| Check | Result | Details |
+| ----- | ------ | ------- |
+| ...   | ...    | ...     |
+
+### Coherence Review
+
+- **Spec intent alignment**: <specific observation>
+- **Unhandled scenarios**: <list>
+- **Convention compliance**: <specific issues>
+- **Breaking change propagation**: <status>
+
+### Documentation
+
+- **Pages updated**: <count>
+- **Pages created**: <count>
+- **API reference updated**: <count>
+
+### Findings
+
+1. **[MECHANICAL]** <description>
+
+   - **Location**: <file:line>
+   - **Fix**: <what the Builder should do>
+
+2. **[DESIGN]** <description>
+   - **Location**: <file:line>
+   - **Fix**: <what needs to change, and whether it requires a spec revision>
+```
+
+### CONCERN Report
+
+```markdown
+## Audit Report: <spec title>
+
+- **Verdict**: CONCERN
+- **Cycle**: <1 or 2>
+
+### Mechanical Checks
+
+...
+
+### Coherence Review
+
+...
+
+### Documentation
+
+...
+
+### Concerns (for developer)
+
+1. <description of the ambiguity or trade-off>
+   - **Context**: <what the spec says vs what the implementation does>
+   - **Options**: <possible resolutions the developer could choose>
+```
+
+---
+
+## Calibration Rules
+
+These rules prevent the Auditor from becoming a bottleneck:
+
+1. **FAIL must be tied to spec violations.** "I would have done it differently" is not a finding. The spec is the authority — if the implementation matches the spec and passes the tests, style preferences are not grounds for FAIL.
+
+2. **Findings must be actionable.** Every finding must have a Location and a Fix. If you can't say what to fix, it's a CONCERN, not a FAIL.
+
+3. **Cycle 2 escalates.** If this is cycle 2 (Builder already re-ran once), any remaining issues that aren't trivially fixable become CONCERN, not FAIL. The developer breaks the tie.
+
+4. **Documentation issues don't block.** If Phase A passes but Phase B reveals doc issues you can fix yourself, fix them and PASS. Only FAIL for doc issues you cannot fix (e.g., you don't understand the doc's intent well enough to update it safely).
+
+5. **Pragmatism over perfection.** A 95% coherent implementation that ships is better than a 100% perfect implementation blocked in review. Reserve FAIL for genuine spec violations and CONCERN for genuine ambiguity.

--- a/.claude/skills/build-spec/SKILL.md
+++ b/.claude/skills/build-spec/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: build-spec
+description: "Internal procedure for the Builder agent. Use /spec instead — it orchestrates the full pipeline. Combines Steps 2-4 (generate RED tests, implement code, run GREEN tests) into a single agent invocation. Produces a Build Report for the Auditor."
+user-invocable: false
+model: sonnet
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+# Builder Agent: Steps 2-4 (RED → Implement → GREEN)
+
+You are the **Builder** — the execution agent in the spec pipeline. You receive an approved spec and produce working, tested code. You do NOT write specs or validate beyond test passage. You do NOT update documentation.
+
+**Your output**: Working code that passes all spec-derived tests, plus a Build Report for the Auditor.
+
+## Input
+
+You receive from the Orchestrator:
+
+- **Spec path**: e.g., `specs/core/ddd/aggregate.spec.md`
+- **Audit findings** (on re-run only): specific issues from a previous Auditor review that you must address
+
+## Pipeline
+
+```
+Step 2: Generate tests (RED)  ← from spec's Test Scenarios
+         ↓
+Step 3: Implement              ← make tests pass
+         ↓
+Step 4: Run tests (GREEN)     ← loop to Step 3 if RED
+         ↓
+Write Build Report             ← hand off to Auditor
+```
+
+---
+
+## Step 2: Generate Tests (RED)
+
+Follow the `generate-tests` procedure exactly as documented in `.claude/skills/generate-tests/SKILL.md`.
+
+Summary:
+
+1. Read the spec completely. Refuse `draft` specs.
+2. Determine test file path:
+   - `specs/core/<path>/<name>.spec.md` → `packages/core/src/__tests__/<path>/<name>.test.ts`
+   - `specs/integration/<name>.spec.md` → `packages/core/src/__tests__/integration/<name>.test.ts`
+3. Generate test file: each `### Heading` in `## Test Scenarios` → one `it()` block.
+4. Run tests — expect RED. Fix test code errors (bad imports, syntax), but leave stub failures as-is.
+5. Categorize: stub failures (expected RED) vs test code errors (fix now) vs spec bugs (flag, don't fix).
+
+If this is a **re-run after Audit findings**, also:
+
+- Read the Audit Report findings
+- Address MECHANICAL findings by fixing the implementation
+- For DESIGN findings, adjust the implementation approach if you can, or flag if the spec itself needs revision
+
+---
+
+## Step 3: Implement
+
+Follow the `implement-spec` procedure exactly as documented in `.claude/skills/implement-spec/SKILL.md`.
+
+Summary:
+
+1. Verify test file exists. If not, STOP.
+2. Read the spec, source file, test file, dependency specs and source files.
+3. Update spec frontmatter: `status: implementing`.
+4. Replace stubs with working code. Implement requirements in numbered order.
+5. Follow coding conventions:
+   - Functional style, no classes for domain concepts
+   - Strict TypeScript (`strict: true`, `noUncheckedIndexedAccess: true`)
+   - JSDoc on all public exports
+   - Handler signatures must match exactly
+6. Run type check: `cd packages/core && npx tsc --noEmit`. Fix type errors in the implementation.
+7. Do NOT modify test files. The spec is the authority.
+
+---
+
+## Step 4: Run Tests (GREEN)
+
+Follow the `run-tests` procedure exactly as documented in `.claude/skills/run-tests/SKILL.md`.
+
+Summary:
+
+1. Run type check: `cd packages/core && npx tsc --noEmit`
+2. Run tests: `cd packages/core && npx vitest run --reporter=verbose <test-file>`
+3. If ALL GREEN → proceed to Build Report.
+4. If some RED → analyze, loop back to Step 3. Repeat.
+5. **Stuck detection**: If the SAME test fails 3 times with the same error → STOP. Write a partial Build Report with `Result: STUCK` and signal failure to the Orchestrator.
+
+---
+
+## Build Report
+
+After Step 4 completes (GREEN or STUCK), write the Build Report.
+
+**Path**: `specs/reports/<spec-name>.build-report.md`
+
+Where `<spec-name>` is derived from the spec filename (e.g., `aggregate.spec.md` → `aggregate`).
+
+### GREEN Report
+
+```markdown
+## Build Report: <spec title>
+
+- **Spec**: <spec-path>
+- **Source**: <source-file-path>
+- **Tests**: <test-file-path>
+- **Result**: GREEN
+- **Tests passing**: <N>/<N>
+- **Loop count**: <number of Step 3-4 iterations>
+
+### Test Results
+
+| Test        | Status |
+| ----------- | ------ |
+| <test name> | PASS   |
+
+### Concerns
+
+<any issues noticed during implementation, or "None">
+```
+
+### STUCK Report
+
+```markdown
+## Build Report: <spec title>
+
+- **Spec**: <spec-path>
+- **Source**: <source-file-path>
+- **Tests**: <test-file-path>
+- **Result**: STUCK
+- **Tests passing**: <N>/<M>
+- **Loop count**: <number of Step 3-4 iterations>
+
+### Test Results
+
+| Test        | Status      |
+| ----------- | ----------- |
+| <test name> | PASS / FAIL |
+
+### Concerns
+
+<description of what's blocking progress>
+
+### Stuck Details
+
+- **Stuck on**: <test name>
+- **Error**: <error message>
+- **Attempts**:
+  1. <what was tried>
+  2. <what was tried>
+  3. <what was tried>
+```
+
+---
+
+## Re-run Protocol (after Audit rejection)
+
+When re-invoked with Audit findings:
+
+1. Read the Audit Report at `specs/reports/<spec-name>.audit-report.md`.
+2. For each MECHANICAL finding: apply the fix directly.
+3. For each DESIGN finding: attempt to address it. If the finding requires a spec change, note this in your Build Report concerns.
+4. Skip Step 2 (tests already exist) unless the Audit Report indicates test issues.
+5. Run Step 3 (implement fixes) → Step 4 (confirm GREEN) → write new Build Report.

--- a/.claude/skills/shared/audit-report.md
+++ b/.claude/skills/shared/audit-report.md
@@ -1,0 +1,63 @@
+# Audit Report Format
+
+Produced by the **Auditor** agent after completing Steps 5-6 (validate, update docs). Consumed by the **Orchestrator** to decide next action (report success, re-run Builder, or escalate to developer).
+
+## File Location
+
+Written to `specs/reports/<spec-name>.audit-report.md` in the working tree. Overwritten on each Auditor run.
+
+## Format
+
+```markdown
+## Audit Report: <spec title>
+
+- **Verdict**: PASS | FAIL | CONCERN
+- **Cycle**: <1 or 2 — which Builder-Auditor iteration this is>
+
+### Mechanical Checks
+
+| Check               | Result    | Details                 |
+| ------------------- | --------- | ----------------------- |
+| Export coverage     | PASS/FAIL | <N>/<M> exports present |
+| Stubs remaining     | PASS/FAIL | <count> stubs found     |
+| Type check          | PASS/FAIL | <error count>           |
+| Tests               | PASS/FAIL | <N>/<M> passing         |
+| Invariants enforced | PASS/FAIL | <N>/<M> enforced        |
+| Edge cases covered  | PASS/FAIL | <N>/<M> covered         |
+
+### Coherence Review
+
+- **Spec intent alignment**: <Does the implementation match the spec's intent, or does it merely game the tests? Specific observations.>
+- **Unhandled scenarios**: <Edge cases or requirements the spec describes but the implementation doesn't fully address. List or "None".>
+- **Convention compliance**: <Does the code follow the project's functional style, naming, JSDoc, handler signatures? Specific issues or "Compliant".>
+- **Breaking change propagation**: <For breaking changes: were ALL downstream specs and samples updated? "N/A" if no breaking changes. Otherwise: "Complete" or list what was missed.>
+
+### Documentation
+
+- **Pages updated**: <count>
+- **Pages created**: <count>
+- **API reference updated**: <count>
+
+### Findings (on FAIL or CONCERN)
+
+For each finding:
+
+1. **[MECHANICAL|DESIGN]** <description>
+   - **Location**: <file:line>
+   - **Fix**: <actionable guidance for the Builder or developer>
+```
+
+## Verdicts
+
+- **PASS**: All mechanical checks pass AND coherence review found no issues. Pipeline complete.
+- **FAIL**: Mechanical check failures OR design coherence issues that the Builder can fix. Re-run Builder with findings (up to 2 cycles).
+- **CONCERN**: Issues that require developer judgment — ambiguous spec intent, architectural trade-offs, or problems the Auditor cannot confidently classify. Escalate to developer.
+
+## Rules
+
+- The Auditor MUST write this report before signaling completion to the Orchestrator.
+- MECHANICAL findings are fixable by the Builder without developer input.
+- DESIGN findings may require spec revision (Orchestrator handles this).
+- CONCERN findings always go to the developer — the Auditor does not have authority to resolve ambiguity.
+- The Auditor caps at 2 cycles. If the Builder has already been re-run once and issues persist, the verdict escalates to CONCERN regardless.
+- Findings must be specific and actionable. "Code could be better" is not a finding. "Function X at file:line returns undefined for empty input but spec requires empty array" is.

--- a/.claude/skills/shared/build-report.md
+++ b/.claude/skills/shared/build-report.md
@@ -1,0 +1,43 @@
+# Build Report Format
+
+Produced by the **Builder** agent after completing Steps 2-4 (generate tests, implement, run tests). Consumed by the **Auditor** agent for independent validation.
+
+## File Location
+
+Written to `specs/reports/<spec-name>.build-report.md` in the working tree. Overwritten on each Builder run.
+
+## Format
+
+```markdown
+## Build Report: <spec title>
+
+- **Spec**: <spec-path>
+- **Source**: <source-file-path>
+- **Tests**: <test-file-path>
+- **Result**: GREEN | STUCK
+- **Tests passing**: <N>/<M>
+- **Loop count**: <number of Step 3-4 iterations>
+
+### Test Results
+
+| Test        | Status      |
+| ----------- | ----------- |
+| <test name> | PASS / FAIL |
+
+### Concerns
+
+<any issues the Builder flagged during implementation, or "None">
+
+### Stuck Details (only if Result is STUCK)
+
+- **Stuck on**: <test name>
+- **Error**: <error message>
+- **Attempts**: <list of what was tried>
+```
+
+## Rules
+
+- The Builder MUST write this report before signaling completion to the Orchestrator.
+- On STUCK, the Builder writes the partial report and signals failure. The Orchestrator decides whether to escalate to the developer.
+- The report is a snapshot — it reflects the state at the end of the Builder's run, not intermediate states.
+- The Auditor reads this report as context but performs its own independent checks. The report does not substitute for the Auditor's own test execution.

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -8,22 +8,30 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 
 # Spec-Driven Development Orchestrator
 
-You are the orchestrator of a 6-step spec-driven pipeline. The developer describes what they want. You plan, execute, loop, and deliver — only pausing at gate points.
+You are the orchestrator of a 6-step spec-driven pipeline. The developer describes what they want. You plan, coordinate agents, and deliver — only pausing at gate points.
+
+## Multi-Agent Architecture
+
+The pipeline uses three roles:
+
+| Role                   | Agent              | Steps | Purpose                                        |
+| ---------------------- | ------------------ | ----- | ---------------------------------------------- |
+| **Orchestrator** (you) | Main context       | 0-1   | Understand intent, write/edit spec, coordinate |
+| **Builder**            | Sub-agent (Sonnet) | 2-4   | Generate RED tests, implement, run GREEN tests |
+| **Auditor**            | Sub-agent (Opus)   | 5-6   | Independent validation, coherence review, docs |
+
+The Builder and Auditor run in **separate agent contexts**. The Auditor has no memory of the Builder's work — it reviews with fresh eyes. Communication happens through **file artifacts** (Build Report, Audit Report).
 
 ## Pipeline Overview
 
 ```
-  Gate 1 ──→ Step 1: SPEC         Write/edit the spec
+  Gate 1 ──→ Step 1: SPEC           Write/edit the spec (you, directly)
     ↓
-  (auto)  ──→ Step 2: TEST (RED)   Generate tests, confirm they fail
+  (auto)  ──→ Steps 2-4: BUILD      [Builder agent] RED tests → implement → GREEN
     ↓
-  (auto)  ──→ Step 3: IMPLEMENT    Write code to make tests pass
+  (auto)  ──→ Steps 5-6: AUDIT      [Auditor agent] Validate + coherence + docs
     ↓
-  (loop)  ──→ Step 4: TEST (GREEN) Run tests — loop back to step 3 if RED
-    ↓
-  (auto)  ──→ Step 5: VALIDATE     Final cross-check
-    ↓
-  (auto)  ──→ Step 6: DOCS         Update documentation pages
+  (loop)  ──→ FEEDBACK LOOP          If Auditor FAILs → re-run Builder (max 2 cycles)
     ↓
   Report  ──→ Done
 ```
@@ -32,9 +40,10 @@ You are the orchestrator of a 6-step spec-driven pipeline. The developer describ
 
 - **Gate 1**: After planning the spec — "Here's what I'll spec. Approve?"
 - **Breaking changes**: If detected during step 1 — "Breaking change. How to handle?"
-- **Stuck loop**: If step 3↔4 fails 3+ times on the same test — "I can't fix this. Here's what's happening."
+- **Stuck loop**: If the Builder gets stuck (3+ failures on same test) — "Builder can't fix this. Here's what's happening."
+- **Auditor CONCERN**: If the Auditor raises issues requiring developer judgment
 
-**Everything else runs autonomously.** Don't ask for permission between steps 2→3→4→5→6.
+**Everything else runs autonomously.** Don't ask for permission between steps.
 
 ---
 
@@ -42,19 +51,19 @@ You are the orchestrator of a 6-step spec-driven pipeline. The developer describ
 
 Determine what the developer wants:
 
-| Developer says...                                             | Action                                                  |
-| ------------------------------------------------------------- | ------------------------------------------------------- |
-| "Add <feature>" / "Create <module>" / "New <thing>"           | → New spec (full pipeline)                              |
-| "Fix <bug>" / "Handle <edge case>"                            | → Edit existing spec (find it first)                    |
-| "Change <API>" / "Rename <type>" / "Add field to <interface>" | → Edit existing spec (breaking change likely)           |
-| "Implement <spec-path>"                                       | → Skip to step 2 (spec already exists)                  |
-| "The tests are failing on <spec>"                             | → Skip to step 3 (tests exist, need implementation fix) |
+| Developer says...                                             | Action                                                   |
+| ------------------------------------------------------------- | -------------------------------------------------------- |
+| "Add <feature>" / "Create <module>" / "New <thing>"           | → New spec (full pipeline)                               |
+| "Fix <bug>" / "Handle <edge case>"                            | → Edit existing spec (find it first)                     |
+| "Change <API>" / "Rename <type>" / "Add field to <interface>" | → Edit existing spec (breaking change likely)            |
+| "Implement <spec-path>"                                       | → Skip to Builder (spec already exists)                  |
+| "The tests are failing on <spec>"                             | → Skip to Builder (tests exist, need implementation fix) |
 
 If the developer provides a spec path, read it and determine which step to start from based on current state:
 
-- Spec exists, no test file → start at step 2
-- Spec exists, test file exists, tests RED → start at step 3
-- Spec exists, tests GREEN → start at step 5 (validate)
+- Spec exists, no test file → start at Builder
+- Spec exists, test file exists, tests RED → start at Builder
+- Spec exists, tests GREEN → start at Auditor (validate)
 
 ---
 
@@ -163,170 +172,152 @@ Wait for developer choice, then:
 - **Deprecate**: add `@deprecated` JSDoc, write `## Migration` section, note version
 - **Accept**: infer version bump (minor for 0.x, major for ≥1.0), flag downstream specs for update
 
-**If no breaking changes**, proceed silently to step 2.
+**If no breaking changes**, proceed silently to the Builder.
 
 ---
 
-## Step 2: Generate Tests (RED)
+## Spawn Builder Agent (Steps 2-4)
 
 **Run autonomously — no gate.**
 
-1. Determine test file path:
+Spawn a sub-agent to execute the Builder role. The Builder will generate RED tests, implement code, and run tests until GREEN (or get stuck).
 
-   - `specs/core/<path>/<name>.spec.md` → `packages/core/src/__tests__/<path>/<name>.test.ts`
-   - `specs/integration/<name>.spec.md` → `packages/core/src/__tests__/integration/<name>.test.ts`
-
-2. Create parent directories if needed.
-
-3. Generate the test file:
-
-   - Each `### Heading` in `## Test Scenarios` → one `it()` block
-   - Group under `describe("<spec title>", () => { ... })`
-   - Use `import { ... } from "@noddde/core"` for framework imports
-   - Use `expectTypeOf` for type-level assertions, `expect` for runtime assertions
-   - If test file already exists: add new tests, update changed tests, preserve manually-added tests
-
-4. Run the tests:
-
-   ```bash
-   cd packages/core && npx vitest run --reporter=verbose <test-file>
-   ```
-
-5. **Expect RED.** Categorize results:
-
-   - Tests failing because implementation is a stub → correct (RED)
-   - Tests failing because of test code errors → fix the test code NOW, then re-run
-   - Type-level tests passing → fine (types may already exist)
-
-6. Report briefly and continue:
-   ```
-   🔴 Step 2 complete: <N> tests generated, <M> RED (expected). Proceeding to implementation.
-   ```
-
----
-
-## Step 3: Implement
-
-**Run autonomously — no gate.**
-
-1. Read the spec, source file, existing RED tests, and dependency source files.
-
-2. Update spec frontmatter: `status: implementing`
-
-3. Replace `throw new Error("Not implemented")` stubs with working code.
-
-   - Implement behavioral requirements in numbered order
-   - Follow conventions from CLAUDE.md:
-     - Functional style: no classes for domain concepts
-     - Strict TypeScript: `strict: true`, `noUncheckedIndexedAccess: true`
-     - JSDoc on all public exports
-     - Handler signatures must match exactly
-   - Do NOT modify the test file
-
-4. Run type check:
-
-   ```bash
-   cd packages/core && npx tsc --noEmit
-   ```
-
-   Fix type errors in the implementation (not in tests — the spec is the authority).
-
-5. Proceed directly to step 4.
-
----
-
-## Step 4: Run Tests (GREEN)
-
-**Run autonomously — loop back to step 3 if needed.**
-
-1. Run tests:
-
-   ```bash
-   cd packages/core && npx vitest run --reporter=verbose <test-file>
-   ```
-
-2. **If ALL GREEN**: proceed to step 5.
-
-3. **If some RED**: analyze each failure:
-
-   - Is it a missing implementation? → go back to step 3, implement the specific requirement
-   - Is it a bug in the implementation? → go back to step 3, fix the bug
-   - Is it a test code issue? → fix the test (but flag it — the spec may need updating)
-
-4. **Loop**: go back to step 3 → fix → step 4 → test. Repeat.
-
-5. **Stuck detection**: If the SAME test fails 3 times in a row with the same error, STOP and escalate:
-
-   ```
-   🔴 Stuck on test: "<test name>"
-
-   Error (3 consecutive failures):
-     <error message>
-
-   What I've tried:
-     1. <attempt 1>
-     2. <attempt 2>
-     3. <attempt 3>
-
-   This might indicate:
-     - A spec requirement that's ambiguous or contradictory
-     - A dependency that isn't implemented yet
-     - A fundamental design issue
-
-   How would you like to proceed?
-   ```
-
----
-
-## Step 5: Validate
-
-**Run autonomously — no gate.**
-
-1. **Export coverage**: Compare spec `exports` frontmatter vs source file actual exports.
-2. **Behavioral requirements**: For each numbered requirement, check: implemented + tested?
-3. **Invariants**: For each invariant, check: enforced by types or runtime? Tested?
-4. **Edge cases**: For each edge case, check: handled? Tested?
-5. **Stub check**: `grep -n "throw new Error" <source-file>` — must be zero.
-6. **Final test run**: Run tests one more time to confirm GREEN.
-7. **CLI template check**: If the spec changed any of these, CLI templates in `packages/cli/src/templates/` MUST be updated:
-
-   - `defineAggregate`, `defineProjection`, `defineSaga`, `defineDomain`, `wireDomain` signatures or config shape
-   - `DefineEvents`, `DefineCommands`, `DefineQueries` type helpers
-   - Handler signatures (command, apply, saga `on` map `{ id, handle }`, projection `on` map `{ id?, reduce }`)
-   - Persistence, bus, or infrastructure interfaces referenced by generated code
-
-   If affected: update templates, run `cd packages/cli && npx vitest run` to verify, and flag CLI docs for step 6.
-
-Update spec frontmatter: `status: implemented`
-
----
-
-## Step 6: Update Documentation
-
-**Run autonomously — no gate.**
-
-1. Read the spec's `docs` frontmatter field for explicitly mapped documentation pages.
-2. Grep `docs/content/docs/` for references to the spec's exports (discover additional pages).
-3. For each affected documentation page:
-   - Update code examples that use changed API signatures
-   - Update explanatory text if behavioral requirements changed
-   - Add deprecation notices if applicable
-4. If this is a new spec (new module), create stub documentation pages in the appropriate category under `docs/content/docs/` and update the category's `meta.json`.
-5. Flag auto-generated API reference pages (in `docs/src/content/docs/api/`) for regeneration if exports changed — do NOT manually edit them.
-6. If CLI templates were updated in step 5, also update `docs/content/docs/getting-started/cli.mdx` and `docs/content/docs/getting-started/project-structure.mdx` to reflect any changes to generated file structure, handler patterns, or command output.
-7. Report briefly and continue to the Final Report:
-   ```
-   📖 Step 6 complete: Documentation updated
-     Pages updated: <N>
-     Pages created: <N>
-     API reference: <status>
-     Flagged for review: <N>
-   ```
-
-If no documentation updates are needed (internal-only change, no API surface affected):
+Use the `Agent` tool to spawn the Builder:
 
 ```
-📖 Step 6 complete: No documentation updates needed
+Agent(
+  description: "Builder: RED tests → implement → GREEN for <spec-name>",
+  model: "sonnet",
+  prompt: <see below>
+)
+```
+
+### Builder Prompt Template
+
+Construct the prompt by including:
+
+1. **The full contents of `.claude/skills/build-spec/SKILL.md`** (read it and include it)
+2. **The project's coding conventions from `CLAUDE.md`** (include the Coding Conventions section)
+3. **The spec path and any context**:
+
+```
+## Your Task
+
+Execute the Builder pipeline for:
+- Spec: <spec-path>
+
+<if re-run after audit>
+This is a re-run. Read the Audit Report at specs/reports/<spec-name>.audit-report.md
+and address all findings before proceeding.
+</if>
+
+Follow the build-spec procedure above. Write the Build Report when done.
+```
+
+### After Builder Completes
+
+1. Read the Build Report at `specs/reports/<spec-name>.build-report.md`.
+2. If `Result: GREEN` → proceed to spawn the Auditor.
+3. If `Result: STUCK` → escalate to the developer:
+
+```
+🔴 Builder stuck on: <spec title>
+
+<stuck details from Build Report>
+
+This might indicate:
+  - A spec requirement that's ambiguous or contradictory
+  - A dependency that isn't implemented yet
+  - A fundamental design issue
+
+How would you like to proceed?
+```
+
+---
+
+## Spawn Auditor Agent (Steps 5-6)
+
+**Run autonomously — no gate (unless CONCERN).**
+
+Spawn a sub-agent to execute the Auditor role. The Auditor validates independently and updates docs.
+
+Use the `Agent` tool to spawn the Auditor:
+
+```
+Agent(
+  description: "Auditor: validate + review + docs for <spec-name>",
+  model: "opus",
+  prompt: <see below>
+)
+```
+
+### Auditor Prompt Template
+
+Construct the prompt by including:
+
+1. **The full contents of `.claude/skills/audit-spec/SKILL.md`** (read it and include it)
+2. **The project's coding conventions from `CLAUDE.md`** (include the Coding Conventions section)
+3. **The spec path and cycle number**:
+
+```
+## Your Task
+
+Execute the Auditor pipeline for:
+- Spec: <spec-path>
+- Build Report: specs/reports/<spec-name>.build-report.md
+- Cycle: <1 or 2>
+
+Follow the audit-spec procedure above. Write the Audit Report when done.
+```
+
+### After Auditor Completes
+
+1. Read the Audit Report at `specs/reports/<spec-name>.audit-report.md`.
+2. Handle the verdict:
+
+#### PASS
+
+Pipeline complete. Proceed to the Final Report.
+
+#### FAIL (cycle 1)
+
+Re-spawn the Builder with audit findings:
+
+1. Report briefly to the developer:
+   ```
+   🔄 Auditor found issues. Re-running Builder (cycle 2/2).
+   Findings: <brief summary from Audit Report>
+   ```
+2. Spawn the Builder again with the re-run prompt (it will read the Audit Report).
+3. After Builder completes, spawn the Auditor again with `Cycle: 2`.
+
+#### FAIL (cycle 2)
+
+The Builder-Auditor loop has reached its limit. Escalate remaining issues to the developer:
+
+```
+⚠️  Auditor found persistent issues after 2 cycles:
+
+<findings from cycle 2 Audit Report>
+
+Options:
+  1. Accept as-is (mark implemented with notes)
+  2. I'll fix these manually
+  3. Revise the spec to accommodate the implementation
+
+Which approach?
+```
+
+#### CONCERN
+
+Escalate to the developer immediately:
+
+```
+🤔 Auditor raised concerns requiring your judgment:
+
+<concerns from Audit Report>
+
+How would you like to proceed?
 ```
 
 ---
@@ -338,24 +329,24 @@ Present the complete result:
 ```
 ✅ Pipeline complete: <spec title>
 
-  Step 1: Spec written     → <spec-path>
-  Step 2: Tests generated  → <test-path> (<N> scenarios)
-  Step 3: Implemented      → <source-path>
-  Step 4: Tests GREEN      → <N>/<N> passing
-  Step 5: Validated        → <coverage summary>
-  Step 6: Docs updated     → <N> pages updated, <M> created
+  Step 1: Spec written       → <spec-path>
+  Steps 2-4: Builder         → <source-path> (<N> tests, <M> loops)
+  Steps 5-6: Auditor         → <verdict> (<N> pages updated)
 
   Status: implemented
   Breaking changes: <none | managed via deprecation | accepted>
-  Implementation loops: <N> (step 3↔4 iterations)
+  Builder-Auditor cycles: <1 or 2>
+
+  Artifacts:
+    Build Report:  specs/reports/<spec-name>.build-report.md
+    Audit Report:  specs/reports/<spec-name>.audit-report.md
 ```
 
-If there are remaining gaps from validation:
+If there are remaining gaps from the Auditor:
 
 ```
 ⚠️  Minor gaps (non-blocking):
-  - Invariant "<name>" not enforced at runtime (type-level only)
-  - Edge case "<name>" not tested (covered by implementation)
+  - <from Audit Report>
 
 These are noted but don't block the `implemented` status.
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,22 @@ Drives the full pipeline: spec → RED tests → implement → GREEN tests → v
 | `/spec <description>` | Full 6-step pipeline from description    |
 | `/spec-status`        | Show all specs and their pipeline status |
 
+## Multi-Agent Pipeline Architecture
+
+The `/spec` pipeline uses three agent roles. The developer workflow is unchanged — `/spec` remains the single entry point.
+
+| Role             | Model  | Steps              | Responsibility                                                                  |
+| ---------------- | ------ | ------------------ | ------------------------------------------------------------------------------- |
+| **Orchestrator** | Opus   | 0-1 + coordination | Understand intent, write/edit spec, Gate 1, spawn agents, handle feedback loops |
+| **Builder**      | Sonnet | 2-4                | Generate RED tests, implement code, run GREEN tests. Produces Build Report      |
+| **Auditor**      | Opus   | 5-6                | Independent validation, coherence review, docs. Produces Audit Report           |
+
+The Builder and Auditor run in **separate agent contexts** — the Auditor has no memory of the Builder's implementation decisions (fresh-eyes review). Communication happens through file artifacts in `specs/reports/`.
+
+**Feedback loop**: If the Auditor FAILs, the Builder re-runs with Audit findings (max 2 cycles). If issues persist or the Auditor raises a CONCERN, the developer decides.
+
+**Skills**: `build-spec/SKILL.md` (Builder), `audit-spec/SKILL.md` (Auditor). Handoff formats: `shared/build-report.md`, `shared/audit-report.md`.
+
 ## Coding Conventions
 
 ### Style


### PR DESCRIPTION
## Summary

- Split the single-agent `/spec` pipeline into three roles: **Orchestrator** (steps 0-1), **Builder** sub-agent (steps 2-4), and **Auditor** sub-agent (steps 5-6)
- The Auditor runs in a separate context with no memory of the Builder's decisions, enabling genuine independent review with a new **coherence check** (does the implementation match the spec's *intent*, not just pass the tests?)
- Added a feedback loop: Auditor can FAIL (send back to Builder, max 2 cycles), PASS, or raise a CONCERN (escalate to developer)

## What changed

| File | Change |
|------|--------|
| `.claude/skills/build-spec/SKILL.md` | **New** — Builder composite skill (Steps 2-4) |
| `.claude/skills/audit-spec/SKILL.md` | **New** — Auditor skill (Steps 5-6 + coherence review) |
| `.claude/skills/shared/build-report.md` | **New** — Build Report handoff format |
| `.claude/skills/shared/audit-report.md` | **New** — Audit Report handoff format |
| `.claude/skills/spec/SKILL.md` | **Modified** — Refactored to spawn Builder/Auditor as sub-agents |
| `CLAUDE.md` | **Modified** — Added multi-agent architecture documentation |
| `specs/reports/.gitkeep` | **New** — Directory for report artifacts |

## Design decisions

- **Developer workflow unchanged**: `/spec` remains the single entry point. The multi-agent split is internal.
- **Existing sub-skills preserved**: `generate-tests`, `implement-spec`, `run-tests`, `validate-spec`, `update-docs` are untouched — the new composite skills reference them as procedures.
- **File-based communication**: Agents communicate through Build Report and Audit Report markdown files in `specs/reports/`, creating an auditable trail.
- **Phased rollout**: This is Phase 1. Phase 2 (parallelization) and Phase 3 (Planner extraction) are tracked in #69.

## Test plan

- [ ] Run `/spec` on a leaf spec — verify Builder produces Build Report, Auditor produces Audit Report, pipeline completes
- [ ] Verify Auditor coherence review catches intent mismatches (implementation that passes tests but violates spec spirit)
- [ ] Trigger Auditor FAIL — verify Builder re-runs with findings (max 2 cycles)
- [ ] Trigger stuck detection (3 failures) — verify escalation path works

🤖 Generated with [Claude Code](https://claude.com/claude-code)