### PR TITLE
feat(docs): add landing page with hero, features, and footer

### DIFF
--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -1,3 +1,5 @@
+@import "fumadocs-ui/css/style.css";
+
 .logo-light {
   display: block;
 }
@@ -9,4 +11,13 @@
 }
 .dark .logo-dark {
   display: block;
+}
+
+.dashed-grid-bg {
+  background-image:
+    linear-gradient(to right, var(--color-fd-border) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--color-fd-border) 1px, transparent 1px);
+  background-size: 120px 120px;
+  mask-image: radial-gradient(ellipse 60% 60% at 50% 50%, black 20%, transparent 100%);
+  opacity: 0.4;
 }

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import { RootProvider } from "fumadocs-ui/provider/next";
-import "fumadocs-ui/style.css";
 import "./globals.css";
 import type { Metadata } from "next";
 import { Instrument_Sans, JetBrains_Mono } from "next/font/google";

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -1,6 +1,9 @@
+import { HomeLayout } from "fumadocs-ui/layouts/home";
 import Image from "next/image";
-import Link from "next/link";
 import type { Metadata } from "next";
+import { Hero } from "@/components/landing/hero";
+import { Features } from "@/components/landing/features";
+import { Footer } from "@/components/landing/footer";
 
 export const metadata: Metadata = {
   alternates: {
@@ -10,50 +13,42 @@ export const metadata: Metadata = {
 
 export default function HomePage() {
   return (
-    <main className="fixed inset-0 flex flex-col items-center justify-center px-6">
-      <Image
-        src="/icon-light.png"
-        alt="noddde"
-        width={56}
-        height={40}
-        className="logo-light"
-      />
-      <Image
-        src="/icon-dark.png"
-        alt="noddde"
-        width={56}
-        height={40}
-        className="logo-dark"
-      />
-
-      <h1 className="mt-5 text-4xl font-bold tracking-tight text-fd-foreground">
-        noddde
-      </h1>
-
-      <p className="mt-4 max-w-md text-center text-base leading-relaxed text-fd-muted-foreground">
-        Build business applications with aggregates, projections, and
-        sagas&nbsp;&mdash; using plain objects and pure functions. No base
-        classes. No decorators. No DI&nbsp;container.
-      </p>
-
-      <pre className="mt-6 rounded-lg border border-fd-border bg-fd-card px-4 py-2.5 text-sm text-fd-muted-foreground">
-        <code>yarn add @noddde/core</code>
-      </pre>
-
-      <div className="mt-6 flex gap-4">
-        <Link
-          href="/docs/getting-started/introduction"
-          className="rounded-lg bg-fd-primary px-6 py-3 text-sm font-medium text-fd-primary-foreground"
-        >
-          Get Started
-        </Link>
-        <Link
-          href="/docs"
-          className="rounded-lg border border-fd-border px-6 py-3 text-sm font-medium"
-        >
-          Documentation
-        </Link>
-      </div>
-    </main>
+    <HomeLayout
+      nav={{
+        title: (
+          <div className="flex items-center gap-2">
+            <Image
+              src="/icon-light.png"
+              alt=""
+              width={20}
+              height={14}
+              className="logo-light"
+            />
+            <Image
+              src="/icon-dark.png"
+              alt=""
+              width={20}
+              height={14}
+              className="logo-dark"
+            />
+            <span className="font-semibold">noddde</span>
+          </div>
+        ),
+        transparentMode: "top",
+      }}
+      links={[
+        {
+          type: "main",
+          text: "Documentation",
+          url: "/docs",
+          active: "none",
+        },
+      ]}
+      githubUrl="https://github.com/dogganidhal/noddde"
+    >
+      <Hero />
+      <Features />
+      <Footer />
+    </HomeLayout>
   );
 }

--- a/docs/src/components/landing/feature-card.tsx
+++ b/docs/src/components/landing/feature-card.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+export function FeatureCard({
+  icon,
+  title,
+  description,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="group rounded-xl border border-fd-border bg-fd-card/50 p-6 transition-all duration-200 hover:border-fd-primary/40 hover:bg-fd-card">
+      <div className="mb-4 flex size-10 items-center justify-center rounded-lg bg-fd-primary/10 text-fd-primary">
+        {icon}
+      </div>
+      <h3 className="text-base font-semibold text-fd-foreground">{title}</h3>
+      <p className="mt-2 text-sm leading-relaxed text-fd-muted-foreground">
+        {description}
+      </p>
+    </div>
+  );
+}

--- a/docs/src/components/landing/features.tsx
+++ b/docs/src/components/landing/features.tsx
@@ -1,0 +1,69 @@
+import {
+  Eye,
+  GitBranch,
+  History,
+  ShieldCheck,
+  Split,
+  Workflow,
+} from "lucide-react";
+import { FeatureCard } from "./feature-card";
+
+const features = [
+  {
+    icon: <GitBranch className="size-5" />,
+    title: "Decider Pattern",
+    description:
+      "Pure functions for state transitions. initialState + decide + evolve — nothing else.",
+  },
+  {
+    icon: <Split className="size-5" />,
+    title: "CQRS",
+    description:
+      "Separate command and query models with dedicated buses and handlers.",
+  },
+  {
+    icon: <History className="size-5" />,
+    title: "Event Sourcing",
+    description:
+      "Full audit trail of state changes. Replay and rebuild state from events.",
+  },
+  {
+    icon: <Eye className="size-5" />,
+    title: "Projections",
+    description:
+      "Materialized read models built from event streams, always up to date.",
+  },
+  {
+    icon: <Workflow className="size-5" />,
+    title: "Sagas",
+    description:
+      "Coordinate long-running business processes across aggregates.",
+  },
+  {
+    icon: <ShieldCheck className="size-5" />,
+    title: "Type-Safe",
+    description:
+      "Full TypeScript inference from end to end. Zero decorators. Zero runtime magic.",
+  },
+];
+
+export function Features() {
+  return (
+    <section className="border-t border-fd-border py-16 lg:py-24">
+      <div className="mx-auto max-w-5xl px-6 text-center">
+        <h2 className="text-3xl font-bold tracking-tight text-fd-foreground">
+          Everything you need to model your domain
+        </h2>
+        <p className="mx-auto mt-4 max-w-2xl text-fd-muted-foreground">
+          Aggregates, projections, and sagas — using plain objects and pure
+          functions. No base classes. No decorators. No DI container.
+        </p>
+        <div className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((feature) => (
+            <FeatureCard key={feature.title} {...feature} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/docs/src/components/landing/footer.tsx
+++ b/docs/src/components/landing/footer.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { LogoIcon } from "@/components/logo";
+
+export function Footer() {
+  return (
+    <footer className="border-t border-fd-border py-8">
+      <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-4 px-6 sm:flex-row">
+        <div className="flex items-center gap-2 text-fd-muted-foreground">
+          <LogoIcon className="size-6" />
+          <span className="text-sm">noddde &middot; MIT License</span>
+        </div>
+        <div className="flex gap-6 text-sm text-fd-muted-foreground">
+          <Link
+            href="/docs"
+            className="transition-colors hover:text-fd-foreground"
+          >
+            Documentation
+          </Link>
+          <a
+            href="https://github.com/dogganidhal/noddde"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-fd-foreground"
+          >
+            GitHub
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/docs/src/components/landing/hero-code.tsx
+++ b/docs/src/components/landing/hero-code.tsx
@@ -1,0 +1,40 @@
+import { highlight } from "fumadocs-core/highlight";
+import { CodeBlock, Pre } from "fumadocs-ui/components/codeblock";
+
+const HERO_CODE = `import { defineAggregate } from "@noddde/core";
+
+const Auction = defineAggregate<AuctionDef>({
+  initialState: { status: "pending", bids: [] },
+
+  decide: {
+    CreateAuction: (command, state) => ({
+      type: "AuctionCreated",
+      payload: { title: command.payload.title },
+    }),
+    PlaceBid: (command, state) => ({
+      type: "BidPlaced",
+      payload: { amount: command.payload.amount },
+    }),
+  },
+
+  evolve: {
+    AuctionCreated: (_, state) => ({ ...state, status: "active" }),
+    BidPlaced: (payload, state) => ({
+      ...state,
+      bids: [...state.bids, payload],
+    }),
+  },
+});`;
+
+export async function HeroCode() {
+  const highlighted = await highlight(HERO_CODE, {
+    lang: "typescript",
+    themes: { light: "github-light", dark: "github-dark" },
+  });
+
+  return (
+    <CodeBlock title="auction.ts" keepBackground>
+      <Pre>{highlighted}</Pre>
+    </CodeBlock>
+  );
+}

--- a/docs/src/components/landing/hero.tsx
+++ b/docs/src/components/landing/hero.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import { InstallCommand } from "./install-command";
+import { HeroCode } from "./hero-code";
+
+export function Hero() {
+  return (
+    <section className="relative overflow-hidden py-20 lg:py-32">
+      {/* Dashed grid background */}
+      <div className="dashed-grid-bg pointer-events-none absolute inset-0" />
+
+      <div className="relative mx-auto grid max-w-5xl gap-10 px-6 lg:grid-cols-2 lg:items-center">
+        {/* Left column — text content */}
+        <div className="flex flex-col items-start">
+          <span className="inline-flex items-center rounded-full border border-fd-border bg-fd-card px-3 py-1 text-xs font-medium text-fd-muted-foreground">
+            Functional DDD for TypeScript
+          </span>
+
+          <h1 className="mt-6 text-4xl font-bold tracking-tight text-fd-foreground lg:text-5xl">
+            Build business logic with{" "}
+            <span className="text-fd-primary">pure functions</span>
+          </h1>
+
+          <p className="mt-4 text-lg leading-relaxed text-fd-muted-foreground">
+            Define aggregates, projections, and sagas using the Decider
+            pattern&nbsp;&mdash; typed objects and plain functions, no magic.
+          </p>
+
+          <div className="mt-8">
+            <InstallCommand />
+          </div>
+
+          <div className="mt-6 flex gap-4">
+            <Link
+              href="/docs/getting-started/introduction"
+              className="rounded-lg bg-fd-primary px-6 py-3 text-sm font-medium text-fd-primary-foreground transition-colors hover:bg-fd-primary/90"
+            >
+              Get Started
+            </Link>
+            <Link
+              href="/docs"
+              className="rounded-lg border border-fd-border px-6 py-3 text-sm font-medium text-fd-foreground transition-colors hover:bg-fd-card"
+            >
+              Documentation
+            </Link>
+          </div>
+        </div>
+
+        {/* Right column — code example */}
+        <div className="hidden min-w-0 overflow-hidden lg:block">
+          <HeroCode />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/docs/src/components/landing/install-command.tsx
+++ b/docs/src/components/landing/install-command.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useCallback, useState } from "react";
+
+export function InstallCommand({
+  command = "yarn add @noddde/core",
+}: {
+  command?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(() => {
+    void navigator.clipboard.writeText(command).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [command]);
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className="group flex items-center gap-3 rounded-lg border border-fd-border bg-fd-card px-4 py-2.5 font-mono text-sm text-fd-muted-foreground transition-colors hover:border-fd-primary/40"
+    >
+      <span className="select-all">$ {command}</span>
+      {copied ? (
+        <Check className="size-4 text-green-500" />
+      ) : (
+        <Copy className="size-4 opacity-0 transition-opacity group-hover:opacity-100" />
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace the minimal centered hero with a full paykit.sh-inspired landing page
- Add two-column hero section with build-time syntax-highlighted code example (Auction aggregate)
- Add responsive feature cards grid (Decider Pattern, CQRS, Event Sourcing, Projections, Sagas, Type-Safe)
- Switch from pre-built fumadocs CSS to source CSS to enable Tailwind utility generation for custom components

## Test plan
- [ ] `cd docs && yarn dev` — verify landing page renders correctly in dark and light mode
- [ ] Verify responsive layout: mobile (stacked), tablet (2-col features), desktop (2-col hero + 3-col features)
- [ ] Verify code block has syntax highlighting in both themes
- [ ] Verify copy button on install command works
- [ ] Verify "Get Started" and "Documentation" links navigate correctly
- [ ] Verify `/docs` pages still render correctly after CSS import change
- [ ] `yarn build` — confirm static export succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)