### PR TITLE
fix(samples): add missing created_at column to hotel-booking test schema

### DIFF
--- a/samples/sample-hotel-booking/src/__tests__/integration/setup.ts
+++ b/samples/sample-hotel-booking/src/__tests__/integration/setup.ts
@@ -59,7 +59,8 @@ export async function createTestEnvironment() {
       sequence_number INTEGER NOT NULL,
       event_name TEXT NOT NULL,
       payload TEXT NOT NULL,
-      metadata TEXT
+      metadata TEXT,
+      created_at TEXT NOT NULL DEFAULT ''
     );
     CREATE UNIQUE INDEX noddde_events_stream_version_idx
       ON noddde_events(aggregate_name, aggregate_id, sequence_number);


### PR DESCRIPTION
## Summary
- The Drizzle SQLite schema added a `created_at` column to `noddde_events`, but the hotel-booking integration test setup's `CREATE TABLE` was not updated to match
- This caused all 13 HTTP integration tests to fail with 500 errors (`no such column: "created_at"`)
- Adds the missing `created_at TEXT NOT NULL DEFAULT ''` column to the test schema

## Test plan
- [x] All 108 hotel-booking tests pass (including the 13 previously failing HTTP integration tests)
- [x] Full `turbo test` passes across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)