### PR TITLE
docs: add per-package READMEs, update release workflow and docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,28 +45,38 @@ jobs:
           echo "Publishing version: $VERSION"
 
           # Set own version for all publishable packages
-          for dir in packages/core packages/engine packages/testing packages/adapters/drizzle packages/adapters/prisma packages/adapters/typeorm; do
+          for dir in packages/core packages/engine packages/cli packages/testing packages/adapters/drizzle packages/adapters/prisma packages/adapters/typeorm packages/adapters/rabbitmq packages/adapters/nats packages/adapters/kafka; do
             cd "$dir"
             npm pkg set "version=$VERSION"
             cd "$GITHUB_WORKSPACE"
           done
 
           # Rewrite internal dependency versions
+          # Tier 2: depends on core only
           for dir in packages/engine packages/adapters/drizzle packages/adapters/prisma packages/adapters/typeorm; do
             cd "$dir"
             npm pkg set "dependencies.@noddde/core=$VERSION"
             cd "$GITHUB_WORKSPACE"
           done
 
-          cd packages/testing
-          npm pkg set "dependencies.@noddde/core=$VERSION"
-          npm pkg set "dependencies.@noddde/engine=$VERSION"
-          cd "$GITHUB_WORKSPACE"
+          # Tier 3: depends on core + engine
+          for dir in packages/testing packages/adapters/rabbitmq packages/adapters/nats packages/adapters/kafka; do
+            cd "$dir"
+            npm pkg set "dependencies.@noddde/core=$VERSION"
+            npm pkg set "dependencies.@noddde/engine=$VERSION"
+            cd "$GITHUB_WORKSPACE"
+          done
 
       # Tier 1: no internal dependencies
       - name: Publish @noddde/core
         run: npm publish --access public --provenance
         working-directory: packages/core
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @noddde/cli
+        run: npm publish --access public --provenance
+        working-directory: packages/cli
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -99,5 +109,23 @@ jobs:
       - name: Publish @noddde/testing
         run: npm publish --access public --provenance
         working-directory: packages/testing
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @noddde/rabbitmq
+        run: npm publish --access public --provenance
+        working-directory: packages/adapters/rabbitmq
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @noddde/nats
+        run: npm publish --access public --provenance
+        working-directory: packages/adapters/nats
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @noddde/kafka
+        run: npm publish --access public --provenance
+        working-directory: packages/adapters/kafka
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-> **Status:** Pre-1.0 Release Candidate. The core API is stable. We are currently hardening distributed systems features (Outbox, Graceful Shutdown) ahead of v1.0.
+> **Status:** Pre-1.0 Release Candidate. The core API is stable. Outbox, Graceful Shutdown, and distributed event bus adapters (RabbitMQ, NATS, Kafka) are shipped. We are currently focused on error isolation and developer ergonomics ahead of v1.0.
 
 Building a CQRS and Event Sourced system in TypeScript usually involves significant boilerplate. Developers often end up extending `AggregateRoot` base classes, decorating methods with `@CommandHandler()`, wiring up DI containers, and working around the type system.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 [![CI](https://github.com/dogganidhal/noddde/actions/workflows/ci.yml/badge.svg)](https://github.com/dogganidhal/noddde/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/dogganidhal/noddde/graph/badge.svg)](https://codecov.io/gh/dogganidhal/noddde)
+[![npm](https://img.shields.io/npm/v/@noddde/core)](https://www.npmjs.com/package/@noddde/core)
+[![license](https://img.shields.io/npm/l/@noddde/core)](https://github.com/dogganidhal/noddde/blob/main/LICENSE)
 
 **Domain modeling that stays out of your way. Production guarantees that protect your data.**
 
@@ -65,10 +67,9 @@ const Wallet = defineAggregate<WalletDef>({
   // ...
 });
 
-// 3. Wire up the right persistence strategy for each aggregate
-const db = drizzle(sqlite);
-const { stateStoredPersistence, eventSourcedPersistence } =
-  createDrizzlePersistence(db, schema);
+// 3. Wire up with a single persistence adapter — it handles everything
+const db = drizzle(connectionString, { schema });
+const adapter = new DrizzleAdapter(db);
 
 const myDomain = defineDomain({
   writeModel: {
@@ -80,13 +81,10 @@ const myDomain = defineDomain({
 });
 
 const domain = await wireDomain(myDomain, {
+  persistenceAdapter: adapter,
   aggregates: {
-    UserProfile: {
-      persistence: () => stateStoredPersistence,
-    },
-    Wallet: {
-      persistence: () => eventSourcedPersistence,
-    },
+    UserProfile: { persistence: "state-stored" },
+    Wallet: { persistence: "event-sourced" },
   },
 });
 ```
@@ -181,6 +179,35 @@ const result = await testAggregate(BankAccount)
 expect(result.events[0].name).toBe("WithdrawalMade");
 expect(result.state.balance).toBe(800);
 ```
+
+## Packages
+
+### Core
+
+| Package                                                            | Description                                                               |
+| :----------------------------------------------------------------- | :------------------------------------------------------------------------ |
+| [`@noddde/core`](https://www.npmjs.com/package/@noddde/core)       | Types, interfaces, and definition functions — zero runtime deps           |
+| [`@noddde/engine`](https://www.npmjs.com/package/@noddde/engine)   | Runtime engine: domain orchestration and in-memory implementations        |
+| [`@noddde/cli`](https://www.npmjs.com/package/@noddde/cli)         | CLI for scaffolding aggregates, projections, sagas, domains, and projects |
+| [`@noddde/testing`](https://www.npmjs.com/package/@noddde/testing) | Type-safe Given/When/Then test harnesses                                  |
+
+### Persistence Adapters
+
+| Package                                                            | Peer Dependency         | Features                                                         |
+| :----------------------------------------------------------------- | :---------------------- | :--------------------------------------------------------------- |
+| [`@noddde/drizzle`](https://www.npmjs.com/package/@noddde/drizzle) | `drizzle-orm` >= 0.30   | PostgreSQL, MySQL, SQLite; advisory locking; convenience schemas |
+| [`@noddde/prisma`](https://www.npmjs.com/package/@noddde/prisma)   | `@prisma/client` >= 5.0 | Any Prisma-supported database; advisory locking; built-in models |
+| [`@noddde/typeorm`](https://www.npmjs.com/package/@noddde/typeorm) | `typeorm` >= 0.3        | PostgreSQL, MySQL, MariaDB, MSSQL, SQLite; built-in entities     |
+
+### Distributed Event Bus Adapters
+
+| Package                                                              | Peer Dependency   | Features                                                                 |
+| :------------------------------------------------------------------- | :---------------- | :----------------------------------------------------------------------- |
+| [`@noddde/rabbitmq`](https://www.npmjs.com/package/@noddde/rabbitmq) | `amqplib` >= 0.10 | Exchange-based routing, durable queues, exponential backoff reconnection |
+| [`@noddde/nats`](https://www.npmjs.com/package/@noddde/nats)         | `nats` >= 2.0     | JetStream durable consumers, subject-based routing, consumer groups      |
+| [`@noddde/kafka`](https://www.npmjs.com/package/@noddde/kafka)       | `kafkajs` >= 2.0  | Consumer group fan-out, partition key strategy, manual offset commits    |
+
+All event bus adapters provide at-least-once delivery with manual acknowledgment and configurable retry policies.
 
 ## Getting Started
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Where noddde is headed: what is shipped, what is required for v1.0, and our vision for distributed TypeScript domains.
 
-**Current Status:** Pre-1.0. The core Decider pattern and type-inference engine are stable. We are currently focused on production hardening, fault tolerance, and developer guardrails ahead of our v1.0 Release Candidate.
+**Current Status:** Pre-1.0. The core Decider pattern, type-inference engine, persistence adapters, distributed event buses, and observability are all shipped. We are currently focused on error isolation and developer ergonomics ahead of our v1.0 Release Candidate.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,6 +19,8 @@ Where noddde is headed: what is shipped, what is required for v1.0, and our visi
 - [x] **State Snapshotting:** Configurable strategies (e.g., every N events).
 - [x] **ORM Adapters:** Drizzle, Prisma, and TypeORM with UoW transaction support.
 - [x] **Testing Toolkit:** Type-safe Given-When-Then test harnesses (`@noddde/testing`).
+- [x] **Observability & OpenTelemetry (OTel):** Native OTel trace context propagation spanning the full asynchronous lifecycle: API -> Command Bus -> Aggregate -> Event Bus -> Saga -> Read Model. Zero required configuration — auto-detects `@opentelemetry/api` at runtime.
+- [x] **Distributed Event Bus Adapters:** Official adapters for RabbitMQ (`@noddde/rabbitmq`), NATS (`@noddde/nats`), and Kafka (`@noddde/kafka`) with consumer group support, at-least-once delivery, manual acknowledgment, and configurable retry policies.
 
 ---
 
@@ -43,10 +45,6 @@ _These items must be completed to guarantee state consistency and developer ergo
 
 _Features required for deploying noddde across multi-node, high-throughput microservice environments._
 
-- [x] **Observability & OpenTelemetry (OTel)**
-  - Native OTel trace context propagation spanning the full asynchronous lifecycle: API -> Command Bus -> Aggregate -> Event Bus -> Saga -> Read Model.
-- [ ] **Distributed Event Bus Adapters**
-  - Official adapters for Kafka, NATS, or RabbitMQ with consumer group support, ensuring events are routed safely across multiple instances.
 - [ ] **Advanced Outbox Management**
   - Add poison pill detection, exponential backoff, and Dead Letter Queues (DLQ) to the Outbox Relay to handle downstream event bus outages.
   - Optimize ORM outbox polling with `SKIP LOCKED` to prevent contention in multi-node deployments.

--- a/packages/adapters/drizzle/README.md
+++ b/packages/adapters/drizzle/README.md
@@ -1,0 +1,81 @@
+# @noddde/drizzle
+
+Drizzle ORM persistence adapter for noddde. Supports PostgreSQL, MySQL, and SQLite.
+
+**[Documentation](https://noddde.dev)** | **[GitHub](https://github.com/dogganidhal/noddde)**
+
+## Install
+
+```bash
+yarn add @noddde/drizzle drizzle-orm
+# or
+npm install @noddde/drizzle drizzle-orm
+```
+
+## What's Inside
+
+- **`DrizzleAdapter`** &mdash; Full persistence adapter for `wireDomain`: event-sourced aggregates, state-stored aggregates, sagas, snapshots, and outbox
+- **`DrizzleAdvisoryLocker`** &mdash; Distributed pessimistic locking (PostgreSQL/MySQL)
+- **`DrizzleSnapshotStore`** / **`DrizzleOutboxStore`** &mdash; Optional stores
+- **Built-in schemas** via `@noddde/drizzle/pg`, `@noddde/drizzle/sqlite`, `@noddde/drizzle/mysql`
+
+The dialect is auto-detected from your Drizzle `db` instance.
+
+## Usage
+
+```typescript
+import { drizzle } from "drizzle-orm/node-postgres";
+import { DrizzleAdapter } from "@noddde/drizzle";
+import { wireDomain } from "@noddde/engine";
+import * as schema from "./schema";
+
+const db = drizzle(connectionString, { schema });
+
+const adapter = new DrizzleAdapter(db);
+
+const domain = await wireDomain(definition, {
+  persistenceAdapter: adapter,
+});
+```
+
+### With Convenience Schemas
+
+```typescript
+// PostgreSQL
+import { nodddeSchema } from "@noddde/drizzle/pg";
+// SQLite
+import { nodddeSchema } from "@noddde/drizzle/sqlite";
+// MySQL
+import { nodddeSchema } from "@noddde/drizzle/mysql";
+```
+
+### Dedicated State Tables
+
+For state-stored aggregates with custom table shapes:
+
+```typescript
+const adapter = new DrizzleAdapter(db);
+
+adapter.stateStored(usersTable, {
+  aggregateId: "id",
+  state: "data",
+  version: "version",
+});
+```
+
+## Peer Dependencies
+
+- `drizzle-orm` >= 0.30.0
+
+## Related Packages
+
+| Package                                                            | Description                                 |
+| :----------------------------------------------------------------- | :------------------------------------------ |
+| [`@noddde/core`](https://www.npmjs.com/package/@noddde/core)       | Types, interfaces, and definition functions |
+| [`@noddde/engine`](https://www.npmjs.com/package/@noddde/engine)   | Runtime engine with domain orchestration    |
+| [`@noddde/prisma`](https://www.npmjs.com/package/@noddde/prisma)   | Prisma persistence adapter                  |
+| [`@noddde/typeorm`](https://www.npmjs.com/package/@noddde/typeorm) | TypeORM persistence adapter                 |
+
+## License
+
+MIT

--- a/packages/adapters/kafka/README.md
+++ b/packages/adapters/kafka/README.md
@@ -1,0 +1,75 @@
+# @noddde/kafka
+
+Kafka event bus adapter for noddde. Provides scalable event streaming with consumer groups, partition-based ordering, and at-least-once delivery guarantees.
+
+**[Documentation](https://noddde.dev)** | **[GitHub](https://github.com/dogganidhal/noddde)**
+
+## Install
+
+```bash
+yarn add @noddde/kafka kafkajs
+# or
+npm install @noddde/kafka kafkajs
+```
+
+## What's Inside
+
+- **`KafkaEventBus`** &mdash; Topic-based event publishing with consumer group fan-out, manual offset commits, configurable partition key strategy, and delivery retry tracking
+- Partition key defaults to `aggregateId` for ordered processing per aggregate
+- Session timeout and heartbeat configuration
+
+## Usage
+
+```typescript
+import { KafkaEventBus } from "@noddde/kafka";
+import { wireDomain } from "@noddde/engine";
+
+const eventBus = new KafkaEventBus({
+  brokers: ["localhost:9092"],
+  clientId: "my-service",
+  groupId: "my-service-group",
+});
+
+await eventBus.connect();
+
+const domain = await wireDomain(definition, {
+  eventBus,
+});
+
+// Clean shutdown
+await eventBus.close();
+```
+
+### Configuration
+
+```typescript
+const eventBus = new KafkaEventBus({
+  brokers: ["localhost:9092"],
+  clientId: "my-service",
+  groupId: "my-service-group",
+  topicPrefix: "myapp", // Optional topic namespace
+  sessionTimeout: 30000,
+  heartbeatInterval: 3000,
+  resilience: {
+    maxRetries: 5,
+    retryDelay: 1000,
+  },
+});
+```
+
+## Peer Dependencies
+
+- `kafkajs` >= 2.0.0
+
+## Related Packages
+
+| Package                                                              | Description                                 |
+| :------------------------------------------------------------------- | :------------------------------------------ |
+| [`@noddde/core`](https://www.npmjs.com/package/@noddde/core)         | Types, interfaces, and definition functions |
+| [`@noddde/engine`](https://www.npmjs.com/package/@noddde/engine)     | Runtime engine with domain orchestration    |
+| [`@noddde/rabbitmq`](https://www.npmjs.com/package/@noddde/rabbitmq) | RabbitMQ event bus adapter                  |
+| [`@noddde/nats`](https://www.npmjs.com/package/@noddde/nats)         | NATS event bus adapter                      |
+
+## License
+
+MIT

--- a/packages/adapters/nats/README.md
+++ b/packages/adapters/nats/README.md
@@ -1,0 +1,73 @@
+# @noddde/nats
+
+NATS event bus adapter for noddde. Provides high-performance distributed event publishing and subscription using JetStream with at-least-once delivery guarantees.
+
+**[Documentation](https://noddde.dev)** | **[GitHub](https://github.com/dogganidhal/noddde)**
+
+## Install
+
+```bash
+yarn add @noddde/nats nats
+# or
+npm install @noddde/nats nats
+```
+
+## What's Inside
+
+- **`NatsEventBus`** &mdash; JetStream-based event publishing with durable consumers, subject-based routing, manual acknowledgment, and consumer group support
+- Built-in resilience via NATS native reconnection
+- Configurable subject prefix for multi-tenant environments
+
+## Usage
+
+```typescript
+import { NatsEventBus } from "@noddde/nats";
+import { wireDomain } from "@noddde/engine";
+
+const eventBus = new NatsEventBus({
+  servers: "nats://localhost:4222",
+  stream: "my-domain-events",
+  consumerGroup: "my-service",
+});
+
+await eventBus.connect();
+
+const domain = await wireDomain(definition, {
+  eventBus,
+});
+
+// Clean shutdown
+await eventBus.close();
+```
+
+### Configuration
+
+```typescript
+const eventBus = new NatsEventBus({
+  servers: "nats://localhost:4222",
+  stream: "my-domain-events",
+  consumerGroup: "my-service", // Durable consumer group
+  subjectPrefix: "myapp", // Optional subject namespace
+  resilience: {
+    maxRetries: 5,
+    retryDelay: 1000,
+  },
+});
+```
+
+## Peer Dependencies
+
+- `nats` >= 2.0.0
+
+## Related Packages
+
+| Package                                                              | Description                                 |
+| :------------------------------------------------------------------- | :------------------------------------------ |
+| [`@noddde/core`](https://www.npmjs.com/package/@noddde/core)         | Types, interfaces, and definition functions |
+| [`@noddde/engine`](https://www.npmjs.com/package/@noddde/engine)     | Runtime engine with domain orchestration    |
+| [`@noddde/rabbitmq`](https://www.npmjs.com/package/@noddde/rabbitmq) | RabbitMQ event bus adapter                  |
+| [`@noddde/kafka`](https://www.npmjs.com/package/@noddde/kafka)       | Kafka event bus adapter                     |
+
+## License
+
+MIT

--- a/packages/adapters/prisma/README.md
+++ b/packages/adapters/prisma/README.md
@@ -1,0 +1,67 @@
+# @noddde/prisma
+
+Prisma persistence adapter for noddde. Works with any Prisma-supported database.
+
+**[Documentation](https://noddde.dev)** | **[GitHub](https://github.com/dogganidhal/noddde)**
+
+## Install
+
+```bash
+yarn add @noddde/prisma @prisma/client
+# or
+npm install @noddde/prisma @prisma/client
+```
+
+## What's Inside
+
+- **`PrismaAdapter`** &mdash; Full persistence adapter for `wireDomain`: event-sourced aggregates, state-stored aggregates, sagas, snapshots, and outbox
+- **`PrismaAdvisoryLocker`** &mdash; Distributed pessimistic locking (PostgreSQL/MySQL)
+- **Individual persistence classes** if you need fine-grained control: `PrismaEventSourcedAggregatePersistence`, `PrismaStateStoredAggregatePersistence`, `PrismaSagaPersistence`, `PrismaSnapshotStore`, `PrismaOutboxStore`
+- **`PrismaUnitOfWork`** &mdash; ACID transaction context
+
+## Usage
+
+```typescript
+import { PrismaClient } from "@prisma/client";
+import { PrismaAdapter } from "@noddde/prisma";
+import { wireDomain } from "@noddde/engine";
+
+const prisma = new PrismaClient();
+
+const adapter = new PrismaAdapter(prisma, { dialect: "pg" });
+
+const domain = await wireDomain(definition, {
+  persistenceAdapter: adapter,
+});
+```
+
+### Dedicated State Models
+
+For state-stored aggregates with custom Prisma models:
+
+```typescript
+const adapter = new PrismaAdapter(prisma);
+
+adapter.stateStored("order", {
+  aggregateId: "id",
+  state: "data",
+  version: "rev",
+});
+```
+
+## Peer Dependencies
+
+- `@prisma/client` >= 5.0.0
+
+## Related Packages
+
+| Package                                                            | Description                                 |
+| :----------------------------------------------------------------- | :------------------------------------------ |
+| [`@noddde/core`](https://www.npmjs.com/package/@noddde/core)       | Types, interfaces, and definition functions |
+| [`@noddde/engine`](https://www.npmjs.com/package/@noddde/engine)   | Runtime engine with domain orchestration    |
+| [`@noddde/drizzle`](https://www.npmjs.com/package/@noddde/drizzle) | Drizzle ORM persistence adapter             |
+| [`@noddde/typeorm`](https://www.npmjs.com/package/@noddde/typeorm) | TypeORM persistence adapter                 |
+
+## License
+
+MIT

--- a/packages/adapters/rabbitmq/README.md
+++ b/packages/adapters/rabbitmq/README.md
@@ -1,0 +1,72 @@
+# @noddde/rabbitmq
+
+RabbitMQ event bus adapter for noddde. Provides distributed event publishing and subscription with at-least-once delivery guarantees.
+
+**[Documentation](https://noddde.dev)** | **[GitHub](https://github.com/dogganidhal/noddde)**
+
+## Install
+
+```bash
+yarn add @noddde/rabbitmq amqplib
+# or
+npm install @noddde/rabbitmq amqplib
+```
+
+## What's Inside
+
+- **`RabbitMqEventBus`** &mdash; Exchange-based event publishing with topic routing, durable queues, manual acknowledgment, and exponential backoff reconnection
+- Prefetch-based backpressure control
+- Configurable retry policies per handler
+
+## Usage
+
+```typescript
+import { RabbitMqEventBus } from "@noddde/rabbitmq";
+import { wireDomain } from "@noddde/engine";
+
+const eventBus = new RabbitMqEventBus({
+  url: "amqp://localhost:5672",
+  exchange: "my-domain-events",
+});
+
+await eventBus.connect();
+
+const domain = await wireDomain(definition, {
+  eventBus,
+});
+
+// Clean shutdown
+await eventBus.close();
+```
+
+### Configuration
+
+```typescript
+const eventBus = new RabbitMqEventBus({
+  url: "amqp://localhost:5672",
+  exchange: "my-domain-events",
+  queue: "my-service", // Consumer queue name
+  prefetch: 10, // Backpressure control
+  resilience: {
+    maxRetries: 5,
+    retryDelay: 1000, // Base delay in ms (exponential backoff)
+  },
+});
+```
+
+## Peer Dependencies
+
+- `amqplib` >= 0.10.0
+
+## Related Packages
+
+| Package                                                          | Description                                 |
+| :--------------------------------------------------------------- | :------------------------------------------ |
+| [`@noddde/core`](https://www.npmjs.com/package/@noddde/core)     | Types, interfaces, and definition functions |
+| [`@noddde/engine`](https://www.npmjs.com/package/@noddde/engine) | Runtime engine with domain orchestration    |
+| [`@noddde/nats`](https://www.npmjs.com/package/@noddde/nats)     | NATS event bus adapter                      |
+| [`@noddde/kafka`](https://www.npmjs.com/package/@noddde/kafka)   | Kafka event bus adapter                     |
+
+## License
+
+MIT

--- a/packages/adapters/typeorm/README.md
+++ b/packages/adapters/typeorm/README.md
@@ -1,0 +1,84 @@
+# @noddde/typeorm
+
+TypeORM persistence adapter for noddde. Works with PostgreSQL, MySQL, MariaDB, MSSQL, and SQLite.
+
+**[Documentation](https://noddde.dev)** | **[GitHub](https://github.com/dogganidhal/noddde)**
+
+## Install
+
+```bash
+yarn add @noddde/typeorm typeorm
+# or
+npm install @noddde/typeorm typeorm
+```
+
+## What's Inside
+
+- **`TypeORMAdapter`** &mdash; Full persistence adapter for `wireDomain`: event-sourced aggregates, state-stored aggregates, sagas, snapshots, and outbox
+- **`TypeORMAdvisoryLocker`** &mdash; Distributed pessimistic locking (auto-detected from DataSource)
+- **Built-in entities** &mdash; `NodddeEventEntity`, `NodddeAggregateStateEntity`, `NodddeSagaStateEntity`, `NodddeSnapshotEntity`, `NodddeOutboxEntryEntity`
+- **Individual persistence classes** for fine-grained control
+- **`TypeORMUnitOfWork`** &mdash; ACID transaction context
+
+## Usage
+
+```typescript
+import { DataSource } from "typeorm";
+import {
+  TypeORMAdapter,
+  NodddeEventEntity,
+  NodddeAggregateStateEntity,
+  NodddeSagaStateEntity,
+} from "@noddde/typeorm";
+import { wireDomain } from "@noddde/engine";
+
+const dataSource = new DataSource({
+  type: "postgres",
+  url: process.env.DATABASE_URL,
+  entities: [
+    NodddeEventEntity,
+    NodddeAggregateStateEntity,
+    NodddeSagaStateEntity,
+  ],
+  synchronize: true,
+});
+
+await dataSource.initialize();
+
+const adapter = new TypeORMAdapter(dataSource);
+
+const domain = await wireDomain(definition, {
+  persistenceAdapter: adapter,
+});
+```
+
+### Dedicated State Entities
+
+For state-stored aggregates with custom TypeORM entities:
+
+```typescript
+const adapter = new TypeORMAdapter(dataSource);
+
+adapter.stateStored(OrderStateEntity, {
+  aggregateId: "id",
+  state: "data",
+  version: "rev",
+});
+```
+
+## Peer Dependencies
+
+- `typeorm` >= 0.3.0
+
+## Related Packages
+
+| Package                                                            | Description                                 |
+| :----------------------------------------------------------------- | :------------------------------------------ |
+| [`@noddde/core`](https://www.npmjs.com/package/@noddde/core)       | Types, interfaces, and definition functions |
+| [`@noddde/engine`](https://www.npmjs.com/package/@noddde/engine)   | Runtime engine with domain orchestration    |
+| [`@noddde/drizzle`](https://www.npmjs.com/package/@noddde/drizzle) | Drizzle ORM persistence adapter             |
+| [`@noddde/prisma`](https://www.npmjs.com/package/@noddde/prisma)   | Prisma persistence adapter                  |
+
+## License
+
+MIT

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,43 @@
+# @noddde/cli
+
+CLI tool for scaffolding noddde DDD aggregates, projections, and sagas.
+
+**[Documentation](https://noddde.dev)** | **[GitHub](https://github.com/dogganidhal/noddde)**
+
+## Install
+
+```bash
+# Run directly with npx
+npx @noddde/cli new aggregate
+
+# Or install globally
+npm install -g @noddde/cli
+```
+
+## Usage
+
+The CLI scaffolds new domain modules with the correct folder structure, types, and handler signatures.
+
+```bash
+# Scaffold a new aggregate
+noddde new aggregate
+
+# Scaffold a new projection
+noddde new projection
+
+# Scaffold a new saga
+noddde new saga
+```
+
+The interactive prompts guide you through naming and configuration. Generated files follow noddde conventions: pure functions, typed events and commands, and the Decider pattern.
+
+## Related Packages
+
+| Package                                                          | Description                                 |
+| :--------------------------------------------------------------- | :------------------------------------------ |
+| [`@noddde/core`](https://www.npmjs.com/package/@noddde/core)     | Types, interfaces, and definition functions |
+| [`@noddde/engine`](https://www.npmjs.com/package/@noddde/engine) | Runtime engine with domain orchestration    |
+
+## License
+
+MIT

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,89 @@
+# @noddde/core
+
+TypeScript types and definitions for DDD, CQRS, and Event Sourcing using the functional Decider pattern.
+
+**[Documentation](https://noddde.dev)** | **[GitHub](https://github.com/dogganidhal/noddde)**
+
+## Install
+
+```bash
+yarn add @noddde/core
+# or
+npm install @noddde/core
+```
+
+## What's Inside
+
+`@noddde/core` is the foundation of the noddde framework. It provides:
+
+- **Aggregate definitions** (`defineAggregate`) with the Decider pattern: `initialState`, `decide`, `evolve`
+- **Saga definitions** (`defineSaga`) for orchestrating cross-aggregate workflows as pure functions
+- **Projection definitions** (`defineProjection`) for building read models from event streams
+- **CQRS abstractions** for command and query buses, handlers, and typed messages
+- **Event-driven types** for event buses, event handlers, and domain events with metadata
+- **Persistence interfaces** for event-sourced and state-stored strategies
+- **Infrastructure contracts** for locking, snapshots, outbox, idempotency, and unit of work
+
+Zero runtime dependencies. Strict TypeScript with full type inference.
+
+## Usage
+
+```typescript
+import { defineAggregate, type DefineAggregateTypes } from "@noddde/core";
+
+type BankAccountTypes = DefineAggregateTypes<{
+  name: "BankAccount";
+  state: { balance: number };
+  events: {
+    DepositMade: { amount: number };
+    WithdrawalMade: { amount: number };
+  };
+  commands: {
+    Deposit: { amount: number };
+    Withdraw: { amount: number };
+  };
+}>;
+
+const BankAccount = defineAggregate<BankAccountTypes>({
+  initialState: { balance: 0 },
+
+  decide: {
+    Deposit: (command, state) => ({
+      name: "DepositMade",
+      payload: { amount: command.payload.amount },
+    }),
+    Withdraw: (command, state) => {
+      if (state.balance < command.payload.amount) {
+        throw new Error("Insufficient funds");
+      }
+      return {
+        name: "WithdrawalMade",
+        payload: { amount: command.payload.amount },
+      };
+    },
+  },
+
+  evolve: {
+    DepositMade: (payload, state) => ({
+      balance: state.balance + payload.amount,
+    }),
+    WithdrawalMade: (payload, state) => ({
+      balance: state.balance - payload.amount,
+    }),
+  },
+});
+```
+
+## Related Packages
+
+| Package                                                            | Description                                                            |
+| :----------------------------------------------------------------- | :--------------------------------------------------------------------- |
+| [`@noddde/engine`](https://www.npmjs.com/package/@noddde/engine)   | Runtime engine with domain orchestration and in-memory implementations |
+| [`@noddde/testing`](https://www.npmjs.com/package/@noddde/testing) | Test harnesses for aggregates, sagas, projections, and domains         |
+| [`@noddde/drizzle`](https://www.npmjs.com/package/@noddde/drizzle) | Drizzle ORM persistence adapter                                        |
+| [`@noddde/prisma`](https://www.npmjs.com/package/@noddde/prisma)   | Prisma persistence adapter                                             |
+| [`@noddde/typeorm`](https://www.npmjs.com/package/@noddde/typeorm) | TypeORM persistence adapter                                            |
+
+## License
+
+MIT

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -1,0 +1,77 @@
+# @noddde/engine
+
+Runtime engine for noddde: domain orchestration and in-memory implementations for DDD, CQRS, and Event Sourcing.
+
+**[Documentation](https://noddde.dev)** | **[GitHub](https://github.com/dogganidhal/noddde)**
+
+## Install
+
+```bash
+yarn add @noddde/core @noddde/engine
+# or
+npm install @noddde/core @noddde/engine
+```
+
+## What's Inside
+
+`@noddde/engine` provides:
+
+- **Domain orchestration** (`defineDomain`, `wireDomain`) to compose aggregates, projections, and sagas into a running domain
+- **In-memory implementations** for all infrastructure contracts: command bus, query bus, event bus, aggregate persistence, saga persistence, snapshot store, outbox store, unit of work, locking, and idempotency
+- **Outbox relay** for reliable event publishing
+- **Logger** with pluggable backends
+
+The in-memory implementations are useful for development, testing, and prototyping. For production, swap them out with a persistence adapter (`@noddde/drizzle`, `@noddde/prisma`, or `@noddde/typeorm`).
+
+## Usage
+
+```typescript
+import { defineDomain, wireDomain } from "@noddde/engine";
+import { BankAccount } from "./aggregates/bank-account";
+import { BalanceProjection } from "./projections/balance";
+
+const definition = defineDomain({
+  writeModel: {
+    aggregates: { BankAccount },
+  },
+  readModel: {
+    projections: { BalanceProjection },
+  },
+});
+
+// Wire with in-memory backends (no adapter needed)
+const domain = await wireDomain(definition);
+
+// Dispatch commands
+await domain.commandBus.dispatch({
+  name: "Deposit",
+  targetAggregateId: "acc-1",
+  payload: { amount: 100 },
+});
+```
+
+### With a Persistence Adapter
+
+```typescript
+import { DrizzleAdapter } from "@noddde/drizzle";
+
+const adapter = new DrizzleAdapter(db);
+
+const domain = await wireDomain(definition, {
+  persistenceAdapter: adapter,
+});
+```
+
+## Related Packages
+
+| Package                                                            | Description                                                    |
+| :----------------------------------------------------------------- | :------------------------------------------------------------- |
+| [`@noddde/core`](https://www.npmjs.com/package/@noddde/core)       | Types, interfaces, and definition functions                    |
+| [`@noddde/testing`](https://www.npmjs.com/package/@noddde/testing) | Test harnesses for aggregates, sagas, projections, and domains |
+| [`@noddde/drizzle`](https://www.npmjs.com/package/@noddde/drizzle) | Drizzle ORM persistence adapter                                |
+| [`@noddde/prisma`](https://www.npmjs.com/package/@noddde/prisma)   | Prisma persistence adapter                                     |
+| [`@noddde/typeorm`](https://www.npmjs.com/package/@noddde/typeorm) | TypeORM persistence adapter                                    |
+
+## License
+
+MIT

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,0 +1,94 @@
+# @noddde/testing
+
+Test harnesses and utilities for noddde domains: Given / When / Then style testing for aggregates, projections, sagas, and full domain integration tests.
+
+**[Documentation](https://noddde.dev)** | **[GitHub](https://github.com/dogganidhal/noddde)**
+
+## Install
+
+```bash
+yarn add --dev @noddde/testing
+# or
+npm install --save-dev @noddde/testing
+```
+
+## What's Inside
+
+- **`testAggregate`** / **`evolveAggregate`** &mdash; Unit test aggregate decide and evolve handlers
+- **`testProjection`** &mdash; Unit test projection reducers
+- **`testSaga`** &mdash; Unit test saga handlers and returned commands
+- **`testDomain`** &mdash; Integration test a full domain with command dispatch and event flow
+- **Metadata utilities** &mdash; `stripMetadata`, `expectValidMetadata`, `expectSameCorrelation`, `expectCausationChain`
+
+No database or broker setup required. All harnesses run entirely in-memory.
+
+## Usage
+
+### Aggregate Testing
+
+```typescript
+import { testAggregate } from "@noddde/testing";
+import { BankAccount } from "../aggregates/bank-account";
+
+const result = await testAggregate(BankAccount)
+  .given(
+    { name: "AccountCreated", payload: { id: "acc-1" } },
+    { name: "DepositMade", payload: { amount: 1000 } },
+  )
+  .when({
+    name: "Withdraw",
+    targetAggregateId: "acc-1",
+    payload: { amount: 200 },
+  })
+  .execute();
+
+expect(result.events[0].name).toBe("WithdrawalMade");
+expect(result.state.balance).toBe(800);
+```
+
+### Saga Testing
+
+```typescript
+import { testSaga } from "@noddde/testing";
+import { OrderFulfillmentSaga } from "../sagas/order-fulfillment";
+
+const result = await testSaga(OrderFulfillmentSaga)
+  .given({ orderId: "order-1", status: "pending" })
+  .when({
+    name: "PaymentCompleted",
+    payload: { orderId: "order-1", shipmentId: "ship-1" },
+  })
+  .execute();
+
+expect(result.commands).toHaveLength(2);
+expect(result.state.status).toBe("awaiting_shipment");
+```
+
+### Domain Integration Testing
+
+```typescript
+import { testDomain } from "@noddde/testing";
+
+const { commandBus, queryBus, spy } = await testDomain(domainDefinition);
+
+await commandBus.dispatch({
+  name: "Deposit",
+  targetAggregateId: "acc-1",
+  payload: { amount: 100 },
+});
+
+expect(spy.publishedEvents).toContainEqual(
+  expect.objectContaining({ name: "DepositMade" }),
+);
+```
+
+## Related Packages
+
+| Package                                                          | Description                                 |
+| :--------------------------------------------------------------- | :------------------------------------------ |
+| [`@noddde/core`](https://www.npmjs.com/package/@noddde/core)     | Types, interfaces, and definition functions |
+| [`@noddde/engine`](https://www.npmjs.com/package/@noddde/engine) | Runtime engine with domain orchestration    |
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- Add focused `README.md` for all 10 published npm packages (`core`, `engine`, `cli`, `testing`, `drizzle`, `prisma`, `typeorm`, `rabbitmq`, `nats`, `kafka`) so they render on npmjs.com
- Update the release workflow to publish `@noddde/cli` (Tier 1), `@noddde/rabbitmq`, `@noddde/nats`, and `@noddde/kafka` (Tier 3) with correct internal dependency version rewriting
- Modernize the root README: replace deprecated `createDrizzlePersistence` example with `DrizzleAdapter` + `persistenceAdapter`, add a full Packages section, and add npm/license badges
- Update ROADMAP: move OTel and Distributed Event Bus Adapters to the Shipped section

## Test plan

- [ ] Verify each package README renders correctly on GitHub
- [ ] Verify the release workflow YAML is valid (`act` or dry-run)
- [ ] Confirm root README code examples match the current API

🤖 Generated with [Claude Code](https://claude.com/claude-code)