### PR TITLE
feat(cli): add commands for extending existing aggregates and projections

### DIFF
--- a/docs/content/docs/getting-started/cli.mdx
+++ b/docs/content/docs/getting-started/cli.mdx
@@ -1,9 +1,12 @@
 ---
 title: CLI
-description: Scaffold noddde projects, domains, aggregates, projections, and sagas from the command line
+description: Scaffold and extend noddde projects, domains, aggregates, projections, and sagas from the command line
 ---
 
-The `@noddde/cli` package provides generators that scaffold noddde modules with the correct folder structure, type definitions, and wiring code.
+The `@noddde/cli` package provides generators that scaffold noddde modules with the correct folder structure, type definitions, and wiring code. Two command groups are available:
+
+- **`noddde new`** — create new modules from scratch (projects, domains, aggregates, projections, sagas)
+- **`noddde add`** — extend existing aggregates and projections with new commands, queries, or event handlers
 
 ## Installation
 
@@ -149,6 +152,134 @@ Generates:
 </Files>
 
 On-entries are `{ id, handle }` objects typed with `InferSagaOnEntry<Def, "EventName">` once event types are wired. They are imported into the `defineSaga` `on` map. Each entry specifies how to extract the saga ID from the event and how to handle the state transition.
+
+## Extending Existing Modules
+
+After initial scaffolding, you rarely work with a single `Create` command or `Get` query — aggregates grow commands over time, and projections grow queries and event handlers. The `noddde add` command group (alias `noddde a`) generates the new handler files and wires them into the existing barrels and definition file, so you don't have to touch imports, `DefineCommands`/`DefineEvents`/`DefineQueries` unions, or the `decide`/`evolve`/`queryHandlers`/`on` maps by hand.
+
+All `add` subcommands are **idempotent** — running them twice leaves your files unchanged.
+
+### `noddde add command <name>`
+
+Adds a command (with decider and evolver) to an existing aggregate.
+
+```bash
+noddde add command PlaceBid --aggregate auction
+```
+
+If you omit `--aggregate`, the CLI lists the aggregates it finds under `src/domain/write-model/aggregates/` and prompts you to pick one.
+
+The CLI auto-derives the event name from the command name using the convention **verb + subject → subject + past-tense verb**:
+
+| Command         | Derived event    |
+| :-------------- | :--------------- |
+| `PlaceBid`      | `BidPlaced`      |
+| `CreateAuction` | `AuctionCreated` |
+| `CloseAuction`  | `AuctionClosed`  |
+| `Submit`        | `Submitted`      |
+
+You're shown the derived name and can confirm it or type a different one. Pass `--event <name>` to skip the prompt.
+
+The command creates three new files under the target aggregate:
+
+<Files>
+  <Folder name="auction">
+    <Folder name="commands">
+      <File name="place-bid.ts" />
+    </Folder>
+    <Folder name="deciders">
+      <File name="decide-place-bid.ts" />
+    </Folder>
+    <Folder name="evolvers">
+      <File name="evolve-bid-placed.ts" />
+    </Folder>
+  </Folder>
+</Files>
+
+And updates four existing files:
+
+- `commands/index.ts` — appends the payload re-export
+- `deciders/index.ts` — appends the decider re-export
+- `evolvers/index.ts` — appends the evolver re-export
+- `auction.ts` — adds imports, inserts into `DefineCommands`, `DefineEvents`, `decide`, and `evolve`
+
+You then fill in the payload fields, decider logic, and evolver state transition — everything else is wired for you.
+
+### `noddde add query <name>`
+
+Adds a query (with handler) to an existing projection.
+
+```bash
+noddde add query ListActiveAuctions --projection auction-summary
+```
+
+If you omit `--projection`, the CLI prompts you to pick from the projections under `src/domain/read-model/projections/`.
+
+Creates two new files under the projection:
+
+<Files>
+  <Folder name="auction-summary">
+    <Folder name="queries">
+      <File name="list-active-auctions.ts" />
+    </Folder>
+    <Folder name="query-handlers">
+      <File name="handle-list-active-auctions.ts" />
+    </Folder>
+  </Folder>
+</Files>
+
+And updates:
+
+- `queries/index.ts` — adds the payload import and a new entry in `DefineQueries<{...}>` (result type defaults to `<View> | null`)
+- `query-handlers/index.ts` — appends the handler re-export
+- `auction-summary.ts` — adds the handler import and the entry in `queryHandlers`
+
+The generated handler is typed with `InferProjectionQueryHandler<Def, "QueryName">` and defaults to `views.load(query.payload.id)`. Adjust the payload shape and the handler body to fit your query.
+
+### `noddde add event-handler <event-name>`
+
+Adds an event handler (on-entry / view reducer) to an existing projection.
+
+```bash
+noddde add event-handler BidPlaced --projection auction-summary
+```
+
+If you omit `--projection`, the CLI prompts you to pick.
+
+Creates one new file:
+
+<Files>
+  <Folder name="auction-summary">
+    <Folder name="on-entries">
+      <File name="on-bid-placed.ts" />
+    </Folder>
+  </Folder>
+</Files>
+
+And updates:
+
+- `on-entries/index.ts` — appends the reducer re-export
+- `auction-summary.ts` — adds the import and the entry in the `on` map
+
+The generated reducer takes the event and the current view and returns a new view. Once event types are wired in the projection's `events` union, replace the stub signature with `InferProjectionEventHandler<Def, "EventName">` for full type inference.
+
+### Aliases
+
+All `add` subcommands have short aliases:
+
+| Full                       | Alias         |
+| :------------------------- | :------------ |
+| `noddde add command`       | `noddde a c`  |
+| `noddde add query`         | `noddde a q`  |
+| `noddde add event-handler` | `noddde a eh` |
+
+### Flag reference
+
+| Flag           | Applies to                       | Purpose                                                |
+| :------------- | :------------------------------- | :----------------------------------------------------- |
+| `--aggregate`  | `add command`                    | Target aggregate name (interactive picker if omitted)  |
+| `--projection` | `add query`, `add event-handler` | Target projection name (interactive picker if omitted) |
+| `--event`      | `add command`                    | Override the auto-derived event name                   |
 
 ## Name Handling
 

--- a/docs/content/docs/modeling/command-handlers.mdx
+++ b/docs/content/docs/modeling/command-handlers.mdx
@@ -21,12 +21,15 @@ Every aggregate decide handler has this shape:
 The return value is always one or more events describing what happened. The framework narrows the `command` parameter per handler -- when you write the handler for `AuthorizeTransaction`, the `command` type is narrowed to `{ name: "AuthorizeTransaction"; payload: { amount: number; merchant: string }; targetAggregateId: string }`. You never need to check the command name or cast anything.
 
 <Callout type="info">
-  You can scaffold a new command with its decider and evolver -- and have them
-  wired into the aggregate definition automatically -- with `noddde add command
-  AuthorizeTransaction --aggregate bank-account`. The CLI derives the event name
-  (`AuthorizeTransaction` → `TransactionAuthorized`) and lets you confirm or
-  override it. See [CLI
-  Reference](/docs/getting-started/cli#noddde-add-command-name) for details.
+  **Scaffold with the CLI.**
+
+- **Add a command:** `noddde add command AuthorizeTransaction --aggregate bank-account`
+
+The CLI creates the decider and evolver, wires them into the aggregate
+definition, and derives the event name (`AuthorizeTransaction` →
+`TransactionAuthorized`) with an interactive confirm/override prompt. See the
+[CLI Reference](/docs/getting-started/cli#noddde-add-command-name) for details.
+
 </Callout>
 
 The recommended pattern is to define each decide handler as a standalone function in its own file, typed with `InferDecideHandler`. This gives you full type inference from the `AggregateTypes` bundle without manually reconstructing parameter types:

--- a/docs/content/docs/modeling/command-handlers.mdx
+++ b/docs/content/docs/modeling/command-handlers.mdx
@@ -20,6 +20,15 @@ Every aggregate decide handler has this shape:
 
 The return value is always one or more events describing what happened. The framework narrows the `command` parameter per handler -- when you write the handler for `AuthorizeTransaction`, the `command` type is narrowed to `{ name: "AuthorizeTransaction"; payload: { amount: number; merchant: string }; targetAggregateId: string }`. You never need to check the command name or cast anything.
 
+<Callout type="info">
+  You can scaffold a new command with its decider and evolver -- and have them
+  wired into the aggregate definition automatically -- with `noddde add command
+  AuthorizeTransaction --aggregate bank-account`. The CLI derives the event name
+  (`AuthorizeTransaction` → `TransactionAuthorized`) and lets you confirm or
+  override it. See [CLI
+  Reference](/docs/getting-started/cli#noddde-add-command-name) for details.
+</Callout>
+
 The recommended pattern is to define each decide handler as a standalone function in its own file, typed with `InferDecideHandler`. This gives you full type inference from the `AggregateTypes` bundle without manually reconstructing parameter types:
 
 ```typescript

--- a/docs/content/docs/modeling/defining-aggregates.mdx
+++ b/docs/content/docs/modeling/defining-aggregates.mdx
@@ -14,11 +14,15 @@ An aggregate definition is a **blueprint**, not a singleton. You define the beha
 The rest of this page walks through building a complete aggregate from scratch using the banking domain as a running example.
 
 <Callout type="info">
-  You can scaffold this entire structure with the CLI: `noddde new aggregate
-  BankAccount`. Once the aggregate exists, add new commands (with their decider
-  and evolver, fully wired into the definition) with `noddde add command
-  AuthorizeTransaction --aggregate bank-account`. See [CLI
-  Reference](/docs/getting-started/cli#noddde-new-aggregate-name) for details.
+  **Scaffold with the CLI.**
+
+- **New aggregate:** `noddde new aggregate BankAccount`
+- **Add a command:** `noddde add command AuthorizeTransaction --aggregate bank-account`
+
+The `add` command creates the decider and evolver and wires them into the
+aggregate definition. See the [CLI
+Reference](/docs/getting-started/cli#noddde-new-aggregate-name) for details.
+
 </Callout>
 
 ## Step 1: Define Events

--- a/docs/content/docs/modeling/defining-aggregates.mdx
+++ b/docs/content/docs/modeling/defining-aggregates.mdx
@@ -15,7 +15,9 @@ The rest of this page walks through building a complete aggregate from scratch u
 
 <Callout type="info">
   You can scaffold this entire structure with the CLI: `noddde new aggregate
-  BankAccount`. See [CLI
+  BankAccount`. Once the aggregate exists, add new commands (with their decider
+  and evolver, fully wired into the definition) with `noddde add command
+  AuthorizeTransaction --aggregate bank-account`. See [CLI
   Reference](/docs/getting-started/cli#noddde-new-aggregate-name) for details.
 </Callout>
 

--- a/docs/content/docs/read-model/projections.mdx
+++ b/docs/content/docs/read-model/projections.mdx
@@ -12,13 +12,16 @@ An aggregate's state is structured to enforce business rules -- not to serve que
 Projections solve this by building query-specific views from the event stream. Adding a new read model means writing a new projection. The write model is never touched.
 
 <Callout type="info">
-  You can scaffold a projection with the CLI: `noddde new projection
-  OrderSummary`. To extend an existing projection, use `noddde add query
-  ListOrders --projection order-summary` to add a new query (with handler) or
-  `noddde add event-handler OrderShipped --projection order-summary` to add a
-  new event reducer — both wire themselves into the projection definition. See
-  [CLI Reference](/docs/getting-started/cli#noddde-new-projection-name) for
-  details.
+  **Scaffold with the CLI.**
+
+- **New projection:** `noddde new projection OrderSummary`
+- **Add a query:** `noddde add query ListOrders --projection order-summary`
+- **Add an event reducer:** `noddde add event-handler OrderShipped --projection order-summary`
+
+The `add` commands wire themselves into the projection definition. See the
+[CLI Reference](/docs/getting-started/cli#noddde-new-projection-name) for
+details.
+
 </Callout>
 
 ## The Event Flow

--- a/docs/content/docs/read-model/projections.mdx
+++ b/docs/content/docs/read-model/projections.mdx
@@ -13,8 +13,12 @@ Projections solve this by building query-specific views from the event stream. A
 
 <Callout type="info">
   You can scaffold a projection with the CLI: `noddde new projection
-  OrderSummary`. See [CLI
-  Reference](/docs/getting-started/cli#noddde-new-projection-name) for details.
+  OrderSummary`. To extend an existing projection, use `noddde add query
+  ListOrders --projection order-summary` to add a new query (with handler) or
+  `noddde add event-handler OrderShipped --projection order-summary` to add a
+  new event reducer — both wire themselves into the projection definition. See
+  [CLI Reference](/docs/getting-started/cli#noddde-new-projection-name) for
+  details.
 </Callout>
 
 ## The Event Flow

--- a/docs/content/docs/read-model/queries.mdx
+++ b/docs/content/docs/read-model/queries.mdx
@@ -5,6 +5,13 @@ description: Defining type-safe queries with DefineQueries, implementing query h
 
 Queries are read-only requests for data. They never modify state. In a CQRS architecture, queries are the counterpart to commands on the write side -- commands express intent to change, queries express a request to read. For background on the command/query separation, see [CQRS and Event Sourcing](/docs/core-concepts/cqrs-and-event-sourcing).
 
+<Callout type="info">
+  You can scaffold a new query with its handler -- and have both wired into the
+  projection's `DefineQueries` union and `queryHandlers` map -- with `noddde add
+  query ListBankAccountTransactions --projection bank-account-summary`. See [CLI
+  Reference](/docs/getting-started/cli#noddde-add-query-name) for details.
+</Callout>
+
 ## The Query Interface
 
 A query is defined by extending `Query<TResult>`:

--- a/docs/content/docs/read-model/queries.mdx
+++ b/docs/content/docs/read-model/queries.mdx
@@ -6,10 +6,14 @@ description: Defining type-safe queries with DefineQueries, implementing query h
 Queries are read-only requests for data. They never modify state. In a CQRS architecture, queries are the counterpart to commands on the write side -- commands express intent to change, queries express a request to read. For background on the command/query separation, see [CQRS and Event Sourcing](/docs/core-concepts/cqrs-and-event-sourcing).
 
 <Callout type="info">
-  You can scaffold a new query with its handler -- and have both wired into the
-  projection's `DefineQueries` union and `queryHandlers` map -- with `noddde add
-  query ListBankAccountTransactions --projection bank-account-summary`. See [CLI
-  Reference](/docs/getting-started/cli#noddde-add-query-name) for details.
+  **Scaffold with the CLI.**
+
+- **Add a query:** `noddde add query ListBankAccountTransactions --projection bank-account-summary`
+
+The CLI creates the payload and handler and wires them into the projection's
+`DefineQueries` union and `queryHandlers` map. See the [CLI
+Reference](/docs/getting-started/cli#noddde-add-query-name) for details.
+
 </Callout>
 
 ## The Query Interface

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @noddde/cli
 
-CLI tool for scaffolding noddde DDD aggregates, projections, and sagas.
+CLI tool for scaffolding and extending noddde DDD aggregates, projections, and sagas.
 
 **[Documentation](https://noddde.dev)** | **[GitHub](https://github.com/dogganidhal/noddde)**
 
@@ -16,20 +16,31 @@ npm install -g @noddde/cli
 
 ## Usage
 
-The CLI scaffolds new domain modules with the correct folder structure, types, and handler signatures.
+The CLI has two command groups:
+
+### `noddde new` — scaffold new modules
 
 ```bash
-# Scaffold a new aggregate
-noddde new aggregate
-
-# Scaffold a new projection
-noddde new projection
-
-# Scaffold a new saga
-noddde new saga
+noddde new project <name>       # full runnable project
+noddde new domain <name>        # domain layer only
+noddde new aggregate <name>     # single aggregate
+noddde new projection <name>    # single projection
+noddde new saga <name>          # single saga
 ```
 
-The interactive prompts guide you through naming and configuration. Generated files follow noddde conventions: pure functions, typed events and commands, and the Decider pattern.
+### `noddde add` — extend existing modules
+
+```bash
+noddde add command <name> [--aggregate <name>] [--event <name>]
+noddde add query <name> [--projection <name>]
+noddde add event-handler <event-name> [--projection <name>]
+```
+
+`add` commands generate the new handler files and wire them into the existing barrels, `DefineCommands`/`DefineEvents`/`DefineQueries` unions, and `decide`/`evolve`/`queryHandlers`/`on` maps — no manual import juggling. They're idempotent: running twice leaves files unchanged.
+
+When adding a command, the event name is auto-derived (`PlaceBid` → `BidPlaced`) with interactive confirmation. Override via `--event`. If `--aggregate` or `--projection` is omitted, the CLI prompts you to pick from discovered modules.
+
+Generated files follow noddde conventions: pure functions, typed events and commands, and the Decider pattern.
 
 ## Related Packages
 

--- a/packages/cli/src/__tests__/generators/add-command.test.ts
+++ b/packages/cli/src/__tests__/generators/add-command.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile, access } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { generateAggregate } from "../../generators/aggregate.js";
+import { addCommandToAggregate } from "../../generators/add-command.js";
+
+describe("addCommandToAggregate", () => {
+  let tmpDir: string;
+  let aggDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "noddde-test-"));
+    await generateAggregate("Auction", tmpDir);
+    aggDir = path.join(tmpDir, "auction");
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates command payload, decider, and evolver files", async () => {
+    await addCommandToAggregate("PlaceBid", aggDir, {
+      eventName: "BidPlaced",
+    });
+
+    const expectedFiles = [
+      "commands/place-bid.ts",
+      "deciders/decide-place-bid.ts",
+      "evolvers/evolve-bid-placed.ts",
+    ];
+
+    for (const file of expectedFiles) {
+      await expect(access(path.join(aggDir, file))).resolves.toBeUndefined();
+    }
+  });
+
+  it("generates command payload interface", async () => {
+    await addCommandToAggregate("PlaceBid", aggDir, {
+      eventName: "BidPlaced",
+    });
+
+    const content = await readFile(
+      path.join(aggDir, "commands/place-bid.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("interface PlaceBidPayload");
+  });
+
+  it("generates decider using InferDecideHandler", async () => {
+    await addCommandToAggregate("PlaceBid", aggDir, {
+      eventName: "BidPlaced",
+    });
+
+    const content = await readFile(
+      path.join(aggDir, "deciders/decide-place-bid.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("InferDecideHandler");
+    expect(content).toContain("AuctionDef");
+    expect(content).toContain("decidePlaceBid");
+    expect(content).toContain('"BidPlaced" as const');
+  });
+
+  it("generates evolver using InferEvolveHandler", async () => {
+    await addCommandToAggregate("PlaceBid", aggDir, {
+      eventName: "BidPlaced",
+    });
+
+    const content = await readFile(
+      path.join(aggDir, "evolvers/evolve-bid-placed.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("InferEvolveHandler");
+    expect(content).toContain("AuctionDef");
+    expect(content).toContain("evolveBidPlaced");
+  });
+
+  it("updates commands/index.ts barrel with new export", async () => {
+    await addCommandToAggregate("PlaceBid", aggDir, {
+      eventName: "BidPlaced",
+    });
+
+    const content = await readFile(
+      path.join(aggDir, "commands/index.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("CreateAuctionPayload");
+    expect(content).toContain("PlaceBidPayload");
+  });
+
+  it("updates deciders/index.ts barrel with new export", async () => {
+    await addCommandToAggregate("PlaceBid", aggDir, {
+      eventName: "BidPlaced",
+    });
+
+    const content = await readFile(
+      path.join(aggDir, "deciders/index.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("decideCreateAuction");
+    expect(content).toContain("decidePlaceBid");
+  });
+
+  it("updates evolvers/index.ts barrel with new export", async () => {
+    await addCommandToAggregate("PlaceBid", aggDir, {
+      eventName: "BidPlaced",
+    });
+
+    const content = await readFile(
+      path.join(aggDir, "evolvers/index.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("evolveAuctionCreated");
+    expect(content).toContain("evolveBidPlaced");
+  });
+
+  it("updates aggregate definition file with new command and event", async () => {
+    await addCommandToAggregate("PlaceBid", aggDir, {
+      eventName: "BidPlaced",
+    });
+
+    const content = await readFile(path.join(aggDir, "auction.ts"), "utf-8");
+
+    // Imports added
+    expect(content).toContain("PlaceBidPayload");
+    expect(content).toContain("decidePlaceBid");
+    expect(content).toContain("evolveBidPlaced");
+
+    // DefineCommands updated
+    expect(content).toContain("PlaceBid: PlaceBidPayload;");
+
+    // DefineEvents updated
+    expect(content).toContain("BidPlaced: { id: string };");
+
+    // decide map updated
+    expect(content).toContain("PlaceBid: decidePlaceBid,");
+
+    // evolve map updated
+    expect(content).toContain("BidPlaced: evolveBidPlaced,");
+  });
+
+  it("is idempotent — skips if command already exists", async () => {
+    await addCommandToAggregate("PlaceBid", aggDir, {
+      eventName: "BidPlaced",
+    });
+
+    const contentBefore = await readFile(
+      path.join(aggDir, "auction.ts"),
+      "utf-8",
+    );
+
+    await addCommandToAggregate("PlaceBid", aggDir, {
+      eventName: "BidPlaced",
+    });
+
+    const contentAfter = await readFile(
+      path.join(aggDir, "auction.ts"),
+      "utf-8",
+    );
+    expect(contentAfter).toBe(contentBefore);
+  });
+
+  it("can add multiple commands sequentially", async () => {
+    await addCommandToAggregate("PlaceBid", aggDir, {
+      eventName: "BidPlaced",
+    });
+    await addCommandToAggregate("CloseAuction", aggDir, {
+      eventName: "AuctionClosed",
+    });
+
+    const content = await readFile(path.join(aggDir, "auction.ts"), "utf-8");
+    expect(content).toContain("PlaceBid: decidePlaceBid,");
+    expect(content).toContain("CloseAuction: decideCloseAuction,");
+    expect(content).toContain("BidPlaced: evolveBidPlaced,");
+    expect(content).toContain("AuctionClosed: evolveAuctionClosed,");
+  });
+
+  it("rejects invalid command names", async () => {
+    await expect(
+      addCommandToAggregate("123Invalid", aggDir, { eventName: "Invalid" }),
+    ).rejects.toThrow("Invalid name");
+  });
+});

--- a/packages/cli/src/__tests__/generators/add-event-handler.test.ts
+++ b/packages/cli/src/__tests__/generators/add-event-handler.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile, access } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { generateProjection } from "../../generators/projection.js";
+import { addEventHandlerToProjection } from "../../generators/add-event-handler.js";
+
+describe("addEventHandlerToProjection", () => {
+  let tmpDir: string;
+  let projDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "noddde-test-"));
+    await generateProjection("AuctionSummary", tmpDir);
+    projDir = path.join(tmpDir, "auction-summary");
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates on-entry file", async () => {
+    await addEventHandlerToProjection("BidPlaced", projDir);
+
+    await expect(
+      access(path.join(projDir, "on-entries/on-bid-placed.ts")),
+    ).resolves.toBeUndefined();
+  });
+
+  it("generates view reducer with correct event name", async () => {
+    await addEventHandlerToProjection("BidPlaced", projDir);
+
+    const content = await readFile(
+      path.join(projDir, "on-entries/on-bid-placed.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("onBidPlaced");
+    expect(content).toContain("AuctionSummaryView");
+    expect(content).toContain('"BidPlaced"');
+  });
+
+  it("updates on-entries/index.ts barrel", async () => {
+    await addEventHandlerToProjection("BidPlaced", projDir);
+
+    const content = await readFile(
+      path.join(projDir, "on-entries/index.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("onAuctionSummaryCreated");
+    expect(content).toContain("onBidPlaced");
+  });
+
+  it("updates projection definition file with new on-entry", async () => {
+    await addEventHandlerToProjection("BidPlaced", projDir);
+
+    const content = await readFile(
+      path.join(projDir, "auction-summary.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("onBidPlaced");
+    expect(content).toContain("BidPlaced:");
+  });
+
+  it("is idempotent — skips if handler already exists", async () => {
+    await addEventHandlerToProjection("BidPlaced", projDir);
+
+    const contentBefore = await readFile(
+      path.join(projDir, "auction-summary.ts"),
+      "utf-8",
+    );
+
+    await addEventHandlerToProjection("BidPlaced", projDir);
+
+    const contentAfter = await readFile(
+      path.join(projDir, "auction-summary.ts"),
+      "utf-8",
+    );
+    expect(contentAfter).toBe(contentBefore);
+  });
+
+  it("rejects invalid event names", async () => {
+    await expect(
+      addEventHandlerToProjection("123Invalid", projDir),
+    ).rejects.toThrow("Invalid name");
+  });
+});

--- a/packages/cli/src/__tests__/generators/add-query.test.ts
+++ b/packages/cli/src/__tests__/generators/add-query.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile, access } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { generateProjection } from "../../generators/projection.js";
+import { addQueryToProjection } from "../../generators/add-query.js";
+
+describe("addQueryToProjection", () => {
+  let tmpDir: string;
+  let projDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "noddde-test-"));
+    await generateProjection("AuctionSummary", tmpDir);
+    projDir = path.join(tmpDir, "auction-summary");
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates query payload and handler files", async () => {
+    await addQueryToProjection("ListAuctions", projDir);
+
+    const expectedFiles = [
+      "queries/list-auctions.ts",
+      "query-handlers/handle-list-auctions.ts",
+    ];
+
+    for (const file of expectedFiles) {
+      await expect(access(path.join(projDir, file))).resolves.toBeUndefined();
+    }
+  });
+
+  it("generates query payload interface", async () => {
+    await addQueryToProjection("ListAuctions", projDir);
+
+    const content = await readFile(
+      path.join(projDir, "queries/list-auctions.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("interface ListAuctionsPayload");
+  });
+
+  it("generates query handler using InferProjectionQueryHandler", async () => {
+    await addQueryToProjection("ListAuctions", projDir);
+
+    const content = await readFile(
+      path.join(projDir, "query-handlers/handle-list-auctions.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("InferProjectionQueryHandler");
+    expect(content).toContain("AuctionSummaryProjectionDef");
+    expect(content).toContain("handleListAuctions");
+  });
+
+  it("updates queries/index.ts with new import and DefineQueries entry", async () => {
+    await addQueryToProjection("ListAuctions", projDir);
+
+    const content = await readFile(
+      path.join(projDir, "queries/index.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("ListAuctionsPayload");
+    expect(content).toContain("ListAuctions:");
+  });
+
+  it("updates query-handlers/index.ts barrel", async () => {
+    await addQueryToProjection("ListAuctions", projDir);
+
+    const content = await readFile(
+      path.join(projDir, "query-handlers/index.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("handleGetAuctionSummary");
+    expect(content).toContain("handleListAuctions");
+  });
+
+  it("updates projection definition file with new handler", async () => {
+    await addQueryToProjection("ListAuctions", projDir);
+
+    const content = await readFile(
+      path.join(projDir, "auction-summary.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("handleListAuctions");
+    expect(content).toContain("ListAuctions: handleListAuctions,");
+  });
+
+  it("is idempotent — skips if query already exists", async () => {
+    await addQueryToProjection("ListAuctions", projDir);
+
+    const contentBefore = await readFile(
+      path.join(projDir, "auction-summary.ts"),
+      "utf-8",
+    );
+
+    await addQueryToProjection("ListAuctions", projDir);
+
+    const contentAfter = await readFile(
+      path.join(projDir, "auction-summary.ts"),
+      "utf-8",
+    );
+    expect(contentAfter).toBe(contentBefore);
+  });
+
+  it("rejects invalid query names", async () => {
+    await expect(addQueryToProjection("123Invalid", projDir)).rejects.toThrow(
+      "Invalid name",
+    );
+  });
+});

--- a/packages/cli/src/__tests__/utils/event-naming.test.ts
+++ b/packages/cli/src/__tests__/utils/event-naming.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { deriveEventName, eventKebab } from "../../utils/event-naming.js";
+
+describe("deriveEventName", () => {
+  it("converts PlaceBid → BidPlaced", () => {
+    expect(deriveEventName("PlaceBid")).toBe("BidPlaced");
+  });
+
+  it("converts CreateAuction → AuctionCreated", () => {
+    expect(deriveEventName("CreateAuction")).toBe("AuctionCreated");
+  });
+
+  it("converts CloseAuction → AuctionClosed", () => {
+    expect(deriveEventName("CloseAuction")).toBe("AuctionClosed");
+  });
+
+  it("handles single-word commands", () => {
+    expect(deriveEventName("Submit")).toBe("Submitted");
+  });
+
+  it("handles verbs ending in e", () => {
+    expect(deriveEventName("CloseAccount")).toBe("AccountClosed");
+  });
+
+  it("handles kebab-case input", () => {
+    expect(deriveEventName("place-bid")).toBe("BidPlaced");
+  });
+});
+
+describe("eventKebab", () => {
+  it("converts PascalCase to kebab-case", () => {
+    expect(eventKebab("BidPlaced")).toBe("bid-placed");
+  });
+
+  it("converts AuctionCreated to kebab-case", () => {
+    expect(eventKebab("AuctionCreated")).toBe("auction-created");
+  });
+});

--- a/packages/cli/src/__tests__/utils/file-modifier.test.ts
+++ b/packages/cli/src/__tests__/utils/file-modifier.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import {
+  insertBeforeMarker,
+  insertAfterLastMatch,
+  appendToBarrel,
+  insertImports,
+  fileContains,
+} from "../../utils/file-modifier.js";
+
+describe("file-modifier utilities", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "noddde-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("insertBeforeMarker", () => {
+    it("inserts content before a string marker", async () => {
+      const filePath = path.join(tmpDir, "test.ts");
+      await writeFile(filePath, `line1\n  // TODO: add more\nline3\n`, "utf-8");
+
+      const result = await insertBeforeMarker(
+        filePath,
+        "// TODO: add more",
+        "  newLine;",
+      );
+
+      expect(result).toEqual({ inserted: true, usedFallback: false });
+      const content = await readFile(filePath, "utf-8");
+      expect(content).toContain("newLine;");
+      expect(content.indexOf("newLine")).toBeLessThan(
+        content.indexOf("// TODO"),
+      );
+    });
+
+    it("preserves marker line indentation", async () => {
+      const filePath = path.join(tmpDir, "test.ts");
+      await writeFile(filePath, `{\n    // TODO: marker\n}\n`, "utf-8");
+
+      await insertBeforeMarker(filePath, "// TODO: marker", "inserted;");
+
+      const content = await readFile(filePath, "utf-8");
+      expect(content).toContain("    inserted;");
+    });
+
+    it("returns not inserted when marker not found", async () => {
+      const filePath = path.join(tmpDir, "test.ts");
+      await writeFile(filePath, `no marker here\n`, "utf-8");
+
+      const result = await insertBeforeMarker(
+        filePath,
+        "// MISSING",
+        "content",
+      );
+
+      expect(result).toEqual({ inserted: false, usedFallback: false });
+    });
+
+    it("uses fallback append when marker not found and option set", async () => {
+      const filePath = path.join(tmpDir, "test.ts");
+      await writeFile(filePath, `existing content\n`, "utf-8");
+
+      const result = await insertBeforeMarker(
+        filePath,
+        "// MISSING",
+        "appended;",
+        { fallbackAppend: true },
+      );
+
+      expect(result).toEqual({ inserted: true, usedFallback: true });
+      const content = await readFile(filePath, "utf-8");
+      expect(content).toContain("appended;");
+    });
+  });
+
+  describe("insertAfterLastMatch", () => {
+    it("inserts content after the last matching line", async () => {
+      const filePath = path.join(tmpDir, "test.ts");
+      await writeFile(
+        filePath,
+        `  decide: {\n    Create: decideCreate,\n  },\n`,
+        "utf-8",
+      );
+
+      const result = await insertAfterLastMatch(
+        filePath,
+        /^\s+\w+: decide\w+,$/,
+        "    PlaceBid: decidePlaceBid,",
+      );
+
+      expect(result).toBe(true);
+      const content = await readFile(filePath, "utf-8");
+      expect(content).toContain("PlaceBid: decidePlaceBid,");
+    });
+
+    it("returns false when no match found", async () => {
+      const filePath = path.join(tmpDir, "test.ts");
+      await writeFile(filePath, `no match here\n`, "utf-8");
+
+      const result = await insertAfterLastMatch(
+        filePath,
+        /decide\w+/,
+        "content",
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("appendToBarrel", () => {
+    it("appends export line to barrel file", async () => {
+      const filePath = path.join(tmpDir, "index.ts");
+      await writeFile(
+        filePath,
+        `export { existing } from "./existing.js";\n`,
+        "utf-8",
+      );
+
+      await appendToBarrel(
+        filePath,
+        `export { newThing } from "./new-thing.js";`,
+      );
+
+      const content = await readFile(filePath, "utf-8");
+      expect(content).toContain("existing");
+      expect(content).toContain("newThing");
+    });
+  });
+
+  describe("insertImports", () => {
+    it("inserts import after last existing import", async () => {
+      const filePath = path.join(tmpDir, "test.ts");
+      await writeFile(
+        filePath,
+        `import { a } from "./a.js";\nimport { b } from "./b.js";\n\nconst x = 1;\n`,
+        "utf-8",
+      );
+
+      await insertImports(filePath, `import { c } from "./c.js";`);
+
+      const content = await readFile(filePath, "utf-8");
+      const lines = content.split("\n");
+      const cIndex = lines.findIndex((l) => l.includes("./c.js"));
+      const bIndex = lines.findIndex((l) => l.includes("./b.js"));
+      expect(cIndex).toBeGreaterThan(bIndex);
+    });
+
+    it("prepends import when no existing imports", async () => {
+      const filePath = path.join(tmpDir, "test.ts");
+      await writeFile(filePath, `const x = 1;\n`, "utf-8");
+
+      await insertImports(filePath, `import { a } from "./a.js";`);
+
+      const content = await readFile(filePath, "utf-8");
+      expect(content.startsWith("import")).toBe(true);
+    });
+  });
+
+  describe("fileContains", () => {
+    it("returns true when string is found", async () => {
+      const filePath = path.join(tmpDir, "test.ts");
+      await writeFile(filePath, `const x = "hello";\n`, "utf-8");
+
+      expect(await fileContains(filePath, "hello")).toBe(true);
+    });
+
+    it("returns false when string is not found", async () => {
+      const filePath = path.join(tmpDir, "test.ts");
+      await writeFile(filePath, `const x = "hello";\n`, "utf-8");
+
+      expect(await fileContains(filePath, "goodbye")).toBe(false);
+    });
+  });
+});

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,0 +1,68 @@
+import { Command } from "commander";
+import { addCommandToAggregate } from "../generators/add-command.js";
+import { addQueryToProjection } from "../generators/add-query.js";
+import { addEventHandlerToProjection } from "../generators/add-event-handler.js";
+import {
+  resolveAggregateDir,
+  resolveProjectionDir,
+} from "../utils/discovery.js";
+import { promptEventName } from "../utils/event-naming.js";
+import { validateName } from "../utils/naming.js";
+
+/** Registers the `add` command and its subcommands. */
+export function registerAddCommand(program: Command): void {
+  const addCmd = program
+    .command("add")
+    .alias("a")
+    .description(
+      "Add a command, query, or event handler to an existing module",
+    );
+
+  addCmd
+    .command("command <name>")
+    .alias("c")
+    .description("Add a command (decider + evolver) to an existing aggregate")
+    .option(
+      "--aggregate <name>",
+      "Target aggregate name (interactive if omitted)",
+    )
+    .option("--event <name>", "Override the derived event name")
+    .action(
+      async (name: string, opts: { aggregate?: string; event?: string }) => {
+        validateName(name);
+        const { dir } = await resolveAggregateDir(opts.aggregate);
+        const eventName = opts.event ?? (await promptEventName(name));
+        await addCommandToAggregate(name, dir, { eventName });
+      },
+    );
+
+  addCmd
+    .command("query <name>")
+    .alias("q")
+    .description("Add a query (handler) to an existing projection")
+    .option(
+      "--projection <name>",
+      "Target projection name (interactive if omitted)",
+    )
+    .action(async (name: string, opts: { projection?: string }) => {
+      validateName(name);
+      const { dir } = await resolveProjectionDir(opts.projection);
+      await addQueryToProjection(name, dir);
+    });
+
+  addCmd
+    .command("event-handler <event-name>")
+    .alias("eh")
+    .description(
+      "Add an event handler (on-entry / view reducer) to an existing projection",
+    )
+    .option(
+      "--projection <name>",
+      "Target projection name (interactive if omitted)",
+    )
+    .action(async (eventName: string, opts: { projection?: string }) => {
+      validateName(eventName);
+      const { dir } = await resolveProjectionDir(opts.projection);
+      await addEventHandlerToProjection(eventName, dir);
+    });
+}

--- a/packages/cli/src/generators/add-command.ts
+++ b/packages/cli/src/generators/add-command.ts
@@ -1,0 +1,142 @@
+import path from "node:path";
+import { buildContext } from "../utils/context.js";
+import { validateName } from "../utils/naming.js";
+import { toKebabCase } from "../utils/naming.js";
+import { writeFileIfNotExists } from "../utils/fs.js";
+import {
+  fileContains,
+  insertBeforeMarker,
+  insertAfterLastMatch,
+  appendToBarrel,
+  insertImports,
+} from "../utils/file-modifier.js";
+import {
+  addCommandPayloadTemplate,
+  addDeciderTemplate,
+  addEvolverTemplate,
+} from "../templates/add/command.js";
+import type { AddCommandContext } from "../templates/add/command.js";
+
+/**
+ * Adds a command (with decider and evolver) to an existing aggregate.
+ *
+ * Creates new files for the command payload, decider, and evolver, then
+ * wires them into the aggregate's barrel files and definition file.
+ */
+export async function addCommandToAggregate(
+  commandName: string,
+  aggregateDir: string,
+  options: { eventName: string },
+): Promise<void> {
+  validateName(commandName);
+  validateName(options.eventName);
+
+  const command = buildContext(commandName);
+  const aggregateKebab = path.basename(aggregateDir);
+  const aggregate = buildContext(aggregateKebab);
+  const eventName = options.eventName;
+  const eventKebabName = toKebabCase(eventName);
+
+  const ctx: AddCommandContext = {
+    aggregate,
+    command,
+    eventName,
+    eventKebabName,
+  };
+
+  // ── Check idempotency ──────────────────────────────────────────
+  const aggDefFile = path.join(aggregateDir, `${aggregate.kebabName}.ts`);
+  if (await fileContains(aggDefFile, `${command.name}:`)) {
+    console.log(
+      `  Skipped — command "${command.name}" already exists in ${aggregate.name}`,
+    );
+    return;
+  }
+
+  // ── 1. Create new files ────────────────────────────────────────
+  const newFiles = [
+    {
+      relativePath: `commands/${command.kebabName}.ts`,
+      content: addCommandPayloadTemplate(ctx),
+    },
+    {
+      relativePath: `deciders/decide-${command.kebabName}.ts`,
+      content: addDeciderTemplate(ctx),
+    },
+    {
+      relativePath: `evolvers/evolve-${eventKebabName}.ts`,
+      content: addEvolverTemplate(ctx),
+    },
+  ];
+
+  for (const file of newFiles) {
+    const filePath = path.join(aggregateDir, file.relativePath);
+    const created = await writeFileIfNotExists(filePath, file.content);
+    if (created) {
+      console.log(`  Created ${path.relative(process.cwd(), filePath)}`);
+    } else {
+      console.log(
+        `  Skipped ${path.relative(process.cwd(), filePath)} (already exists)`,
+      );
+    }
+  }
+
+  // ── 2. Update barrel files ─────────────────────────────────────
+  const commandsIndex = path.join(aggregateDir, "commands/index.ts");
+  await appendToBarrel(
+    commandsIndex,
+    `export type { ${command.name}Payload } from "./${command.kebabName}.js";`,
+  );
+  console.log(`  Updated ${path.relative(process.cwd(), commandsIndex)}`);
+
+  const decidersIndex = path.join(aggregateDir, "deciders/index.ts");
+  await appendToBarrel(
+    decidersIndex,
+    `export { decide${command.name} } from "./decide-${command.kebabName}.js";`,
+  );
+  console.log(`  Updated ${path.relative(process.cwd(), decidersIndex)}`);
+
+  const evolversIndex = path.join(aggregateDir, "evolvers/index.ts");
+  await appendToBarrel(
+    evolversIndex,
+    `export { evolve${eventName} } from "./evolve-${eventKebabName}.js";`,
+  );
+  console.log(`  Updated ${path.relative(process.cwd(), evolversIndex)}`);
+
+  // ── 3. Update aggregate definition file ────────────────────────
+  // Add imports
+  await insertImports(
+    aggDefFile,
+    `import type { ${command.name}Payload } from "./commands/${command.kebabName}.js";\nimport { decide${command.name} } from "./deciders/index.js";\nimport { evolve${eventName} } from "./evolvers/index.js";`,
+  );
+
+  // Add to DefineCommands<{...}> before "// TODO: add more commands"
+  await insertBeforeMarker(
+    aggDefFile,
+    "// TODO: add more commands",
+    `  ${command.name}: ${command.name}Payload;`,
+  );
+
+  // Add to DefineEvents<{...}> before "// TODO: add more events"
+  await insertBeforeMarker(
+    aggDefFile,
+    "// TODO: add more events",
+    `  ${eventName}: { id: string };`,
+  );
+
+  // Add to decide: { ... } — insert after last existing entry
+  await insertAfterLastMatch(
+    aggDefFile,
+    /^\s+\w+: decide\w+,$/,
+    `    ${command.name}: decide${command.name},`,
+  );
+
+  // Add to evolve: { ... } — insert after last existing entry
+  await insertAfterLastMatch(
+    aggDefFile,
+    /^\s+\w+: evolve\w+,$/,
+    `    ${eventName}: evolve${eventName},`,
+  );
+
+  console.log(`  Updated ${path.relative(process.cwd(), aggDefFile)}`);
+}

--- a/packages/cli/src/generators/add-event-handler.ts
+++ b/packages/cli/src/generators/add-event-handler.ts
@@ -1,0 +1,95 @@
+import path from "node:path";
+import { buildContext } from "../utils/context.js";
+import { validateName, toKebabCase } from "../utils/naming.js";
+import { writeFileIfNotExists } from "../utils/fs.js";
+import {
+  fileContains,
+  insertAfterLastMatch,
+  appendToBarrel,
+  insertImports,
+} from "../utils/file-modifier.js";
+import { addEventHandlerTemplate } from "../templates/add/event-handler.js";
+import type { AddEventHandlerContext } from "../templates/add/event-handler.js";
+
+/**
+ * Adds an event handler (on-entry / view reducer) to an existing projection.
+ *
+ * Creates a new on-entry file and wires it into the projection's barrel
+ * and definition file.
+ */
+export async function addEventHandlerToProjection(
+  eventName: string,
+  projectionDir: string,
+): Promise<void> {
+  validateName(eventName);
+
+  const projectionKebab = path.basename(projectionDir);
+  const projection = buildContext(projectionKebab);
+  const eventKebabName = toKebabCase(eventName);
+
+  const ctx: AddEventHandlerContext = {
+    projection,
+    eventName,
+    eventKebabName,
+  };
+
+  // ── Check idempotency ──────────────────────────────────────────
+  const projDefFile = path.join(projectionDir, `${projection.kebabName}.ts`);
+  if (await fileContains(projDefFile, `on${eventName}`)) {
+    console.log(
+      `  Skipped — event handler "on${eventName}" already exists in ${projection.name}Projection`,
+    );
+    return;
+  }
+
+  // ── 1. Create new file ─────────────────────────────────────────
+  const filePath = path.join(
+    projectionDir,
+    `on-entries/on-${eventKebabName}.ts`,
+  );
+  const created = await writeFileIfNotExists(
+    filePath,
+    addEventHandlerTemplate(ctx),
+  );
+  if (created) {
+    console.log(`  Created ${path.relative(process.cwd(), filePath)}`);
+  } else {
+    console.log(
+      `  Skipped ${path.relative(process.cwd(), filePath)} (already exists)`,
+    );
+  }
+
+  // ── 2. Update barrel ───────────────────────────────────────────
+  const onEntriesIndex = path.join(projectionDir, "on-entries/index.ts");
+  await appendToBarrel(
+    onEntriesIndex,
+    `export { on${eventName} } from "./on-${eventKebabName}.js";`,
+  );
+  console.log(`  Updated ${path.relative(process.cwd(), onEntriesIndex)}`);
+
+  // ── 3. Update projection definition file ───────────────────────
+  // Add import for the handler
+  await insertImports(
+    projDefFile,
+    `import { on${eventName} } from "./on-entries/index.js";`,
+  );
+
+  // Add to on: { ... } map
+  // Try inserting after the last existing on-entry
+  const insertedAfterExisting = await insertAfterLastMatch(
+    projDefFile,
+    /^\s+reduce: on\w+,$/,
+    `  },\n    ${eventName}: {\n      reduce: on${eventName},`,
+  );
+
+  if (!insertedAfterExisting) {
+    // No existing on-entries — insert after "on: {"
+    await insertAfterLastMatch(
+      projDefFile,
+      /^\s+on:\s*\{$/,
+      `    ${eventName}: {\n      reduce: on${eventName},\n    },`,
+    );
+  }
+
+  console.log(`  Updated ${path.relative(process.cwd(), projDefFile)}`);
+}

--- a/packages/cli/src/generators/add-query.ts
+++ b/packages/cli/src/generators/add-query.ts
@@ -1,0 +1,120 @@
+import path from "node:path";
+import { buildContext } from "../utils/context.js";
+import { validateName } from "../utils/naming.js";
+import { writeFileIfNotExists } from "../utils/fs.js";
+import {
+  fileContains,
+  insertBeforeMarker,
+  insertAfterLastMatch,
+  appendToBarrel,
+  insertImports,
+} from "../utils/file-modifier.js";
+import {
+  addQueryPayloadTemplate,
+  addQueryHandlerTemplate,
+} from "../templates/add/query.js";
+import type { AddQueryContext } from "../templates/add/query.js";
+
+/**
+ * Adds a query (with handler) to an existing projection.
+ *
+ * Creates new files for the query payload and handler, then
+ * wires them into the projection's barrel files and definition file.
+ */
+export async function addQueryToProjection(
+  queryName: string,
+  projectionDir: string,
+): Promise<void> {
+  validateName(queryName);
+
+  const query = buildContext(queryName);
+  const projectionKebab = path.basename(projectionDir);
+  const projection = buildContext(projectionKebab);
+
+  const ctx: AddQueryContext = { projection, query };
+
+  // ── Check idempotency ──────────────────────────────────────────
+  const projDefFile = path.join(projectionDir, `${projection.kebabName}.ts`);
+  if (await fileContains(projDefFile, `${query.name}:`)) {
+    console.log(
+      `  Skipped — query "${query.name}" already exists in ${projection.name}Projection`,
+    );
+    return;
+  }
+
+  // ── 1. Create new files ────────────────────────────────────────
+  const newFiles = [
+    {
+      relativePath: `queries/${query.kebabName}.ts`,
+      content: addQueryPayloadTemplate(ctx),
+    },
+    {
+      relativePath: `query-handlers/handle-${query.kebabName}.ts`,
+      content: addQueryHandlerTemplate(ctx),
+    },
+  ];
+
+  for (const file of newFiles) {
+    const filePath = path.join(projectionDir, file.relativePath);
+    const created = await writeFileIfNotExists(filePath, file.content);
+    if (created) {
+      console.log(`  Created ${path.relative(process.cwd(), filePath)}`);
+    } else {
+      console.log(
+        `  Skipped ${path.relative(process.cwd(), filePath)} (already exists)`,
+      );
+    }
+  }
+
+  // ── 2. Update barrel files ─────────────────────────────────────
+  const queriesIndex = path.join(projectionDir, "queries/index.ts");
+
+  // Add import for the new query payload
+  await insertImports(
+    queriesIndex,
+    `import type { ${query.name}Payload } from "./${query.kebabName}.js";`,
+  );
+
+  // Add entry to DefineQueries<{...}> — insert before closing }>
+  // Find the last query entry and insert after it
+  const queriesHasEntries = await fileContains(queriesIndex, "payload:");
+  if (queriesHasEntries) {
+    await insertAfterLastMatch(
+      queriesIndex,
+      /^\s+};$/,
+      `  ${query.name}: {\n    payload: ${query.name}Payload;\n    result: ${projection.name}View | null;\n  };`,
+    );
+  } else {
+    // If no entries yet (shouldn't happen), insert before closing of DefineQueries
+    await insertBeforeMarker(
+      queriesIndex,
+      "}>",
+      `  ${query.name}: {\n    payload: ${query.name}Payload;\n    result: ${projection.name}View | null;\n  };`,
+    );
+  }
+
+  console.log(`  Updated ${path.relative(process.cwd(), queriesIndex)}`);
+
+  const handlersIndex = path.join(projectionDir, "query-handlers/index.ts");
+  await appendToBarrel(
+    handlersIndex,
+    `export { handle${query.name} } from "./handle-${query.kebabName}.js";`,
+  );
+  console.log(`  Updated ${path.relative(process.cwd(), handlersIndex)}`);
+
+  // ── 3. Update projection definition file ───────────────────────
+  // Add import for the handler
+  await insertImports(
+    projDefFile,
+    `import { handle${query.name} } from "./query-handlers/index.js";`,
+  );
+
+  // Add to queryHandlers: { ... } — insert after last existing entry
+  await insertAfterLastMatch(
+    projDefFile,
+    /^\s+\w+: handle\w+,$/,
+    `    ${query.name}: handle${query.name},`,
+  );
+
+  console.log(`  Updated ${path.relative(process.cwd(), projDefFile)}`);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { registerNewCommand } from "./commands/new.js";
+import { registerAddCommand } from "./commands/add.js";
 
 const program = new Command();
 
@@ -10,5 +11,6 @@ program
   .version("0.0.0");
 
 registerNewCommand(program);
+registerAddCommand(program);
 
 program.parse();

--- a/packages/cli/src/templates/add/command.ts
+++ b/packages/cli/src/templates/add/command.ts
@@ -1,0 +1,51 @@
+import type { TemplateContext } from "../../utils/context.js";
+
+/** Context for adding a command to an existing aggregate. */
+export interface AddCommandContext {
+  /** The aggregate context (PascalCase name, kebab, camel). */
+  aggregate: TemplateContext;
+  /** The command context (PascalCase name, kebab, camel). */
+  command: TemplateContext;
+  /** The derived event name in PascalCase, e.g. "BidPlaced". */
+  eventName: string;
+  /** kebab-case event name, e.g. "bid-placed". */
+  eventKebabName: string;
+}
+
+/** Template for a new command payload interface file. */
+export function addCommandPayloadTemplate(ctx: AddCommandContext): string {
+  return `/** Payload for the ${ctx.command.name} command. */
+export interface ${ctx.command.name}Payload {
+  // TODO: add command payload fields
+}
+`;
+}
+
+/** Template for a new decider handler file. */
+export function addDeciderTemplate(ctx: AddCommandContext): string {
+  return `import type { InferDecideHandler } from "@noddde/core";
+import type { ${ctx.aggregate.name}Def } from "../${ctx.aggregate.kebabName}.js";
+
+/** Decides the ${ctx.command.name} command. */
+export const decide${ctx.command.name}: InferDecideHandler<${ctx.aggregate.name}Def, "${ctx.command.name}"> = (command, _state) => ({
+  name: "${ctx.eventName}" as const,
+  payload: {
+    id: command.targetAggregateId,
+    // TODO: map command payload to event payload
+  },
+});
+`;
+}
+
+/** Template for a new evolver handler file. */
+export function addEvolverTemplate(ctx: AddCommandContext): string {
+  return `import type { InferEvolveHandler } from "@noddde/core";
+import type { ${ctx.aggregate.name}Def } from "../${ctx.aggregate.kebabName}.js";
+
+/** Evolves state for ${ctx.eventName}. */
+export const evolve${ctx.eventName}: InferEvolveHandler<${ctx.aggregate.name}Def, "${ctx.eventName}"> = (_payload, state) => ({
+  ...state,
+  // TODO: evolve state from event payload
+});
+`;
+}

--- a/packages/cli/src/templates/add/event-handler.ts
+++ b/packages/cli/src/templates/add/event-handler.ts
@@ -1,0 +1,33 @@
+import type { TemplateContext } from "../../utils/context.js";
+
+/** Context for adding an event handler to an existing projection. */
+export interface AddEventHandlerContext {
+  /** The projection context (PascalCase name, kebab, camel). */
+  projection: TemplateContext;
+  /** The event name in PascalCase, e.g. "BidPlaced". */
+  eventName: string;
+  /** kebab-case event name, e.g. "bid-placed". */
+  eventKebabName: string;
+}
+
+/** Template for a new projection on-entry (view reducer) file. */
+export function addEventHandlerTemplate(ctx: AddEventHandlerContext): string {
+  return `import type { ${ctx.projection.name}View } from "../queries/index.js";
+
+// TODO: once event types are wired in the projection def, replace with:
+// import type { InferProjectionEventHandler } from "@noddde/core";
+// import type { ${ctx.projection.name}ProjectionDef } from "../${ctx.projection.kebabName}.js";
+// export const on${ctx.eventName}: InferProjectionEventHandler<${ctx.projection.name}ProjectionDef, "${ctx.eventName}"> = { ... };
+
+/** Reduces a ${ctx.eventName} event into a view. */
+export function on${ctx.eventName}(
+  event: { name: "${ctx.eventName}"; payload: Record<string, unknown> },
+  view: ${ctx.projection.name}View,
+): ${ctx.projection.name}View {
+  return {
+    ...view,
+    // TODO: update view fields from event payload
+  };
+}
+`;
+}

--- a/packages/cli/src/templates/add/query.ts
+++ b/packages/cli/src/templates/add/query.ts
@@ -1,0 +1,29 @@
+import type { TemplateContext } from "../../utils/context.js";
+
+/** Context for adding a query to an existing projection. */
+export interface AddQueryContext {
+  /** The projection context (PascalCase name, kebab, camel). */
+  projection: TemplateContext;
+  /** The query context (PascalCase name, kebab, camel). */
+  query: TemplateContext;
+}
+
+/** Template for a new query payload interface file. */
+export function addQueryPayloadTemplate(ctx: AddQueryContext): string {
+  return `/** Payload for the ${ctx.query.name} query. */
+export interface ${ctx.query.name}Payload {
+  id: string;
+}
+`;
+}
+
+/** Template for a new query handler file. */
+export function addQueryHandlerTemplate(ctx: AddQueryContext): string {
+  return `import type { InferProjectionQueryHandler } from "@noddde/core";
+import type { ${ctx.projection.name}ProjectionDef } from "../${ctx.projection.kebabName}.js";
+
+/** Handles the ${ctx.query.name} query. */
+export const handle${ctx.query.name}: InferProjectionQueryHandler<${ctx.projection.name}ProjectionDef, "${ctx.query.name}"> = async (query, { views }) =>
+  (await views.load(query.payload.id)) ?? null;
+`;
+}

--- a/packages/cli/src/utils/discovery.ts
+++ b/packages/cli/src/utils/discovery.ts
@@ -1,0 +1,167 @@
+import { readdir, access } from "node:fs/promises";
+import path from "node:path";
+import { select } from "@inquirer/prompts";
+import { toPascalCase, toKebabCase } from "./naming.js";
+
+/** Discovered module entry. */
+export interface DiscoveredModule {
+  /** PascalCase display name derived from directory name. */
+  name: string;
+  /** Absolute path to the module directory. */
+  dir: string;
+}
+
+const AGGREGATE_BASE = "src/domain/write-model/aggregates";
+const PROJECTION_BASE = "src/domain/read-model/projections";
+
+/**
+ * Scans for existing aggregate directories under the project's write-model path.
+ * A directory is considered an aggregate if it contains a `.ts` definition file
+ * matching its kebab-case name.
+ */
+export async function discoverAggregates(
+  projectRoot?: string,
+): Promise<DiscoveredModule[]> {
+  const root = projectRoot ?? process.cwd();
+  const base = path.resolve(root, AGGREGATE_BASE);
+
+  try {
+    await access(base);
+  } catch {
+    return [];
+  }
+
+  const entries = await readdir(base, { withFileTypes: true });
+  const modules: DiscoveredModule[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const defFile = path.join(base, entry.name, `${entry.name}.ts`);
+    try {
+      await access(defFile);
+      modules.push({
+        name: toPascalCase(entry.name),
+        dir: path.join(base, entry.name),
+      });
+    } catch {
+      // Not a valid aggregate directory — skip
+    }
+  }
+
+  return modules;
+}
+
+/**
+ * Scans for existing projection directories under the project's read-model path.
+ * A directory is considered a projection if it contains a `.ts` definition file
+ * matching its kebab-case name.
+ */
+export async function discoverProjections(
+  projectRoot?: string,
+): Promise<DiscoveredModule[]> {
+  const root = projectRoot ?? process.cwd();
+  const base = path.resolve(root, PROJECTION_BASE);
+
+  try {
+    await access(base);
+  } catch {
+    return [];
+  }
+
+  const entries = await readdir(base, { withFileTypes: true });
+  const modules: DiscoveredModule[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const defFile = path.join(base, entry.name, `${entry.name}.ts`);
+    try {
+      await access(defFile);
+      modules.push({
+        name: toPascalCase(entry.name),
+        dir: path.join(base, entry.name),
+      });
+    } catch {
+      // Not a valid projection directory — skip
+    }
+  }
+
+  return modules;
+}
+
+/**
+ * Resolves an aggregate directory from a name hint or interactive selection.
+ * If `nameHint` is provided, resolves the path directly.
+ * Otherwise, discovers aggregates and prompts the user to select one.
+ */
+export async function resolveAggregateDir(
+  nameHint?: string,
+): Promise<DiscoveredModule> {
+  if (nameHint) {
+    const base = path.resolve(process.cwd(), AGGREGATE_BASE);
+    const kebab = toKebabCase(nameHint);
+    const dir = path.join(base, kebab);
+    try {
+      await access(dir);
+    } catch {
+      throw new Error(
+        `Aggregate "${nameHint}" not found at ${dir}.\n` +
+          `Create it first with: noddde new aggregate ${nameHint}\n`,
+      );
+    }
+    return { name: toPascalCase(nameHint), dir };
+  }
+
+  const aggregates = await discoverAggregates();
+  if (aggregates.length === 0) {
+    throw new Error(
+      `No aggregates found in ${AGGREGATE_BASE}.\n` +
+        `Create one first with: noddde new aggregate <name>\n`,
+    );
+  }
+
+  const chosen = await select<string>({
+    message: "Which aggregate?",
+    choices: aggregates.map((a) => ({ name: a.name, value: a.dir })),
+  });
+
+  return aggregates.find((a) => a.dir === chosen)!;
+}
+
+/**
+ * Resolves a projection directory from a name hint or interactive selection.
+ * If `nameHint` is provided, resolves the path directly.
+ * Otherwise, discovers projections and prompts the user to select one.
+ */
+export async function resolveProjectionDir(
+  nameHint?: string,
+): Promise<DiscoveredModule> {
+  if (nameHint) {
+    const base = path.resolve(process.cwd(), PROJECTION_BASE);
+    const kebab = toKebabCase(nameHint);
+    const dir = path.join(base, kebab);
+    try {
+      await access(dir);
+    } catch {
+      throw new Error(
+        `Projection "${nameHint}" not found at ${dir}.\n` +
+          `Create it first with: noddde new projection ${nameHint}\n`,
+      );
+    }
+    return { name: toPascalCase(nameHint), dir };
+  }
+
+  const projections = await discoverProjections();
+  if (projections.length === 0) {
+    throw new Error(
+      `No projections found in ${PROJECTION_BASE}.\n` +
+        `Create one first with: noddde new projection <name>\n`,
+    );
+  }
+
+  const chosen = await select<string>({
+    message: "Which projection?",
+    choices: projections.map((p) => ({ name: p.name, value: p.dir })),
+  });
+
+  return projections.find((p) => p.dir === chosen)!;
+}

--- a/packages/cli/src/utils/event-naming.ts
+++ b/packages/cli/src/utils/event-naming.ts
@@ -1,0 +1,78 @@
+import { input } from "@inquirer/prompts";
+import { toPascalCase, toKebabCase } from "./naming.js";
+
+/**
+ * Splits a PascalCase string into individual words.
+ * "PlaceBid" → ["Place", "Bid"], "CreateAuction" → ["Create", "Auction"]
+ */
+function splitPascal(name: string): string[] {
+  return name
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .split(/\s+/)
+    .filter((w) => w.length > 0);
+}
+
+/**
+ * Converts a verb to its past tense form (simple heuristic).
+ * - Ends in "e" → append "d" ("Place" → "Placed")
+ * - Short CVC pattern → double final consonant + "ed" ("Submit" → "Submitted")
+ * - Otherwise → append "ed" ("Open" → "Opened")
+ */
+function toPastTense(verb: string): string {
+  const lower = verb.toLowerCase();
+  if (lower.endsWith("e")) {
+    return verb + "d";
+  }
+  // Double final consonant for short CVC-ending verbs (stop, submit, plan, etc.)
+  const vowels = "aeiou";
+  if (
+    lower.length >= 3 &&
+    !vowels.includes(lower[lower.length - 1]!) &&
+    vowels.includes(lower[lower.length - 2]!) &&
+    !vowels.includes(lower[lower.length - 3]!)
+  ) {
+    return verb + verb[verb.length - 1] + "ed";
+  }
+  return verb + "ed";
+}
+
+/**
+ * Derives an event name from a command name using the convention:
+ * verb + subject → subject + past-tense verb.
+ *
+ * "PlaceBid" → "BidPlaced"
+ * "CreateAuction" → "AuctionCreated"
+ * "CloseAuction" → "AuctionClosed"
+ * "Submit" → "Submitted"
+ */
+export function deriveEventName(commandName: string): string {
+  const words = splitPascal(toPascalCase(commandName));
+  if (words.length === 0) return commandName;
+  if (words.length === 1) {
+    return toPascalCase(toPastTense(words[0]!));
+  }
+  const verb = words[0]!;
+  const subject = words.slice(1).join("");
+  return subject + toPastTense(verb);
+}
+
+/**
+ * Derives a kebab-case event name from a PascalCase event name.
+ */
+export function eventKebab(eventName: string): string {
+  return toKebabCase(eventName);
+}
+
+/**
+ * Interactively confirms or overrides the derived event name.
+ * Shows the auto-derived name as default and lets the user type a different one.
+ */
+export async function promptEventName(commandName: string): Promise<string> {
+  const derived = deriveEventName(commandName);
+  const result = await input({
+    message: `Event name for "${commandName}"?`,
+    default: derived,
+  });
+  return toPascalCase(result);
+}

--- a/packages/cli/src/utils/file-modifier.ts
+++ b/packages/cli/src/utils/file-modifier.ts
@@ -1,0 +1,126 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+/**
+ * Reads a file, finds a marker line (string or regex), and inserts content
+ * before it, preserving the marker line's indentation.
+ *
+ * @returns Whether the insertion was made and whether fallback was used.
+ */
+export async function insertBeforeMarker(
+  filePath: string,
+  marker: string | RegExp,
+  content: string,
+  options?: { fallbackAppend?: boolean },
+): Promise<{ inserted: boolean; usedFallback: boolean }> {
+  const fileContent = await readFile(filePath, "utf-8");
+  const lines = fileContent.split("\n");
+
+  const markerIndex = lines.findIndex((line) =>
+    typeof marker === "string" ? line.includes(marker) : marker.test(line),
+  );
+
+  if (markerIndex !== -1) {
+    const markerLine = lines[markerIndex]!;
+    const indent = markerLine.match(/^(\s*)/)?.[1] ?? "";
+    const indentedContent = content
+      .split("\n")
+      .map((l) => (l.trim() ? indent + l.trimStart() : l))
+      .join("\n");
+    lines.splice(markerIndex, 0, indentedContent);
+    await writeFile(filePath, lines.join("\n"), "utf-8");
+    return { inserted: true, usedFallback: false };
+  }
+
+  if (options?.fallbackAppend) {
+    const trimmed = fileContent.trimEnd();
+    await writeFile(filePath, trimmed + "\n" + content + "\n", "utf-8");
+    return { inserted: true, usedFallback: true };
+  }
+
+  return { inserted: false, usedFallback: false };
+}
+
+/**
+ * Inserts content after the last line matching a pattern.
+ * Useful for appending entries to object literals like `decide: { ... }`.
+ */
+export async function insertAfterLastMatch(
+  filePath: string,
+  pattern: string | RegExp,
+  content: string,
+): Promise<boolean> {
+  const fileContent = await readFile(filePath, "utf-8");
+  const lines = fileContent.split("\n");
+
+  let lastIndex = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (
+      typeof pattern === "string" ? line.includes(pattern) : pattern.test(line)
+    ) {
+      lastIndex = i;
+    }
+  }
+
+  if (lastIndex === -1) return false;
+
+  const matchedLine = lines[lastIndex]!;
+  const indent = matchedLine.match(/^(\s*)/)?.[1] ?? "";
+  const indentedContent = content
+    .split("\n")
+    .map((l) => (l.trim() ? indent + l.trimStart() : l))
+    .join("\n");
+  lines.splice(lastIndex + 1, 0, indentedContent);
+  await writeFile(filePath, lines.join("\n"), "utf-8");
+  return true;
+}
+
+/**
+ * Appends an export line to a barrel file (before the final newline).
+ */
+export async function appendToBarrel(
+  filePath: string,
+  exportLine: string,
+): Promise<void> {
+  const fileContent = await readFile(filePath, "utf-8");
+  const trimmed = fileContent.trimEnd();
+  await writeFile(filePath, trimmed + "\n" + exportLine + "\n", "utf-8");
+}
+
+/**
+ * Inserts import lines after the last existing import statement in a file.
+ */
+export async function insertImports(
+  filePath: string,
+  importLines: string,
+): Promise<void> {
+  const fileContent = await readFile(filePath, "utf-8");
+  const lines = fileContent.split("\n");
+
+  let lastImportIndex = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]!.startsWith("import ")) {
+      lastImportIndex = i;
+    }
+  }
+
+  if (lastImportIndex === -1) {
+    // No imports found — prepend
+    await writeFile(filePath, importLines + "\n" + fileContent, "utf-8");
+  } else {
+    lines.splice(lastImportIndex + 1, 0, importLines);
+    await writeFile(filePath, lines.join("\n"), "utf-8");
+  }
+}
+
+/**
+ * Checks whether a file contains a specific string.
+ * Useful for idempotency checks before modifying files.
+ */
+export async function fileContains(
+  filePath: string,
+  search: string,
+): Promise<boolean> {
+  const content = await readFile(filePath, "utf-8");
+  return content.includes(search);
+}


### PR DESCRIPTION
## Summary

- Add `noddde add command <name> [--aggregate] [--event]` — generates a command payload, decider, and evolver, then wires them into the aggregate's barrels and definition file
- Add `noddde add query <name> [--projection]` — generates a query payload and handler, then wires into the projection's barrels and definition file
- Add `noddde add event-handler <event-name> [--projection]` — generates an on-entry view reducer and wires it into the projection

All three commands support interactive aggregate/projection selection (via `@inquirer/prompts`) when the `--aggregate`/`--projection` flag is omitted. Event names for commands are auto-derived (`PlaceBid → BidPlaced`) with interactive confirmation, overridable via `--event`.

## New modules

| File | Purpose |
|------|---------|
| `utils/discovery.ts` | Scans project directories to find existing aggregates/projections |
| `utils/event-naming.ts` | Derives past-tense event names from command names with interactive confirmation |
| `utils/file-modifier.ts` | Inserts into/appends to existing files with idempotency helpers |
| `templates/add/command.ts` | Payload, decider, evolver templates |
| `templates/add/query.ts` | Query payload, handler templates |
| `templates/add/event-handler.ts` | View reducer template |
| `generators/add-command.ts` | Orchestrates file creation + wiring for commands |
| `generators/add-query.ts` | Orchestrates file creation + wiring for queries |
| `generators/add-event-handler.ts` | Orchestrates file creation + wiring for event handlers |
| `commands/add.ts` | Commander.js registration |

## Test plan

- [x] `tsc --noEmit` passes
- [x] 170 tests pass (16 test files, all new + existing)
- [x] Prettier formatted
- [x] ESLint passes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)