### PR TITLE
docs(readmes): fix stale APIs and wrong config fields in package READMEs

### DIFF
--- a/packages/adapters/kafka/README.md
+++ b/packages/adapters/kafka/README.md
@@ -51,8 +51,9 @@ const eventBus = new KafkaEventBus({
   sessionTimeout: 30000,
   heartbeatInterval: 3000,
   resilience: {
-    maxRetries: 5,
-    retryDelay: 1000,
+    maxAttempts: 5,
+    initialDelayMs: 1000,
+    maxDelayMs: 30000,
   },
 });
 ```

--- a/packages/adapters/nats/README.md
+++ b/packages/adapters/nats/README.md
@@ -26,7 +26,7 @@ import { wireDomain } from "@noddde/engine";
 
 const eventBus = new NatsEventBus({
   servers: "nats://localhost:4222",
-  stream: "my-domain-events",
+  streamName: "my-domain-events",
   consumerGroup: "my-service",
 });
 
@@ -45,12 +45,12 @@ await eventBus.close();
 ```typescript
 const eventBus = new NatsEventBus({
   servers: "nats://localhost:4222",
-  stream: "my-domain-events",
+  streamName: "my-domain-events",
   consumerGroup: "my-service", // Durable consumer group
   subjectPrefix: "myapp", // Optional subject namespace
   resilience: {
-    maxRetries: 5,
-    retryDelay: 1000,
+    maxAttempts: 5, // -1 for infinite (default)
+    initialDelayMs: 2000, // NATS uses fixed intervals — maxDelayMs is ignored
   },
 });
 ```

--- a/packages/adapters/rabbitmq/README.md
+++ b/packages/adapters/rabbitmq/README.md
@@ -26,7 +26,7 @@ import { wireDomain } from "@noddde/engine";
 
 const eventBus = new RabbitMqEventBus({
   url: "amqp://localhost:5672",
-  exchange: "my-domain-events",
+  exchangeName: "my-domain-events",
 });
 
 await eventBus.connect();
@@ -44,12 +44,13 @@ await eventBus.close();
 ```typescript
 const eventBus = new RabbitMqEventBus({
   url: "amqp://localhost:5672",
-  exchange: "my-domain-events",
-  queue: "my-service", // Consumer queue name
-  prefetch: 10, // Backpressure control
+  exchangeName: "my-domain-events",
+  queuePrefix: "my-service", // Queues are named "${queuePrefix}.${eventName}"
+  prefetchCount: 10, // Backpressure control
   resilience: {
-    maxRetries: 5,
-    retryDelay: 1000, // Base delay in ms (exponential backoff)
+    maxAttempts: 5, // Retry the initial connection up to 5 times
+    initialDelayMs: 1000, // Base delay in ms (exponential backoff)
+    maxDelayMs: 30000,
   },
 });
 ```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -29,22 +29,31 @@ Zero runtime dependencies. Strict TypeScript with full type inference.
 ## Usage
 
 ```typescript
-import { defineAggregate, type DefineAggregateTypes } from "@noddde/core";
+import {
+  defineAggregate,
+  type DefineCommands,
+  type DefineEvents,
+  type Infrastructure,
+} from "@noddde/core";
 
-type BankAccountTypes = DefineAggregateTypes<{
-  name: "BankAccount";
-  state: { balance: number };
-  events: {
-    DepositMade: { amount: number };
-    WithdrawalMade: { amount: number };
-  };
-  commands: {
-    Deposit: { amount: number };
-    Withdraw: { amount: number };
-  };
+type BankAccountEvent = DefineEvents<{
+  DepositMade: { amount: number };
+  WithdrawalMade: { amount: number };
 }>;
 
-const BankAccount = defineAggregate<BankAccountTypes>({
+type BankAccountCommand = DefineCommands<{
+  Deposit: { amount: number };
+  Withdraw: { amount: number };
+}>;
+
+type BankAccountDef = {
+  state: { balance: number };
+  events: BankAccountEvent;
+  commands: BankAccountCommand;
+  infrastructure: Infrastructure;
+};
+
+const BankAccount = defineAggregate<BankAccountDef>({
   initialState: { balance: 0 },
 
   decide: {

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -43,7 +43,7 @@ const definition = defineDomain({
 const domain = await wireDomain(definition);
 
 // Dispatch commands
-await domain.commandBus.dispatch({
+await domain.dispatchCommand({
   name: "Deposit",
   targetAggregateId: "acc-1",
   payload: { amount: 100 },

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,3 +1,3 @@
-# `@turbo/eslint-config`
+# `@noddde/eslint-config`
 
-Collection of internal eslint configurations.
+Internal ESLint configuration shared across the noddde monorepo. Exposes a `library` config built on `eslint:recommended`, `eslint-config-turbo`, and Prettier compatibility. Consume it from a package's `.eslintrc.js` by adding `@noddde/eslint-config/library` to `extends`.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -68,10 +68,15 @@ expect(result.state.status).toBe("awaiting_shipment");
 
 ```typescript
 import { testDomain } from "@noddde/testing";
+import { BankAccount } from "../aggregates/bank-account";
+import { BalanceProjection } from "../projections/balance";
 
-const { commandBus, queryBus, spy } = await testDomain(domainDefinition);
+const { domain, spy } = await testDomain({
+  aggregates: { BankAccount },
+  projections: { BalanceProjection },
+});
 
-await commandBus.dispatch({
+await domain.dispatchCommand({
   name: "Deposit",
   targetAggregateId: "acc-1",
   payload: { amount: 100 },


### PR DESCRIPTION
## Summary

Audit and fix of every incorrect/stale code example in `packages/*/README.md`. Several READMEs shipped examples that wouldn't compile against the current framework API — wrong type names, wrong config field names, and a stale domain-runtime dispatch pattern. This PR fixes them in one pass so new adopters can copy-paste examples that actually work.

Scope: **docs only**. No source or spec changes.

## Findings & fixes

| README | Before | After |
| --- | --- | --- |
| `packages/core` | `DefineAggregateTypes<{ name, state, events: {...}, commands: {...} }>` (invented wrapper, non-existent `name` field, events/commands as record maps) | `DefineEvents` + `DefineCommands` + four-field `*Def` bundle (`state`, `events`, `commands`, `infrastructure`) — matches what the CLI scaffolds today |
| `packages/engine` | `domain.commandBus.dispatch({...})` | `domain.dispatchCommand({...})` — consumer-facing API on `Domain` |
| `packages/testing` | `testDomain(domainDefinition)` → `{ commandBus, queryBus, spy }` | `testDomain({ aggregates, projections })` → `{ domain, spy }`, then `domain.dispatchCommand(...)` |
| `packages/eslint-config` | `@turbo/eslint-config` (copy-paste from Turborepo template) | `@noddde/eslint-config` with how-to-extend note |
| `packages/adapters/nats` | `stream`, `resilience: { maxRetries, retryDelay }` | `streamName`, `maxAttempts`/`initialDelayMs` (with note that NATS ignores `maxDelayMs`) |
| `packages/adapters/rabbitmq` | `exchange`, `queue`, `prefetch`, `retryDelay` | `exchangeName`, `queuePrefix`, `prefetchCount`, `maxAttempts`/`initialDelayMs`/`maxDelayMs` |
| `packages/adapters/kafka` | `resilience: { maxRetries, retryDelay }` | real `BrokerResilience` fields |

Drizzle, Prisma, TypeORM, and CLI READMEs were already accurate — no changes.

## Why

`noddde` READMEs are the first thing people see on npm and GitHub. Broken copy-paste examples are a terrible first impression. The underlying APIs exist and are stable — it was purely the docs that drifted.

## Test plan

- [ ] Visually skim each modified README on GitHub and check that code blocks render correctly.
- [ ] (Already done locally) Each code block type-checks mentally against the real source — `DefineEvents` / `DefineCommands` / `Infrastructure` / `AggregateTypes` / `Domain.dispatchCommand` / `testDomain` / adapter config interfaces.
- [ ] CI (format:check, lint, build) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)