### PR TITLE
feat(cli): `noddde diagram` — flow diagram from a domain

### DIFF
--- a/docs/content/docs/getting-started/cli.mdx
+++ b/docs/content/docs/getting-started/cli.mdx
@@ -3,10 +3,11 @@ title: CLI
 description: Scaffold and extend noddde projects, domains, aggregates, projections, and sagas from the command line
 ---
 
-The `@noddde/cli` package provides generators that scaffold noddde modules with the correct folder structure, type definitions, and wiring code. Two command groups are available:
+The `@noddde/cli` package provides generators that scaffold noddde modules with the correct folder structure, type definitions, and wiring code. Three command groups are available:
 
 - **`noddde new`** — create new modules from scratch (projects, domains, aggregates, projections, sagas)
 - **`noddde add`** — extend existing aggregates and projections with new commands, queries, or event handlers
+- **`noddde diagram`** — generate a flow diagram of how commands, events, and queries traverse a domain
 
 ## Installation
 
@@ -280,6 +281,87 @@ All `add` subcommands have short aliases:
 | `--aggregate`  | `add command`                    | Target aggregate name (interactive picker if omitted)  |
 | `--projection` | `add query`, `add event-handler` | Target projection name (interactive picker if omitted) |
 | `--event`      | `add command`                    | Override the auto-derived event name                   |
+
+## Visualizing Domains
+
+The `noddde diagram` command (alias `noddde d`) reads a domain module and emits a flow diagram showing how commands, events, and queries move through the system. Five of the six edge types — command → aggregate, aggregate → event, event → projection, query → projection, event → saga — are derived directly from `Object.keys(...)` on the loaded definition. The sixth — saga → command — is resolved through the TypeScript compiler API by reading the `commands` field of each saga's type bundle.
+
+```bash
+noddde diagram                                # uses src/domain/domain.ts
+noddde diagram path/to/domain.ts              # explicit entry
+noddde diagram --out diagram.mmd              # write to file
+noddde diagram --format json                  # machine-readable graph
+noddde diagram --scope process                # process-model only
+```
+
+### Output formats
+
+| Format    | Use case                                                                           |
+| :-------- | :--------------------------------------------------------------------------------- |
+| `mermaid` | Default. Renders inline on GitHub, in Fumadocs, and in any Mermaid-aware previewer |
+| `dot`     | Graphviz DOT — pipe to `dot -Tsvg` for high-resolution SVG                         |
+| `json`    | Canonical `DomainGraph` shape for downstream tooling (docs sites, registries)      |
+
+### Diagram structure
+
+Commands, events, and queries are pill-shaped nodes; aggregates, projections, and sagas are box nodes. Three subgraphs group them by model (`Write Model`, `Read Model`, `Process Model`). Solid arrows mark edges derived at runtime; dashed arrows mark edges resolved through type analysis (currently only saga → command).
+
+For the `sample-auction` domain:
+
+```mermaid
+flowchart LR
+  subgraph WM["Write Model"]
+    cmdCreate(["CreateAuction"])
+    cmdBid(["PlaceBid"])
+    cmdClose(["CloseAuction"])
+    Auction[["Auction"]]
+    evCreated(["AuctionCreated"])
+    evBid(["BidPlaced"])
+    evRej(["BidRejected"])
+    evClosed(["AuctionClosed"])
+    cmdCreate --> Auction
+    cmdBid --> Auction
+    cmdClose --> Auction
+    Auction --> evCreated
+    Auction --> evBid
+    Auction --> evRej
+    Auction --> evClosed
+  end
+  subgraph RM["Read Model"]
+    Summary[["AuctionSummary"]]
+    qGet(["GetAuctionSummary"])
+    evCreated --> Summary
+    evBid --> Summary
+    evClosed --> Summary
+    qGet --> Summary
+  end
+```
+
+### Flag reference
+
+| Flag                | Default          | Purpose                                                         |
+| :------------------ | :--------------- | :-------------------------------------------------------------- |
+| `--out <path>`      | stdout           | Write the diagram to a file                                     |
+| `--format <format>` | `mermaid`        | One of `mermaid`, `dot`, `json`                                 |
+| `--scope <scope>`   | `all`            | One of `write`, `read`, `process`, `all` — limits the subgraphs |
+| `--hide-isolated`   | off              | Drop nodes with degree 0 after scope filtering                  |
+| `--tsconfig <path>` | nearest ancestor | Path to a tsconfig.json used by the saga static-analysis pass   |
+
+### What gets diagnosed
+
+The diagram doubles as a static check on the domain. Two diagnostics are surfaced as `warnings` on the JSON output and on stderr:
+
+- **External commands** — a saga dispatches a command name that no aggregate handles. The command node is rendered with an `external` style and the warning names both ends of the broken edge. This commonly catches typos in the saga's `commands` union or aggregates that haven't been wired in yet.
+- **Unresolvable saga commands** — a saga's `commands` field doesn't resolve to a finite union of literal-named members (e.g. it's typed as `Command` rather than a discriminated union). The saga still appears with its incoming event edges; the warning notes that no outgoing edges could be produced.
+
+### Loading the domain
+
+The CLI loads the entry file via [tsx](https://github.com/privatenumber/tsx)'s programmatic API — no prebuild required. The entry must export either:
+
+- `aggregates`, `projections`, and (optionally) `sagas` as named records, or
+- a `definition` object produced by `defineDomain(...)`.
+
+Both forms are supported by the same loader. Convention: `src/domain/domain.ts` carries the structural exports and has no top-level dependencies on infrastructure (DB connections, env vars). If your entry has top-level side effects, dynamic import will fail with a message pointing you to the structural module.
 
 ## Name Handling
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,7 +16,7 @@ npm install -g @noddde/cli
 
 ## Usage
 
-The CLI has two command groups:
+The CLI has three command groups:
 
 ### `noddde new` — scaffold new modules
 
@@ -41,6 +41,16 @@ noddde add event-handler <event-name> [--projection <name>]
 When adding a command, the event name is auto-derived (`PlaceBid` → `BidPlaced`) with interactive confirmation. Override via `--event`. If `--aggregate` or `--projection` is omitted, the CLI prompts you to pick from discovered modules.
 
 Generated files follow noddde conventions: pure functions, typed events and commands, and the Decider pattern.
+
+### `noddde diagram` — flow diagram from a domain
+
+```bash
+noddde diagram [domain-file] [--format mermaid|dot|json] [--scope write|read|process|all] [--out path] [--hide-isolated] [--tsconfig path]
+```
+
+Reads a domain (defaults to `src/domain/domain.ts`), introspects every aggregate / projection / saga, and emits a flow diagram showing how commands, events, and queries traverse the system. Five edge types come straight from runtime introspection (`Object.keys` on the `decide` / `evolve` / `on` / `queryHandlers` maps); saga-dispatched commands are resolved via the TypeScript compiler API from each saga's `commands` discriminated union.
+
+Output is Mermaid by default — paste into a Markdown preview or commit to GitHub for inline rendering. Solid arrows mark runtime-derived edges, dashed arrows mark statically-resolved (saga → command) edges. Commands a saga dispatches but no aggregate handles are flagged as `external` with a warning.
 
 ## Related Packages
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,12 +39,15 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^7.0.0",
-    "commander": "^13.0.0"
+    "commander": "^13.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.3.3"
   },
   "devDependencies": {
+    "@noddde/core": "0.0.0",
+    "@noddde/engine": "0.0.0",
     "@noddde/typescript-config": "0.0.0",
     "eslint": "^8.56.0",
-    "typescript": "^5.3.3",
     "vitest": "^4.1.0"
   }
 }

--- a/packages/cli/src/__tests__/diagram/build-graph.test.ts
+++ b/packages/cli/src/__tests__/diagram/build-graph.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import * as path from "node:path";
+import { loadDomain } from "../../diagram/load-domain.js";
+import { buildDomainGraph } from "../../diagram/build-graph.js";
+import type { DomainDefinition } from "@noddde/engine";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../../..");
+const auctionEntry = path.join(
+  REPO_ROOT,
+  "samples/sample-auction/src/domain/domain.ts",
+);
+const hotelEntry = path.join(
+  REPO_ROOT,
+  "samples/sample-hotel-booking/src/domain/domain.ts",
+);
+
+describe("buildDomainGraph", () => {
+  let auctionDefinition: DomainDefinition;
+  let hotelDefinition: DomainDefinition;
+
+  beforeAll(async () => {
+    auctionDefinition = (await loadDomain(auctionEntry)).definition;
+    hotelDefinition = (await loadDomain(hotelEntry)).definition;
+  });
+
+  it("returns a graph with all six edge kinds present for hotel-booking", async () => {
+    const graph = buildDomainGraph(hotelDefinition, hotelEntry, {
+      scope: "all",
+    });
+
+    const sources = new Set(graph.edges.map((e) => e.source));
+    expect(sources.has("runtime")).toBe(true);
+    expect(sources.has("static")).toBe(true);
+
+    // Saga → command edges flow into known commands handled by aggregates.
+    const sagaToCommand = graph.edges.filter(
+      (e) => e.from.startsWith("saga:") && e.to.startsWith("command:"),
+    );
+    expect(sagaToCommand.length).toBeGreaterThan(0);
+  });
+
+  it("filters out read-model nodes when scope=write", () => {
+    const graph = buildDomainGraph(auctionDefinition, auctionEntry, {
+      scope: "write",
+    });
+    expect(graph.nodes.find((n) => n.kind === "projection")).toBeUndefined();
+    expect(graph.nodes.find((n) => n.kind === "query")).toBeUndefined();
+  });
+
+  it("skips static analysis when there are no sagas", () => {
+    const graph = buildDomainGraph(auctionDefinition, auctionEntry, {});
+    expect(graph.nodes.find((n) => n.kind === "saga")).toBeUndefined();
+    expect(graph.edges.find((e) => e.source === "static")).toBeUndefined();
+  });
+
+  it("marks saga-dispatched commands not handled by any aggregate as external", () => {
+    const graph = buildDomainGraph(
+      hotelDefinition,
+      hotelEntry,
+      {},
+      // Inject a synthetic saga result that includes a known + unknown command.
+      new Map([["BookingFulfillment", ["ConfirmBooking", "FooBar"]]]),
+    );
+
+    const fooBar = graph.nodes.find((n) => n.id === "command:FooBar");
+    expect(fooBar?.model).toBe("external");
+
+    expect(
+      graph.warnings.some(
+        (w) => w.includes("FooBar") && w.toLowerCase().includes("external"),
+      ),
+    ).toBe(true);
+  });
+
+  it("hides isolated nodes when hideIsolated=true", () => {
+    const graph = buildDomainGraph(auctionDefinition, auctionEntry, {
+      hideIsolated: true,
+    });
+    const degree = new Map<string, number>();
+    for (const e of graph.edges) {
+      degree.set(e.from, (degree.get(e.from) ?? 0) + 1);
+      degree.set(e.to, (degree.get(e.to) ?? 0) + 1);
+    }
+    for (const node of graph.nodes) {
+      expect(degree.get(node.id) ?? 0).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/cli/src/__tests__/diagram/emit.test.ts
+++ b/packages/cli/src/__tests__/diagram/emit.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { emitMermaid } from "../../diagram/emit-mermaid.js";
+import { emitDot } from "../../diagram/emit-dot.js";
+import { emitJson } from "../../diagram/emit-json.js";
+import type { DomainGraph } from "../../diagram/types.js";
+
+const sample: DomainGraph = {
+  nodes: [
+    {
+      id: "command:CreateAuction",
+      label: "CreateAuction",
+      kind: "command",
+      model: "write",
+    },
+    {
+      id: "aggregate:Auction",
+      label: "Auction",
+      kind: "aggregate",
+      model: "write",
+    },
+    {
+      id: "event:AuctionCreated",
+      label: "AuctionCreated",
+      kind: "event",
+      model: "write",
+    },
+    { id: "saga:Foo", label: "Foo", kind: "saga", model: "process" },
+    {
+      id: "command:DoFoo",
+      label: "DoFoo",
+      kind: "command",
+      model: "external",
+    },
+  ],
+  edges: [
+    {
+      from: "command:CreateAuction",
+      to: "aggregate:Auction",
+      source: "runtime",
+    },
+    {
+      from: "aggregate:Auction",
+      to: "event:AuctionCreated",
+      source: "runtime",
+    },
+    {
+      from: "event:AuctionCreated",
+      to: "saga:Foo",
+      source: "runtime",
+    },
+    { from: "saga:Foo", to: "command:DoFoo", source: "static" },
+  ],
+  warnings: [],
+};
+
+describe("emitMermaid", () => {
+  it("emits flowchart LR with subgraphs and pill/box shapes", () => {
+    const out = emitMermaid(sample);
+    expect(out).toMatch(/^flowchart LR/);
+    expect(out).toMatch(/subgraph .*Write Model/);
+    expect(out).toMatch(/subgraph .*Process Model/);
+    expect(out).toMatch(/subgraph .*External/);
+    expect(out).toMatch(/\(\["CreateAuction"\]\)/);
+    expect(out).toMatch(/\[\["Auction"\]\]/);
+  });
+
+  it("uses solid arrows for runtime edges and dashed for static", () => {
+    const out = emitMermaid(sample);
+    // Mermaid sanitizes ':' to '_' in node ids.
+    expect(out).toMatch(/command_CreateAuction\s+-->\s+aggregate_Auction/);
+    expect(out).toMatch(/saga_Foo\s+-\.->\s+command_DoFoo/);
+  });
+
+  it("does not emit ':' in node identifiers (Mermaid syntax constraint)", () => {
+    const out = emitMermaid(sample);
+    // Strip the labels (which legitimately contain ':' in their style classDefs)
+    // and check there are no colons in node-id positions.
+    const idLines = out
+      .split("\n")
+      .filter(
+        (l) => l.includes("-->") || l.includes("-.->") || /^\s*class\s/.test(l),
+      );
+    for (const line of idLines) {
+      expect(line).not.toMatch(/[a-z]+:[A-Z]/);
+    }
+  });
+});
+
+describe("emitDot", () => {
+  it("emits a digraph with cluster subgraphs and edge styles", () => {
+    const out = emitDot(sample);
+    expect(out).toMatch(/digraph G \{/);
+    expect(out).toMatch(/rankdir=LR;/);
+    expect(out).toMatch(/subgraph cluster_write \{/);
+    expect(out).toMatch(/subgraph cluster_process \{/);
+    expect(out).toMatch(/"command:CreateAuction" -> "aggregate:Auction";/);
+    expect(out).toMatch(/"saga:Foo" -> "command:DoFoo" \[style="dashed"\];/);
+  });
+});
+
+describe("emitJson", () => {
+  it("round-trips the graph", () => {
+    const out = emitJson(sample);
+    expect(JSON.parse(out)).toEqual(sample);
+  });
+});

--- a/packages/cli/src/__tests__/diagram/introspect.test.ts
+++ b/packages/cli/src/__tests__/diagram/introspect.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import * as path from "node:path";
+import { loadDomain } from "../../diagram/load-domain.js";
+import { introspectDomain } from "../../diagram/introspect.js";
+import type { DomainDefinition } from "@noddde/engine";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../../..");
+const auctionEntry = path.join(
+  REPO_ROOT,
+  "samples/sample-auction/src/domain/domain.ts",
+);
+const hotelEntry = path.join(
+  REPO_ROOT,
+  "samples/sample-hotel-booking/src/domain/domain.ts",
+);
+
+describe("introspectDomain — auction sample (write + read, no sagas)", () => {
+  let definition: DomainDefinition;
+
+  beforeAll(async () => {
+    ({ definition } = await loadDomain(auctionEntry));
+  });
+
+  it("produces a command node + edge for each key in aggregate.decide", () => {
+    const { nodes, edges } = introspectDomain(definition);
+
+    const commandNodes = nodes.filter((n) => n.kind === "command");
+    const auction = (definition.writeModel.aggregates as Record<string, any>)
+      .Auction;
+    const decideKeys = Object.keys(auction.decide).sort();
+
+    expect(commandNodes.map((n) => n.label).sort()).toEqual(decideKeys);
+
+    for (const cmd of decideKeys) {
+      expect(
+        edges.find(
+          (e) => e.from === `command:${cmd}` && e.to === `aggregate:Auction`,
+        ),
+      ).toBeDefined();
+    }
+  });
+
+  it("produces an event node + edge for each key in aggregate.evolve", () => {
+    const { nodes, edges } = introspectDomain(definition);
+
+    const eventNodes = nodes.filter((n) => n.kind === "event");
+    const auction = (definition.writeModel.aggregates as Record<string, any>)
+      .Auction;
+    const evolveKeys = Object.keys(auction.evolve).sort();
+
+    expect(eventNodes.map((n) => n.label).sort()).toEqual(evolveKeys);
+
+    for (const evt of evolveKeys) {
+      expect(
+        edges.find(
+          (e) => e.from === `aggregate:Auction` && e.to === `event:${evt}`,
+        ),
+      ).toBeDefined();
+    }
+  });
+
+  it("produces an event→projection edge for each key in projection.on", () => {
+    const { edges } = introspectDomain(definition);
+    const summary = (definition.readModel.projections as Record<string, any>)
+      .AuctionSummary;
+
+    for (const evt of Object.keys(summary.on)) {
+      expect(
+        edges.find(
+          (e) =>
+            e.from === `event:${evt}` && e.to === `projection:AuctionSummary`,
+        ),
+      ).toBeDefined();
+    }
+  });
+
+  it("produces a query→projection edge for each key in projection.queryHandlers", () => {
+    const { edges } = introspectDomain(definition);
+    const summary = (definition.readModel.projections as Record<string, any>)
+      .AuctionSummary;
+
+    for (const q of Object.keys(summary.queryHandlers)) {
+      expect(
+        edges.find(
+          (e) =>
+            e.from === `query:${q}` && e.to === `projection:AuctionSummary`,
+        ),
+      ).toBeDefined();
+    }
+  });
+
+  it("does not produce saga nodes when processModel is absent", () => {
+    const { nodes } = introspectDomain(definition);
+    expect(nodes.find((n) => n.kind === "saga")).toBeUndefined();
+  });
+});
+
+describe("introspectDomain — hotel-booking sample (full process model)", () => {
+  let definition: DomainDefinition;
+
+  beforeAll(async () => {
+    ({ definition } = await loadDomain(hotelEntry));
+  });
+
+  it("produces event→saga edges for both startedBy and on keys (deduped)", () => {
+    const { edges } = introspectDomain(definition);
+
+    const fulfillment = (definition.processModel?.sagas as Record<string, any>)
+      .BookingFulfillment;
+    const triggers = new Set<string>([
+      ...fulfillment.startedBy,
+      ...Object.keys(fulfillment.on),
+    ]);
+
+    for (const evt of triggers) {
+      expect(
+        edges.find(
+          (e) =>
+            e.from === `event:${evt}` && e.to === `saga:BookingFulfillment`,
+        ),
+      ).toBeDefined();
+    }
+  });
+
+  it("creates exactly one node per saga", () => {
+    const { nodes } = introspectDomain(definition);
+    const sagaNodes = nodes.filter((n) => n.kind === "saga");
+    const sagaKeys = Object.keys(definition.processModel?.sagas ?? {});
+    expect(sagaNodes.map((n) => n.label).sort()).toEqual(sagaKeys.sort());
+  });
+
+  it("deduplicates event nodes that multiple components touch", () => {
+    const { nodes } = introspectDomain(definition);
+    const eventLabels = nodes
+      .filter((n) => n.kind === "event")
+      .map((n) => n.label);
+    expect(new Set(eventLabels).size).toBe(eventLabels.length);
+  });
+});

--- a/packages/cli/src/__tests__/diagram/static-analyze.test.ts
+++ b/packages/cli/src/__tests__/diagram/static-analyze.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import * as path from "node:path";
+import { analyzeSagaCommands } from "../../diagram/static-analyze.js";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../../..");
+const hotelEntry = path.join(
+  REPO_ROOT,
+  "samples/sample-hotel-booking/src/domain/domain.ts",
+);
+
+describe("analyzeSagaCommands", () => {
+  it("returns an empty result when no saga keys are passed", () => {
+    const result = analyzeSagaCommands(hotelEntry, []);
+    expect(result.commands.size).toBe(0);
+    expect(result.unresolved).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("extracts the BookingCommand | RoomCommand union for BookingFulfillment", () => {
+    const result = analyzeSagaCommands(hotelEntry, ["BookingFulfillment"]);
+    const cmds = result.commands.get("BookingFulfillment");
+
+    expect(cmds).toBeDefined();
+    // BookingCommand union members:
+    expect(cmds).toContain("ConfirmBooking");
+    expect(cmds).toContain("CancelBooking");
+    expect(cmds).toContain("CreateBooking");
+    // RoomCommand union members:
+    expect(cmds).toContain("ReserveRoom");
+    expect(cmds).toContain("CheckInGuest");
+  });
+
+  it("warns when a saga key is not present on the entry's `sagas` export", () => {
+    const result = analyzeSagaCommands(hotelEntry, ["NotARealSaga"]);
+    expect(result.unresolved).toContain("NotARealSaga");
+    expect(result.warnings.some((w) => w.includes("NotARealSaga"))).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/diagram.ts
+++ b/packages/cli/src/commands/diagram.ts
@@ -1,0 +1,136 @@
+import { Command } from "commander";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { loadDomain } from "../diagram/load-domain.js";
+import { buildDomainGraph } from "../diagram/build-graph.js";
+import { emitMermaid } from "../diagram/emit-mermaid.js";
+import { emitDot } from "../diagram/emit-dot.js";
+import { emitJson } from "../diagram/emit-json.js";
+import type {
+  DiagramFormat,
+  DiagramScope,
+  DomainGraph,
+} from "../diagram/types.js";
+
+interface DiagramCliOptions {
+  out?: string;
+  format?: string;
+  scope?: string;
+  hideIsolated?: boolean;
+  tsconfig?: string;
+}
+
+const VALID_FORMATS: DiagramFormat[] = ["mermaid", "dot", "json"];
+const VALID_SCOPES: DiagramScope[] = ["write", "read", "process", "all"];
+
+/**
+ * Registers the `noddde diagram` subcommand.
+ *
+ * Usage:
+ *   noddde diagram [domain-file]
+ *     --out <path>
+ *     --format <mermaid|dot|json>
+ *     --scope  <write|read|process|all>
+ *     --hide-isolated
+ *     --tsconfig <path>
+ */
+export function registerDiagramCommand(program: Command): void {
+  program
+    .command("diagram [domain-file]")
+    .alias("d")
+    .description(
+      "Generate a flow diagram (commands → events → projections / sagas → queries) from a noddde domain.",
+    )
+    .option("--out <path>", "Write the diagram to a file. Defaults to stdout.")
+    .option(
+      "--format <format>",
+      `Output format: ${VALID_FORMATS.join(" | ")}. Default: mermaid.`,
+      "mermaid",
+    )
+    .option(
+      "--scope <scope>",
+      `Subgraphs to include: ${VALID_SCOPES.join(" | ")}. Default: all.`,
+      "all",
+    )
+    .option(
+      "--hide-isolated",
+      "Drop nodes with degree 0 after scope filtering.",
+      false,
+    )
+    .option(
+      "--tsconfig <path>",
+      "Path to a tsconfig.json used for the saga static-analysis pass. Auto-discovered when omitted.",
+    )
+    .action(async (domainFile: string | undefined, opts: DiagramCliOptions) => {
+      const entry = resolveEntry(domainFile);
+      const format = parseFormat(opts.format);
+      const scope = parseScope(opts.scope);
+
+      try {
+        const { definition, entryFile } = await loadDomain(entry);
+        const graph = buildDomainGraph(definition, entryFile, {
+          format,
+          scope,
+          hideIsolated: !!opts.hideIsolated,
+          tsconfigPath: opts.tsconfig,
+        });
+
+        const output = render(graph, format);
+
+        if (opts.out) {
+          fs.writeFileSync(path.resolve(opts.out), output, "utf8");
+          process.stdout.write(
+            `Diagram written to ${path.resolve(opts.out)}\n`,
+          );
+        } else {
+          process.stdout.write(output);
+          if (!output.endsWith("\n")) process.stdout.write("\n");
+        }
+
+        if (graph.warnings.length > 0) {
+          process.stderr.write("\nDiagram warnings:\n");
+          for (const w of graph.warnings) process.stderr.write(`  - ${w}\n`);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`${message}\n`);
+        process.exit(1);
+      }
+    });
+}
+
+function render(graph: DomainGraph, format: DiagramFormat): string {
+  switch (format) {
+    case "mermaid":
+      return emitMermaid(graph);
+    case "dot":
+      return emitDot(graph);
+    case "json":
+      return emitJson(graph);
+  }
+}
+
+function resolveEntry(provided: string | undefined): string {
+  if (provided) return provided;
+  return path.join(process.cwd(), "src", "domain", "domain.ts");
+}
+
+function parseFormat(value: string | undefined): DiagramFormat {
+  if (!value) return "mermaid";
+  if (!VALID_FORMATS.includes(value as DiagramFormat)) {
+    throw new Error(
+      `Invalid --format: '${value}'. Expected one of: ${VALID_FORMATS.join(", ")}.`,
+    );
+  }
+  return value as DiagramFormat;
+}
+
+function parseScope(value: string | undefined): DiagramScope {
+  if (!value) return "all";
+  if (!VALID_SCOPES.includes(value as DiagramScope)) {
+    throw new Error(
+      `Invalid --scope: '${value}'. Expected one of: ${VALID_SCOPES.join(", ")}.`,
+    );
+  }
+  return value as DiagramScope;
+}

--- a/packages/cli/src/diagram/build-graph.ts
+++ b/packages/cli/src/diagram/build-graph.ts
@@ -1,0 +1,159 @@
+import type { DomainDefinition } from "@noddde/engine";
+import { introspectDomain } from "./introspect.js";
+import { analyzeSagaCommands } from "./static-analyze.js";
+import {
+  nodeId,
+  type DiagramOptions,
+  type DiagramScope,
+  type DomainGraph,
+  type GraphNode,
+  type GraphNodeKind,
+} from "./types.js";
+
+/**
+ * Builds a `DomainGraph` from a live `DomainDefinition` plus the entry file
+ * path used to anchor the static-analysis pass.
+ *
+ * Steps:
+ *   1. Runtime introspection (`introspectDomain`) — five edge types.
+ *   2. Saga `commands` resolution via `analyzeSagaCommands` — the sixth edge.
+ *   3. Scope filter and (optional) isolated-node filter.
+ *
+ * The 4th positional parameter `injectedSagaCommands` lets tests bypass the
+ * TypeScript-compiler step with a pre-built map.
+ */
+export function buildDomainGraph(
+  definition: DomainDefinition,
+  entryFile: string,
+  options: DiagramOptions = {},
+  injectedSagaCommands?: Map<string, string[]>,
+): DomainGraph {
+  const scope: DiagramScope = options.scope ?? "all";
+  const hideIsolated = options.hideIsolated ?? false;
+
+  const { nodes, edges } = introspectDomain(definition);
+  const warnings: string[] = [];
+
+  const sagaKeys = Object.keys(definition.processModel?.sagas ?? {});
+  let sagaCommands: Map<string, string[]>;
+  if (injectedSagaCommands) {
+    sagaCommands = injectedSagaCommands;
+  } else if (sagaKeys.length === 0) {
+    sagaCommands = new Map();
+  } else {
+    const analysis = analyzeSagaCommands(
+      entryFile,
+      sagaKeys,
+      options.tsconfigPath,
+    );
+    sagaCommands = analysis.commands;
+    warnings.push(...analysis.warnings);
+  }
+
+  const knownCommandNames = new Set(
+    nodes.filter((n) => n.kind === "command").map((n) => n.label),
+  );
+
+  const nodeIndex = new Map<string, GraphNode>(
+    nodes.map((n) => [n.id, n] as const),
+  );
+
+  for (const [sagaKey, commandNames] of sagaCommands) {
+    const sagaIdValue = nodeId("saga", sagaKey);
+    if (!nodeIndex.has(sagaIdValue)) continue;
+
+    for (const commandName of commandNames) {
+      const cmdId = nodeId("command", commandName);
+      if (!nodeIndex.has(cmdId)) {
+        const externalNode: GraphNode = {
+          id: cmdId,
+          label: commandName,
+          kind: "command",
+          model: "external",
+        };
+        nodeIndex.set(cmdId, externalNode);
+        nodes.push(externalNode);
+        warnings.push(
+          `Saga '${sagaKey}' dispatches command '${commandName}', but no aggregate handles it. Marked as external.`,
+        );
+      } else if (!knownCommandNames.has(commandName)) {
+        // Command came from a previous saga's static result; keep model from first sighting.
+      }
+      edges.push({ from: sagaIdValue, to: cmdId, source: "static" });
+    }
+  }
+
+  let filteredNodes = nodes;
+  let filteredEdges = edges;
+
+  if (scope !== "all") {
+    const allowedModels = scopeAllowedModels(scope);
+    const allowedKinds = scopeAllowedKinds(scope);
+
+    filteredNodes = nodes.filter(
+      (n) =>
+        (allowedModels.has(n.model) || n.model === "external") &&
+        allowedKinds.has(n.kind),
+    );
+    const keptIds = new Set(filteredNodes.map((n) => n.id));
+    filteredEdges = edges.filter(
+      (e) => keptIds.has(e.from) && keptIds.has(e.to),
+    );
+  }
+
+  if (hideIsolated) {
+    const degree = new Map<string, number>();
+    for (const e of filteredEdges) {
+      degree.set(e.from, (degree.get(e.from) ?? 0) + 1);
+      degree.set(e.to, (degree.get(e.to) ?? 0) + 1);
+    }
+    filteredNodes = filteredNodes.filter((n) => (degree.get(n.id) ?? 0) > 0);
+    const keptIds = new Set(filteredNodes.map((n) => n.id));
+    filteredEdges = filteredEdges.filter(
+      (e) => keptIds.has(e.from) && keptIds.has(e.to),
+    );
+  }
+
+  if (Object.keys(definition.writeModel?.aggregates ?? {}).length === 0) {
+    warnings.push(
+      "Domain has no aggregates; the diagram will be missing the write model.",
+    );
+  }
+
+  return { nodes: filteredNodes, edges: filteredEdges, warnings };
+}
+
+function scopeAllowedModels(scope: DiagramScope): Set<string> {
+  switch (scope) {
+    case "write":
+      return new Set(["write"]);
+    case "read":
+      return new Set(["read", "write"]);
+    case "process":
+      return new Set(["process", "write"]);
+    default:
+      return new Set(["write", "read", "process"]);
+  }
+}
+
+function scopeAllowedKinds(scope: DiagramScope): Set<GraphNodeKind> {
+  switch (scope) {
+    case "write":
+      return new Set<GraphNodeKind>(["command", "aggregate", "event"]);
+    case "read":
+      return new Set<GraphNodeKind>(["event", "projection", "query"]);
+    case "process":
+      return new Set<GraphNodeKind>(["event", "saga", "command"]);
+    default:
+      return new Set<GraphNodeKind>([
+        "command",
+        "event",
+        "query",
+        "aggregate",
+        "projection",
+        "saga",
+      ]);
+  }
+}
+
+export type { DomainGraph, GraphEdge, GraphNode } from "./types.js";

--- a/packages/cli/src/diagram/emit-dot.ts
+++ b/packages/cli/src/diagram/emit-dot.ts
@@ -1,0 +1,55 @@
+import type { DomainGraph, GraphNode } from "./types.js";
+
+const MODEL_ORDER: Array<{ model: GraphNode["model"]; title: string }> = [
+  { model: "write", title: "Write Model" },
+  { model: "read", title: "Read Model" },
+  { model: "process", title: "Process Model" },
+  { model: "external", title: "External" },
+];
+
+/** Emits a Graphviz DOT digraph with one cluster per model. */
+export function emitDot(graph: DomainGraph): string {
+  const lines: string[] = [
+    "digraph G {",
+    "  rankdir=LR;",
+    "  node [shape=box];",
+  ];
+
+  for (const { model, title } of MODEL_ORDER) {
+    const nodes = graph.nodes.filter((n) => n.model === model);
+    if (nodes.length === 0) continue;
+    lines.push(`  subgraph cluster_${model} {`);
+    lines.push(`    label="${title}";`);
+    for (const node of nodes) {
+      lines.push(
+        `    "${node.id}" [label="${escapeLabel(node.label)}", shape=${shapeFor(node)}];`,
+      );
+    }
+    lines.push("  }");
+  }
+
+  for (const edge of graph.edges) {
+    const style = edge.source === "static" ? ' [style="dashed"]' : "";
+    lines.push(`  "${edge.from}" -> "${edge.to}"${style};`);
+  }
+
+  lines.push("}");
+  return lines.join("\n");
+}
+
+function shapeFor(node: GraphNode): string {
+  switch (node.kind) {
+    case "command":
+    case "event":
+    case "query":
+      return "ellipse";
+    case "aggregate":
+    case "projection":
+    case "saga":
+      return "box3d";
+  }
+}
+
+function escapeLabel(value: string): string {
+  return value.replace(/"/g, '\\"');
+}

--- a/packages/cli/src/diagram/emit-json.ts
+++ b/packages/cli/src/diagram/emit-json.ts
@@ -1,0 +1,6 @@
+import type { DomainGraph } from "./types.js";
+
+/** Emits the canonical JSON serialization of a `DomainGraph`. */
+export function emitJson(graph: DomainGraph): string {
+  return JSON.stringify(graph, null, 2);
+}

--- a/packages/cli/src/diagram/emit-mermaid.ts
+++ b/packages/cli/src/diagram/emit-mermaid.ts
@@ -1,0 +1,89 @@
+import type { DomainGraph, GraphNode, GraphNodeKind } from "./types.js";
+
+const MODEL_ORDER: Array<{
+  model: GraphNode["model"];
+  title: string;
+}> = [
+  { model: "write", title: "Write Model" },
+  { model: "read", title: "Read Model" },
+  { model: "process", title: "Process Model" },
+  { model: "external", title: "External" },
+];
+
+/**
+ * Emits a Mermaid `flowchart LR` diagram. Solid arrows mark runtime-derived
+ * edges; dashed arrows mark statically-resolved (saga → command) edges.
+ *
+ * Canonical `DomainGraph` ids contain `:` (e.g. `command:PlaceBid`); Mermaid
+ * parsers reject the colon in identifier position, so we sanitize to `_` for
+ * Mermaid output only — the JSON / DOT emitters keep the original ids.
+ */
+export function emitMermaid(graph: DomainGraph): string {
+  const lines: string[] = ["flowchart LR"];
+
+  const styleHeader = renderClassDefs();
+  if (styleHeader.length > 0) lines.push(...styleHeader);
+
+  for (const { model, title } of MODEL_ORDER) {
+    const nodes = graph.nodes.filter((n) => n.model === model);
+    if (nodes.length === 0) continue;
+    lines.push(`  subgraph ${subgraphId(model)}["${title}"]`);
+    for (const node of nodes) {
+      lines.push(`    ${renderNode(node)}`);
+    }
+    lines.push(`  end`);
+  }
+
+  for (const edge of graph.edges) {
+    const arrow = edge.source === "static" ? "-.->" : "-->";
+    lines.push(`  ${mermaidId(edge.from)} ${arrow} ${mermaidId(edge.to)}`);
+  }
+
+  for (const node of graph.nodes) {
+    lines.push(
+      `  class ${mermaidId(node.id)} ${classFor(node.kind, node.model)};`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function renderNode(node: GraphNode): string {
+  const id = mermaidId(node.id);
+  switch (node.kind) {
+    case "command":
+    case "event":
+    case "query":
+      return `${id}(["${node.label}"])`;
+    case "aggregate":
+    case "projection":
+    case "saga":
+      return `${id}[["${node.label}"]]`;
+  }
+}
+
+/** Mermaid forbids `:` in node identifiers — replace with `_`. */
+function mermaidId(canonicalId: string): string {
+  return canonicalId.replace(/:/g, "_");
+}
+
+function classFor(kind: GraphNodeKind, model: GraphNode["model"]): string {
+  if (model === "external") return "externalCmd";
+  return kind;
+}
+
+function renderClassDefs(): string[] {
+  return [
+    "  classDef command fill:#dbeafe,stroke:#1e40af,color:#1e3a8a;",
+    "  classDef event fill:#fef3c7,stroke:#a16207,color:#713f12;",
+    "  classDef query fill:#dcfce7,stroke:#166534,color:#14532d;",
+    "  classDef aggregate fill:#e0e7ff,stroke:#3730a3,color:#312e81,stroke-width:2px;",
+    "  classDef projection fill:#ccfbf1,stroke:#115e59,color:#134e4a,stroke-width:2px;",
+    "  classDef saga fill:#fce7f3,stroke:#9d174d,color:#831843,stroke-width:2px;",
+    "  classDef externalCmd fill:#fee2e2,stroke:#b91c1c,color:#7f1d1d,stroke-dasharray:4 4;",
+  ];
+}
+
+function subgraphId(model: GraphNode["model"]): string {
+  return `model_${model}`;
+}

--- a/packages/cli/src/diagram/introspect.ts
+++ b/packages/cli/src/diagram/introspect.ts
@@ -1,0 +1,132 @@
+import type { DomainDefinition } from "@noddde/engine";
+import type { GraphEdge, GraphNode } from "./types.js";
+import { nodeId } from "./types.js";
+
+interface IntrospectResult {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+/**
+ * Walks a `DomainDefinition` and produces nodes + runtime-discoverable edges.
+ *
+ * Covers five of the six edge types:
+ *   - command → aggregate           (`Object.keys(aggregate.decide)`)
+ *   - aggregate → event             (`Object.keys(aggregate.evolve)`)
+ *   - event → projection            (`Object.keys(projection.on)`)
+ *   - query → projection            (`Object.keys(projection.queryHandlers)`)
+ *   - event → saga                  (`saga.startedBy` ∪ `Object.keys(saga.on)`)
+ *
+ * The sixth edge (saga → command) requires TypeScript-level resolution of
+ * the saga's `commands` discriminated union — see `static-analyze.ts`.
+ */
+export function introspectDomain(
+  definition: DomainDefinition,
+): IntrospectResult {
+  const nodes = new Map<string, GraphNode>();
+  const edges: GraphEdge[] = [];
+
+  const ensureNode = (node: GraphNode): void => {
+    const existing = nodes.get(node.id);
+    if (!existing) {
+      nodes.set(node.id, node);
+    }
+  };
+
+  const aggregates = definition.writeModel?.aggregates ?? {};
+  for (const [aggregateName, aggregate] of Object.entries(aggregates)) {
+    if (!aggregate) continue;
+    const aggId = nodeId("aggregate", aggregateName);
+    ensureNode({
+      id: aggId,
+      label: aggregateName,
+      kind: "aggregate",
+      model: "write",
+    });
+
+    for (const commandName of Object.keys(aggregate.decide ?? {})) {
+      const cmdId = nodeId("command", commandName);
+      ensureNode({
+        id: cmdId,
+        label: commandName,
+        kind: "command",
+        model: "write",
+      });
+      edges.push({ from: cmdId, to: aggId, source: "runtime" });
+    }
+
+    for (const eventName of Object.keys(aggregate.evolve ?? {})) {
+      const evtId = nodeId("event", eventName);
+      ensureNode({
+        id: evtId,
+        label: eventName,
+        kind: "event",
+        model: "write",
+      });
+      edges.push({ from: aggId, to: evtId, source: "runtime" });
+    }
+  }
+
+  const projections = definition.readModel?.projections ?? {};
+  for (const [projectionName, projection] of Object.entries(projections)) {
+    if (!projection) continue;
+    const projId = nodeId("projection", projectionName);
+    ensureNode({
+      id: projId,
+      label: projectionName,
+      kind: "projection",
+      model: "read",
+    });
+
+    for (const eventName of Object.keys(projection.on ?? {})) {
+      const evtId = nodeId("event", eventName);
+      ensureNode({
+        id: evtId,
+        label: eventName,
+        kind: "event",
+        model: "write",
+      });
+      edges.push({ from: evtId, to: projId, source: "runtime" });
+    }
+
+    for (const queryName of Object.keys(projection.queryHandlers ?? {})) {
+      const qId = nodeId("query", queryName);
+      ensureNode({
+        id: qId,
+        label: queryName,
+        kind: "query",
+        model: "read",
+      });
+      edges.push({ from: qId, to: projId, source: "runtime" });
+    }
+  }
+
+  const sagas = definition.processModel?.sagas ?? {};
+  for (const [sagaName, saga] of Object.entries(sagas)) {
+    if (!saga) continue;
+    const sagaIdValue = nodeId("saga", sagaName);
+    ensureNode({
+      id: sagaIdValue,
+      label: sagaName,
+      kind: "saga",
+      model: "process",
+    });
+
+    const triggerEvents = new Set<string>([
+      ...(saga.startedBy ?? []),
+      ...Object.keys(saga.on ?? {}),
+    ]);
+    for (const eventName of triggerEvents) {
+      const evtId = nodeId("event", eventName);
+      ensureNode({
+        id: evtId,
+        label: eventName,
+        kind: "event",
+        model: "write",
+      });
+      edges.push({ from: evtId, to: sagaIdValue, source: "runtime" });
+    }
+  }
+
+  return { nodes: Array.from(nodes.values()), edges };
+}

--- a/packages/cli/src/diagram/load-domain.ts
+++ b/packages/cli/src/diagram/load-domain.ts
@@ -1,0 +1,63 @@
+import * as path from "node:path";
+import { register } from "tsx/cjs/api";
+import type { DomainDefinition } from "@noddde/engine";
+import type { Aggregate, Projection, Saga } from "@noddde/core";
+
+/**
+ * The shape an entry file may export. The loader accepts either:
+ *   - the structural form: `aggregates`, `projections`, optional `sagas`
+ *   - a `definition` already produced by `defineDomain(...)`
+ */
+export interface LoadedDomain {
+  definition: DomainDefinition;
+  entryFile: string;
+}
+
+interface DomainModuleShape {
+  aggregates?: Record<string, Aggregate>;
+  projections?: Record<string, Projection>;
+  sagas?: Record<string, Saga>;
+  definition?: DomainDefinition;
+}
+
+/**
+ * Loads a user's TypeScript domain entry file via tsx's CommonJS register hook
+ * (no prebuild required). The entry must export either a `definition` from
+ * `defineDomain(...)` OR named `aggregates`/`projections`/`sagas` records.
+ */
+export function loadDomain(entryFile: string): LoadedDomain {
+  const absolute = path.resolve(entryFile);
+  const unregister = register();
+
+  let mod: DomainModuleShape;
+  try {
+    delete require.cache[absolute];
+    mod = require(absolute) as DomainModuleShape;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Diagram failed to load '${entryFile}'. Ensure your domain module has no top-level infrastructure dependencies.\n  cause: ${reason}`,
+    );
+  } finally {
+    unregister();
+  }
+
+  if (mod.definition) {
+    return { definition: mod.definition, entryFile: absolute };
+  }
+
+  if (mod.aggregates || mod.projections) {
+    const definition: DomainDefinition = {
+      writeModel: { aggregates: (mod.aggregates ?? {}) as never },
+      readModel: { projections: (mod.projections ?? {}) as never },
+      ...(mod.sagas ? { processModel: { sagas: mod.sagas as never } } : {}),
+    };
+    return { definition, entryFile: absolute };
+  }
+
+  throw new Error(
+    `Entry file '${entryFile}' does not export a 'definition', or 'aggregates'/'projections' records. ` +
+      `Expected either: \`export const definition = defineDomain({...})\` ` +
+      `or \`export const aggregates = {...}; export const projections = {...};\`.`,
+  );
+}

--- a/packages/cli/src/diagram/static-analyze.ts
+++ b/packages/cli/src/diagram/static-analyze.ts
@@ -1,0 +1,222 @@
+import * as path from "node:path";
+import * as fs from "node:fs";
+import * as ts from "typescript";
+
+export interface SagaCommandAnalysis {
+  /** Map of `<sagaKey>` → list of dispatched command names. */
+  commands: Map<string, string[]>;
+  /** Sagas whose `commands` type could not be resolved to a finite union. */
+  unresolved: string[];
+  /** Diagnostic messages (e.g. tsconfig not found). */
+  warnings: string[];
+}
+
+/**
+ * Resolves each saga's dispatched command names by reading the `commands`
+ * field of its `SagaTypes` bundle via the TypeScript compiler API.
+ *
+ * The `entryFile` should be the user's domain entry (e.g. `src/domain/domain.ts`)
+ * which exports a `sagas` object literal. For each `sagaKey` provided, the
+ * analyzer locates the export, reads its declared type as `Saga<T>`, extracts
+ * `T`, reads `T["commands"]`, and collects the `name` literal of each
+ * discriminated-union member.
+ */
+export function analyzeSagaCommands(
+  entryFile: string,
+  sagaKeys: string[],
+  tsconfigPath?: string,
+): SagaCommandAnalysis {
+  const result: SagaCommandAnalysis = {
+    commands: new Map(),
+    unresolved: [],
+    warnings: [],
+  };
+
+  if (sagaKeys.length === 0) return result;
+
+  const resolvedTsconfig = tsconfigPath ?? findNearestTsconfig(entryFile);
+  if (!resolvedTsconfig) {
+    result.warnings.push(
+      "No tsconfig.json found near the domain entry; saga command edges will be omitted.",
+    );
+    for (const key of sagaKeys) result.unresolved.push(key);
+    return result;
+  }
+
+  const program = createProgram(resolvedTsconfig, entryFile);
+  const checker = program.getTypeChecker();
+  const sourceFile = program.getSourceFile(path.resolve(entryFile));
+  if (!sourceFile) {
+    result.warnings.push(
+      `Could not load source file ${entryFile} into the TypeScript program.`,
+    );
+    for (const key of sagaKeys) result.unresolved.push(key);
+    return result;
+  }
+
+  const sagasSymbol = findExportedSymbol(sourceFile, checker, "sagas");
+  if (!sagasSymbol) {
+    result.warnings.push(
+      `Entry file does not export a 'sagas' object literal; saga command edges will be omitted.`,
+    );
+    for (const key of sagaKeys) result.unresolved.push(key);
+    return result;
+  }
+
+  const sagasType = checker.getTypeOfSymbolAtLocation(sagasSymbol, sourceFile);
+
+  for (const sagaKey of sagaKeys) {
+    const sagaProperty = sagasType.getProperty(sagaKey);
+    if (!sagaProperty) {
+      result.unresolved.push(sagaKey);
+      result.warnings.push(
+        `Saga '${sagaKey}' not found on the 'sagas' export; static analysis skipped.`,
+      );
+      continue;
+    }
+
+    const sagaPropertyType = checker.getTypeOfSymbolAtLocation(
+      sagaProperty,
+      sourceFile,
+    );
+    const commandNames = extractSagaCommands(checker, sagaPropertyType);
+
+    if (commandNames === null) {
+      result.unresolved.push(sagaKey);
+      result.warnings.push(
+        `Saga '${sagaKey}' declares an unconstrained command type; no Saga→Command edges produced.`,
+      );
+    } else {
+      result.commands.set(sagaKey, commandNames);
+    }
+  }
+
+  return result;
+}
+
+function findNearestTsconfig(start: string): string | undefined {
+  let dir = path.dirname(path.resolve(start));
+  const root = path.parse(dir).root;
+  for (;;) {
+    const candidate = path.join(dir, "tsconfig.json");
+    if (fs.existsSync(candidate)) return candidate;
+    if (dir === root) return undefined;
+    dir = path.dirname(dir);
+  }
+}
+
+function createProgram(tsconfigPath: string, entryFile: string): ts.Program {
+  const configText = fs.readFileSync(tsconfigPath, "utf8");
+  const parsed = ts.parseConfigFileTextToJson(tsconfigPath, configText);
+  const tsconfigDir = path.dirname(tsconfigPath);
+
+  const config = ts.parseJsonConfigFileContent(
+    parsed.config ?? {},
+    ts.sys,
+    tsconfigDir,
+  );
+
+  const rootNames = Array.from(
+    new Set([...config.fileNames, path.resolve(entryFile)]),
+  );
+
+  return ts.createProgram({
+    rootNames,
+    options: config.options,
+  });
+}
+
+function findExportedSymbol(
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker,
+  exportName: string,
+): ts.Symbol | undefined {
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  if (!moduleSymbol) return undefined;
+  const exports = checker.getExportsOfModule(moduleSymbol);
+  return exports.find((sym) => sym.getName() === exportName);
+}
+
+/**
+ * Given the type of one entry on the `sagas` map (a `Saga<T>` instance),
+ * pull out `T["commands"]` and collect the `name` literal of each
+ * discriminated-union member.
+ *
+ * Returns `null` if the commands type is not a finite, name-discriminated
+ * union (i.e. unresolvable).
+ */
+function extractSagaCommands(
+  checker: ts.TypeChecker,
+  sagaType: ts.Type,
+): string[] | null {
+  // The saga value is `Saga<T>`. Extract T.
+  const sagaDef = extractSagaTypeArgument(sagaType);
+  if (!sagaDef) return null;
+
+  const commandsSymbol = sagaDef.getProperty("commands");
+  if (!commandsSymbol) return null;
+  const commandsDecl =
+    commandsSymbol.valueDeclaration ?? commandsSymbol.declarations?.[0];
+  if (!commandsDecl) return null;
+  const commandsType = checker.getTypeOfSymbolAtLocation(
+    commandsSymbol,
+    commandsDecl,
+  );
+
+  return collectNameLiterals(checker, commandsType);
+}
+
+function extractSagaTypeArgument(sagaType: ts.Type): ts.Type | undefined {
+  // `Saga<T>` is a TypeReference; its type arguments contain T.
+  const typeReference = sagaType as ts.TypeReference;
+  if (typeReference.typeArguments && typeReference.typeArguments.length > 0) {
+    return typeReference.typeArguments[0];
+  }
+
+  // Sometimes the type comes back as `Saga<T> & { ... }` (intersection) when
+  // multiple `as const` narrowings happen. Walk intersections.
+  if (sagaType.isIntersection()) {
+    for (const member of sagaType.types) {
+      const inner = extractSagaTypeArgument(member);
+      if (inner) return inner;
+    }
+  }
+
+  return undefined;
+}
+
+function collectNameLiterals(
+  checker: ts.TypeChecker,
+  unionLike: ts.Type,
+): string[] | null {
+  const members = unionLike.isUnion() ? unionLike.types : [unionLike];
+  const names: string[] = [];
+
+  for (const member of members) {
+    const nameSymbol = member.getProperty("name");
+    if (!nameSymbol) return null;
+    const nameDecl =
+      nameSymbol.valueDeclaration ?? nameSymbol.declarations?.[0];
+    if (!nameDecl) return null;
+    const nameType = checker.getTypeOfSymbolAtLocation(nameSymbol, nameDecl);
+
+    if (nameType.isStringLiteral()) {
+      names.push(nameType.value);
+      continue;
+    }
+
+    // Could be a union of literals if the member is itself a union.
+    if (nameType.isUnion()) {
+      const all = nameType.types.every((t) => t.isStringLiteral());
+      if (!all) return null;
+      for (const sub of nameType.types) {
+        if (sub.isStringLiteral()) names.push(sub.value);
+      }
+      continue;
+    }
+
+    return null;
+  }
+
+  return Array.from(new Set(names));
+}

--- a/packages/cli/src/diagram/types.ts
+++ b/packages/cli/src/diagram/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Logical category for a graph node. Drives styling, shape, and subgraph
+ * assignment in emitters.
+ */
+export type GraphNodeKind =
+  | "command"
+  | "event"
+  | "query"
+  | "aggregate"
+  | "projection"
+  | "saga";
+
+/**
+ * Which top-level model a node belongs to. `external` is reserved for
+ * commands that a saga dispatches but no aggregate handles.
+ */
+export type GraphNodeModel = "write" | "read" | "process" | "external";
+
+/** A node in the domain flow graph. */
+export interface GraphNode {
+  /** Stable, unique key. Format: `<kind>:<name>` (e.g. `command:PlaceBid`). */
+  id: string;
+  /** Human-readable display name. */
+  label: string;
+  kind: GraphNodeKind;
+  model: GraphNodeModel;
+}
+
+/** Origin of an edge — runtime introspection or TypeScript-level resolution. */
+export type GraphEdgeSource = "runtime" | "static";
+
+/** A directed edge between two nodes. */
+export interface GraphEdge {
+  from: string;
+  to: string;
+  source: GraphEdgeSource;
+}
+
+/** Output graph consumed by emitters. */
+export interface DomainGraph {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  warnings: string[];
+}
+
+export type DiagramFormat = "mermaid" | "dot" | "json";
+
+export type DiagramScope = "write" | "read" | "process" | "all";
+
+export interface DiagramOptions {
+  format?: DiagramFormat;
+  scope?: DiagramScope;
+  hideIsolated?: boolean;
+  tsconfigPath?: string;
+}
+
+/** Build a node id from kind + name. Always use this — never concatenate. */
+export function nodeId(kind: GraphNodeKind, name: string): string {
+  return `${kind}:${name}`;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 import { registerNewCommand } from "./commands/new.js";
 import { registerAddCommand } from "./commands/add.js";
+import { registerDiagramCommand } from "./commands/diagram.js";
 
 const program = new Command();
 
@@ -12,5 +13,6 @@ program
 
 registerNewCommand(program);
 registerAddCommand(program);
+registerDiagramCommand(program);
 
 program.parse();

--- a/specs/cli/diagram.spec.md
+++ b/specs/cli/diagram.spec.md
@@ -1,0 +1,471 @@
+---
+title: "noddde diagram — flow diagram from a domain"
+module: cli/diagram
+source_file: packages/cli/src/commands/diagram.ts
+status: implemented
+exports:
+  - registerDiagramCommand
+  - DomainGraph
+  - GraphNode
+  - GraphEdge
+  - buildDomainGraph
+  - introspectDomain
+  - analyzeSagaCommands
+  - emitMermaid
+  - emitDot
+  - emitJson
+depends_on:
+  - core/ddd/aggregate-root
+  - core/ddd/projection
+  - core/ddd/saga
+  - engine/domain
+docs:
+  - getting-started/cli.mdx
+---
+
+# noddde diagram
+
+> A CLI command that loads a noddde domain module and emits a flow diagram of how commands, events, and queries traverse the system. Five of the six edge types are derived from runtime introspection of plain `defineAggregate`/`defineProjection`/`defineSaga` objects; only `Saga → Command` requires TypeScript-level type resolution because saga handlers construct commands inline. The default output is Mermaid, with DOT and JSON also supported. A normalized `DomainGraph` intermediate decouples introspection from emission.
+
+## Type Contract
+
+```ts
+/** A node in the domain flow graph. */
+export type GraphNode = {
+  /** Stable, unique key. Format: `<kind>:<name>` (e.g. `command:PlaceBid`). */
+  id: string;
+  /** Human-readable display name (the command/event/query/component name). */
+  label: string;
+  /** Logical category for styling and subgraph assignment. */
+  kind: "command" | "event" | "query" | "aggregate" | "projection" | "saga";
+  /** Which top-level model this node belongs to. */
+  model: "write" | "read" | "process" | "external";
+};
+
+/** A directed edge between two nodes. */
+export type GraphEdge = {
+  from: string; // GraphNode.id
+  to: string; // GraphNode.id
+  /**
+   * `runtime` — derived from `Object.keys(...)` on the live domain.
+   * `static`  — derived by resolving a TypeScript discriminated union.
+   */
+  source: "runtime" | "static";
+};
+
+/** The fully-normalized graph. Emitters consume only this type. */
+export type DomainGraph = {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  /** Non-fatal diagnostics surfaced to the user (missing handlers, fallbacks). */
+  warnings: string[];
+};
+
+/** Output format. */
+export type DiagramFormat = "mermaid" | "dot" | "json";
+
+/** Subgraph filter. */
+export type DiagramScope = "write" | "read" | "process" | "all";
+
+/** Options for the top-level command and the build pipeline. */
+export type DiagramOptions = {
+  format?: DiagramFormat; // default "mermaid"
+  scope?: DiagramScope; // default "all"
+  hideIsolated?: boolean; // default false
+  tsconfigPath?: string; // auto-detected from the entry's package
+};
+
+/** Pure builder. Combines runtime introspection + (lazy) static analysis. */
+export function buildDomainGraph(
+  definition: DomainDefinition,
+  entryFile: string,
+  options?: DiagramOptions,
+): DomainGraph;
+
+/** Runtime walk of a DomainDefinition — covers 5 of 6 edge types. */
+export function introspectDomain(definition: DomainDefinition): {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+};
+
+/** Result of saga command static analysis. */
+export interface SagaCommandAnalysis {
+  /** Map of `<sagaKey>` → list of dispatched command names. */
+  commands: Map<string, string[]>;
+  /** Sagas whose `commands` type could not be resolved to a finite union. */
+  unresolved: string[];
+  /** Diagnostic messages (e.g. tsconfig not found). */
+  warnings: string[];
+}
+
+/**
+ * Resolves each saga's `commands` discriminated union via the TS compiler API
+ * and returns the set of command names per saga key. The `entryFile` is the
+ * domain entry path; the analyzer resolves the saga symbols transitively.
+ */
+export function analyzeSagaCommands(
+  entryFile: string,
+  sagaKeys: string[],
+  tsconfigPath?: string,
+): SagaCommandAnalysis;
+
+/** Emit a Mermaid `flowchart LR` diagram. */
+export function emitMermaid(graph: DomainGraph): string;
+
+/** Emit a Graphviz DOT digraph. */
+export function emitDot(graph: DomainGraph): string;
+
+/** Emit the JSON serialization of the graph. */
+export function emitJson(graph: DomainGraph): string;
+
+/** Registers the `noddde diagram` subcommand on the root program. */
+export function registerDiagramCommand(program: Command): void;
+```
+
+## Behavioral Requirements
+
+1. **Command → Aggregate edges** are produced from `Object.keys(aggregate.decide)` for each aggregate in `definition.writeModel.aggregates`. Each command name yields one node (`command:<name>`) and one edge to the aggregate node (`aggregate:<key>`).
+2. **Aggregate → Event edges** are produced from `Object.keys(aggregate.evolve)` for each aggregate. The `EvolveHandlerMap` is required by the `Aggregate` type (keyed by `T["events"]["name"]`), so every emitted event has a corresponding key. Edge `source` is `"runtime"`.
+3. **Event → Projection edges** are produced from `Object.keys(projection.on)` for each projection. The `on` map is partial; only the listed event names produce edges.
+4. **Query → Projection edges** are produced from `Object.keys(projection.queryHandlers)` for each projection.
+5. **Event → Saga edges** are produced from the union of `saga.startedBy` and `Object.keys(saga.on)` for each saga, deduplicated. `startedBy` is a non-empty tuple at the type level; the introspector treats both arrays the same way.
+6. **Saga → Command edges** are produced by `analyzeSagaCommands`, which uses the TypeScript compiler API to resolve the `commands` field of each saga's type bundle (the type passed as the generic argument to `defineSaga`). The discriminated union members must each have a `name` property whose type is a string literal; those literals are the dispatched command names. Edge `source` is `"static"`.
+7. **Multiple aggregates emitting the same event** produce a single event node with multiple incoming edges (one per emitter). The same applies to events handled by multiple projections or sagas.
+8. **External commands** — when a saga's `analyzeSagaCommands` output contains a command name that no aggregate declares in its `decide` map, the command node is still created and tagged `model: "external"`. A warning is added to `graph.warnings`. This is one of the diagnostic outputs the tool exists to produce.
+9. **Optional `processModel`** — when `definition.processModel?.sagas` is `undefined` or empty, no saga nodes or edges are produced and the static analysis pass is skipped entirely.
+10. **`scope` filter** — when `scope !== "all"`, the graph filters out nodes whose `model` is not in the chosen scope, plus all edges referencing dropped nodes. `command`, `event`, and `query` nodes inherit their model from the component that produces them; events emitted by aggregates are `write`-model events and are kept under `scope: "write"`.
+11. **`hideIsolated`** — when `true`, the builder removes nodes whose total degree (in + out) is zero after scope filtering.
+12. **Format default** — `format: undefined` resolves to `"mermaid"`. `scope: undefined` resolves to `"all"`.
+13. **Mermaid output structure** — emit `flowchart LR` with three `subgraph` blocks (`Write Model`, `Read Model`, `Process Model`), in that order. Empty subgraphs are omitted. Solid edges (`-->`) for `runtime` source; dashed edges (`-.->`) for `static`. Node shapes by kind: command/query/event = pill (`(["X"])`), aggregate/projection/saga = box (`[[X]]`).
+14. **DOT output structure** — emit `digraph G { rankdir=LR; ... }` with cluster subgraphs (`subgraph cluster_write { ... }`). Edge style `solid` for runtime, `dashed` for static.
+15. **JSON output** — emit `JSON.stringify(graph, null, 2)`. This is the contract for downstream consumers.
+16. **CLI command** — `noddde diagram [domain-file]` defaults its first positional argument to `src/domain/domain.ts` resolved against `process.cwd()`. Flags: `--out <path>`, `--format <mermaid|dot|json>`, `--scope <write|read|process|all>`, `--hide-isolated`, `--tsconfig <path>`. When `--out` is omitted, the diagram is written to stdout.
+17. **Domain loading** — the entry file is loaded with [tsx](https://github.com/privatenumber/tsx) via a programmatic API (`tsx.tsImport` or equivalent) so `.ts` files import without a prebuild. The loader expects the entry file to export `aggregates`, `projections`, and optionally `sagas` as named exports, OR to export a `definition` from `defineDomain(...)`. Both shapes are supported; the introspector synthesizes a minimal `DomainDefinition` from the named exports when the latter shape is absent.
+18. **Error: side-effecting domain file** — if the dynamic import throws, the CLI prints a clear message ("Diagram failed to load `<entry>`. Ensure your domain module has no top-level infrastructure dependencies") and exits with code 1.
+19. **Error: missing exports** — if neither `definition` nor `aggregates` is found on the imported module, exit with code 1 and a message naming the expected exports.
+
+## Invariants
+
+- Every edge's `from` and `to` reference an existing node in `graph.nodes`.
+- `GraphNode.id` is unique across `graph.nodes`.
+- A `command` node referenced by both an aggregate edge and a saga edge is **always** the same node (commands are deduplicated by name, never split). The `model` of such a node is `"write"` (a real handled command), never `"external"`.
+- The graph contains no self-loops.
+- `runtime`-source edges never depend on TypeScript resolution; the introspector pass alone is enough to produce them.
+
+## Edge Cases
+
+- **Domain with no projections**: write-model only. Read-model subgraph is omitted from Mermaid/DOT output.
+- **Domain with no sagas**: process-model subgraph omitted; static analysis pass is skipped (no `tsconfig` resolution required).
+- **Saga `commands` resolves to `Command` (the framework base type) with no literal `name`**: emit one warning per saga ("Saga `<key>` declares an unconstrained command type — no Saga→Command edges produced"). The saga still appears as a node with its incoming event edges.
+- **Saga handler dispatches a command that no aggregate handles** (cross-domain or stub): keep the command node (`model: "external"`) and the saga→command edge; add a warning naming both.
+- **Two aggregates emit an event with the same name**: one event node, two incoming edges. No collision.
+- **Empty `aggregates` map** (rare but allowed by `DomainDefinition`): write-model subgraph omitted; warning added.
+- **`tsconfigPath` not provided and not auto-discoverable**: walk up from the entry file looking for the nearest `tsconfig.json`. If none found, skip static analysis with a warning ("No tsconfig.json found; saga command edges will be omitted").
+- **Mermaid identifier sanitization**: canonical `DomainGraph` ids contain `:` (e.g. `command:PlaceBid`), which Mermaid's parser rejects in identifier position. The Mermaid emitter replaces `:` with `_` (e.g. `command_PlaceBid`) when emitting node ids, edge endpoints, and `class` lines. The DOT emitter quotes ids and keeps the colon. The JSON output preserves the canonical ids verbatim.
+
+## Integration Points
+
+- **`@noddde/core`**: imports the `Aggregate`, `Projection`, `Saga` interfaces for typing. No runtime dependency.
+- **`@noddde/engine`**: imports `DomainDefinition` for typing. No runtime dependency.
+- **TypeScript compiler API** (`typescript` — already a dev dep): used by `analyzeSagaCommands`. The analyzer creates a `Program` rooted at the saga module's source file, locates each saga's call to `defineSaga<T>(...)`, resolves `T` to a type, walks the `commands` property type, and reads the literal `name` of each union member.
+- **`tsx`**: a new runtime dep for `.ts` import without prebuild.
+- **`commander`**: subcommand registration follows the existing `registerNewCommand` / `registerAddCommand` pattern in `packages/cli/src/index.ts`.
+
+## Test Scenarios
+
+The test file is `packages/cli/src/__tests__/diagram/diagram.test.ts`. Sample fixtures live at `samples/sample-auction`, `samples/sample-flash-sale`, and `samples/sample-hotel-booking` and are imported directly (no temp project setup needed for the introspector tests).
+
+### Aggregate decide keys produce command nodes and command→aggregate edges
+
+```ts
+import { describe, it, expect } from "vitest";
+import { introspectDomain } from "../../diagram/introspect";
+import { aggregates as auctionAggregates } from "../../../../../../samples/sample-auction/src/domain/domain";
+
+it("produces a command node + edge for each key in aggregate.decide", () => {
+  const { nodes, edges } = introspectDomain({
+    writeModel: { aggregates: auctionAggregates },
+    readModel: { projections: {} },
+  } as any);
+
+  const commandNodes = nodes.filter((n) => n.kind === "command");
+  const auctionDecideKeys = Object.keys(auctionAggregates.Auction.decide);
+  expect(commandNodes.map((n) => n.label).sort()).toEqual(
+    auctionDecideKeys.sort(),
+  );
+
+  for (const cmdName of auctionDecideKeys) {
+    expect(
+      edges.find(
+        (e) => e.from === `command:${cmdName}` && e.to === `aggregate:Auction`,
+      ),
+    ).toBeDefined();
+  }
+});
+```
+
+### Aggregate evolve keys produce event nodes and aggregate→event edges
+
+```ts
+it("produces an event node + edge for each key in aggregate.evolve", () => {
+  const { nodes, edges } = introspectDomain({
+    writeModel: { aggregates: auctionAggregates },
+    readModel: { projections: {} },
+  } as any);
+
+  const eventNodes = nodes.filter((n) => n.kind === "event");
+  const auctionEvolveKeys = Object.keys(auctionAggregates.Auction.evolve);
+  expect(eventNodes.map((n) => n.label).sort()).toEqual(
+    auctionEvolveKeys.sort(),
+  );
+
+  for (const evtName of auctionEvolveKeys) {
+    expect(
+      edges.find(
+        (e) => e.from === `aggregate:Auction` && e.to === `event:${evtName}`,
+      ),
+    ).toBeDefined();
+  }
+});
+```
+
+### Projection on keys produce event→projection edges
+
+```ts
+import { projections as auctionProjections } from "../../../../../../samples/sample-auction/src/domain/domain";
+
+it("produces an event→projection edge for each key in projection.on", () => {
+  const { edges } = introspectDomain({
+    writeModel: { aggregates: auctionAggregates },
+    readModel: { projections: auctionProjections },
+  } as any);
+
+  const summary = auctionProjections.AuctionSummary;
+  for (const evtName of Object.keys(summary.on)) {
+    expect(
+      edges.find(
+        (e) =>
+          e.from === `event:${evtName}` && e.to === `projection:AuctionSummary`,
+      ),
+    ).toBeDefined();
+  }
+});
+```
+
+### Projection queryHandlers keys produce query→projection edges
+
+```ts
+it("produces a query→projection edge for each key in projection.queryHandlers", () => {
+  const { edges } = introspectDomain({
+    writeModel: { aggregates: auctionAggregates },
+    readModel: { projections: auctionProjections },
+  } as any);
+
+  const summary = auctionProjections.AuctionSummary;
+  for (const qName of Object.keys(summary.queryHandlers)) {
+    expect(
+      edges.find(
+        (e) =>
+          e.from === `query:${qName}` && e.to === `projection:AuctionSummary`,
+      ),
+    ).toBeDefined();
+  }
+});
+```
+
+### Saga startedBy and on keys both produce event→saga edges
+
+```ts
+import {
+  aggregates as hotelAggregates,
+  projections as hotelProjections,
+  sagas as hotelSagas,
+} from "../../../../../../samples/sample-hotel-booking/src/domain/domain";
+
+it("produces event→saga edges for both startedBy and on keys", () => {
+  const { edges } = introspectDomain({
+    writeModel: { aggregates: hotelAggregates },
+    readModel: { projections: hotelProjections },
+    processModel: { sagas: hotelSagas },
+  } as any);
+
+  const fulfillment = hotelSagas.BookingFulfillment;
+  const triggers = new Set([
+    ...fulfillment.startedBy,
+    ...Object.keys(fulfillment.on),
+  ]);
+  for (const evtName of triggers) {
+    expect(
+      edges.find(
+        (e) =>
+          e.from === `event:${evtName}` && e.to === `saga:BookingFulfillment`,
+      ),
+    ).toBeDefined();
+  }
+});
+```
+
+### Static analysis resolves SagaDef.commands to the literal command names
+
+```ts
+import { analyzeSagaCommands } from "../../diagram/static-analyze";
+import path from "node:path";
+
+it("extracts dispatched command names from a saga's command union", () => {
+  const entryFile = path.resolve(
+    __dirname,
+    "../../../../../samples/sample-hotel-booking/src/domain/domain.ts",
+  );
+  const result = analyzeSagaCommands(entryFile, ["BookingFulfillment"]);
+
+  const cmds = result.get("BookingFulfillment");
+  expect(cmds).toBeDefined();
+  // BookingCommand union members
+  expect(cmds).toContain("ConfirmBooking");
+  expect(cmds).toContain("CancelBooking");
+  // RoomCommand union members
+  expect(cmds).toContain("BlockRoom");
+  expect(cmds).toContain("ReleaseRoom");
+});
+```
+
+### Saga→command edges flag external commands and emit a warning
+
+```ts
+import { buildDomainGraph } from "../../diagram/build-graph";
+
+it("marks saga-dispatched commands not handled by any aggregate as external", () => {
+  // Synthetic case: saga dispatches "FooBar" but no aggregate has FooBar in decide.
+  // We construct the saga static-analysis result directly to keep the test deterministic.
+  const graph = buildDomainGraph(
+    {
+      writeModel: { aggregates: hotelAggregates },
+      readModel: { projections: hotelProjections },
+      processModel: { sagas: hotelSagas },
+    } as any,
+    "fake-entry.ts",
+    {},
+    // injected for testability
+    new Map([["BookingFulfillment", ["ConfirmBooking", "FooBar"]]]),
+  );
+
+  const fooBarNode = graph.nodes.find((n) => n.id === "command:FooBar");
+  expect(fooBarNode?.model).toBe("external");
+  expect(
+    graph.warnings.some((w) => w.includes("FooBar") && w.includes("external")),
+  ).toBe(true);
+});
+```
+
+### Mermaid emitter renders subgraphs and edge styles
+
+```ts
+import { emitMermaid } from "../../diagram/emit-mermaid";
+
+it("emits Mermaid with subgraphs, pill nodes, and dashed static edges", () => {
+  const graph: DomainGraph = {
+    nodes: [
+      {
+        id: "command:CreateAuction",
+        label: "CreateAuction",
+        kind: "command",
+        model: "write",
+      },
+      {
+        id: "aggregate:Auction",
+        label: "Auction",
+        kind: "aggregate",
+        model: "write",
+      },
+      {
+        id: "event:AuctionCreated",
+        label: "AuctionCreated",
+        kind: "event",
+        model: "write",
+      },
+      { id: "saga:Foo", label: "Foo", kind: "saga", model: "process" },
+      {
+        id: "command:DoFoo",
+        label: "DoFoo",
+        kind: "command",
+        model: "external",
+      },
+    ],
+    edges: [
+      {
+        from: "command:CreateAuction",
+        to: "aggregate:Auction",
+        source: "runtime",
+      },
+      {
+        from: "aggregate:Auction",
+        to: "event:AuctionCreated",
+        source: "runtime",
+      },
+      { from: "event:AuctionCreated", to: "saga:Foo", source: "runtime" },
+      { from: "saga:Foo", to: "command:DoFoo", source: "static" },
+    ],
+    warnings: [],
+  };
+
+  const out = emitMermaid(graph);
+  expect(out).toMatch(/flowchart LR/);
+  expect(out).toMatch(/subgraph .*Write Model/);
+  expect(out).toMatch(/subgraph .*Process Model/);
+  expect(out).toMatch(/\(\["CreateAuction"\]\)/);
+  expect(out).toMatch(/\[\[Auction\]\]/);
+  // Solid edge for runtime
+  expect(out).toMatch(/command:CreateAuction --> aggregate:Auction/);
+  // Dashed edge for static
+  expect(out).toMatch(/saga:Foo -\.-> command:DoFoo/);
+});
+```
+
+### JSON emitter is the canonical contract
+
+```ts
+import { emitJson } from "../../diagram/emit-json";
+
+it("emits valid JSON that round-trips the graph", () => {
+  const graph: DomainGraph = {
+    nodes: [{ id: "command:X", label: "X", kind: "command", model: "write" }],
+    edges: [],
+    warnings: ["a warning"],
+  };
+  const out = emitJson(graph);
+  expect(JSON.parse(out)).toEqual(graph);
+});
+```
+
+### Scope filter drops nodes outside the chosen model
+
+```ts
+it("filters out read-model nodes when scope=write", () => {
+  const graph = buildDomainGraph(
+    {
+      writeModel: { aggregates: auctionAggregates },
+      readModel: { projections: auctionProjections },
+    } as any,
+    "fake.ts",
+    { scope: "write" },
+  );
+  expect(graph.nodes.find((n) => n.kind === "projection")).toBeUndefined();
+  expect(graph.nodes.find((n) => n.kind === "query")).toBeUndefined();
+});
+```
+
+### Empty processModel produces no saga nodes and skips static analysis
+
+```ts
+it("skips the static analysis pass when there are no sagas", () => {
+  const graph = buildDomainGraph(
+    {
+      writeModel: { aggregates: auctionAggregates },
+      readModel: { projections: auctionProjections },
+    } as any,
+    "fake-entry.ts",
+    {},
+  );
+  expect(graph.nodes.find((n) => n.kind === "saga")).toBeUndefined();
+});
+```

--- a/yarn.lock
+++ b/yarn.lock
@@ -9640,7 +9640,7 @@ tsutils@^3.21.0:
   dependencies:
     tslib "^1.8.1"
 
-tsx@^4.21.0:
+tsx@^4.19.0, tsx@^4.21.0:
   version "4.21.0"
   resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.21.0.tgz#32aa6cf17481e336f756195e6fe04dae3e6308b1"
   integrity sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==


### PR DESCRIPTION
## Summary

Adds a new CLI subcommand, `noddde diagram`, that loads a domain module and emits a flow diagram showing how commands, events, and queries traverse the system. Renders as Mermaid by default, with DOT and JSON also supported.

The framework's design makes this unusually clean: aggregates, projections, and sagas are plain identity-function objects, so **5 of the 6 edge types fall straight out of `Object.keys(...)` on the loaded definition**:

| Edge                 | Source                                                      |
| -------------------- | ----------------------------------------------------------- |
| Command → Aggregate  | `Object.keys(aggregate.decide)` — runtime                   |
| Aggregate → Event    | `Object.keys(aggregate.evolve)` — runtime                   |
| Event → Projection   | `Object.keys(projection.on)` — runtime                      |
| Query → Projection   | `Object.keys(projection.queryHandlers)` — runtime           |
| Event → Saga         | `saga.startedBy[]` ∪ `Object.keys(saga.on)` — runtime       |
| Saga → Command       | `SagaDef.commands` discriminated union — TS compiler API    |

A normalized `DomainGraph` intermediate keeps emitters as pure formatters and gives downstream tooling (docs site, registries) a stable JSON contract.

### What's in the PR

- **Spec** — `specs/cli/diagram.spec.md` (`status: implemented`) — full Type Contract, Behavioral Requirements, Edge Cases, and Test Scenarios.
- **CLI** — `noddde diagram [domain-file]` registered alongside `new`/`add`. Flags: `--out`, `--format`, `--scope`, `--hide-isolated`, `--tsconfig`.
- **Modules** in `packages/cli/src/diagram/`: `types.ts`, `load-domain.ts` (tsx-based loader), `introspect.ts` (runtime walks), `static-analyze.ts` (TS Type Checker), `build-graph.ts`, `emit-mermaid.ts` / `emit-dot.ts` / `emit-json.ts`.
- **Tests** — 21 new tests covering all 6 edge types, scope filtering, external commands, hide-isolated, emitter syntax. Total CLI suite: **191 passing**, lint clean, tsc clean.
- **Docs** — extended `docs/content/docs/getting-started/cli.mdx` with a new `## Visualizing Domains` section (usage, output formats, diagram structure, flag reference, diagnostics, loader caveats). Updated `packages/cli/README.md` to mention the third command group.
- **Dep** — `tsx` added to CLI runtime deps (loads `.ts` entries without prebuild).

### Diagnostics worth catching

The diagram doubles as a static check on the domain. Two warnings get surfaced (stderr + JSON `warnings`):

- **External commands** — a saga dispatches a command name no aggregate handles. The command node renders as `external` (red, dashed border in Mermaid) and the warning names both ends.
- **Unresolvable saga commands** — a saga's `commands` field doesn't resolve to a finite literal-named union (e.g. typed as `Command`). The saga still appears with its incoming event edges; the warning notes that no outgoing edges could be produced.

### Verified end-to-end

Run against all three samples:

- `sample-flash-sale` (write only): single subgraph, no projections or sagas.
- `sample-auction` (write + read): full command → aggregate → event → projection ← query flow.
- `sample-hotel-booking` (full process model): all six edge types, including dashed `saga -.-> command` edges resolved from the `BookingCommand | RoomCommand` union via the TS Type Checker.

## Test plan

- [ ] `cd packages/cli && yarn build` — TypeScript clean
- [ ] `cd packages/cli && npx vitest run` — 191/191 passing (21 new diagram tests)
- [ ] `cd packages/cli && yarn lint` — clean (`--max-warnings 0`)
- [ ] `npx prettier --check` — clean on all touched files
- [ ] Manual: `node packages/cli/dist/index.js diagram samples/sample-auction/src/domain/domain.ts` renders a complete write+read Mermaid diagram.
- [ ] Manual: `node packages/cli/dist/index.js diagram samples/sample-hotel-booking/src/domain/domain.ts` renders all six edge types with dashed saga→command arrows.
- [ ] Manual: `node packages/cli/dist/index.js diagram samples/sample-flash-sale/src/domain/domain.ts` correctly omits read/process subgraphs.
- [ ] Manual: `--format json`, `--format dot`, `--scope process`, `--hide-isolated` each behave as documented.

## Notes for reviewers

- Mermaid forbids `:` in node identifiers, so the Mermaid emitter sanitizes canonical ids (`command:PlaceBid` → `command_PlaceBid`). The DOT emitter quotes ids and keeps the colon; the JSON output preserves the canonical ids verbatim.
- The TS-level resolution in `static-analyze.ts` uses the Type Checker (not raw AST traversal) so it follows aliases, intersections, and re-exports correctly. ~150 lines.
- The loader accepts both shapes the framework already produces: structural (`aggregates`/`projections`/`sagas` named exports) or wired (`definition` from `defineDomain(...)`).
- New CLI dep: `tsx@^4.19.0`. Already a dev dep in samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)