### PR TITLE
fix(cli): raise vitest timeouts for diagram TS-compiler tests

### DIFF
--- a/packages/cli/vitest.config.mts
+++ b/packages/cli/vitest.config.mts
@@ -3,5 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/__tests__/**/*.test.ts"],
+    // Diagram tests build a real ts.Program (multi-second on CI). Bump
+    // both per-test and hook budgets so the suite has headroom on slow
+    // GitHub-Actions runners.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Summary

- The v0.3.7 release run [#24985638739](https://github.com/dogganidhal/noddde/actions/runs/24985638739/job/73159924271) failed at the **Test** step: `buildDomainGraph > returns a graph with all six edge kinds present for hotel-booking` (`packages/cli/src/__tests__/diagram/build-graph.test.ts:26`) timed out at 5000 ms.
- Root cause: that test calls `buildDomainGraph` on the hotel-booking sample, which runs `analyzeSagaCommands` and **builds a fresh `ts.Program`** from the sample's tsconfig — multi-second work on GitHub-Actions runners. `static-analyze.test.ts` was already at the edge (~3 s/test, 6.1 s for the file).
- Fix: raise `testTimeout` and `hookTimeout` to 30 s in `packages/cli/vitest.config.mts`. No source/spec/test-logic change — the diagram code is correct, the default vitest budget was just too tight for tests that legitimately invoke the TypeScript compiler.

## Test plan

- [ ] CI `format` job passes (prettier).
- [ ] CI `lint` job passes.
- [ ] CI `test` job passes — specifically `@noddde/cli#test`, including `build-graph.test.ts` and `static-analyze.test.ts`.
- [ ] Re-running the release workflow (after merge + new tag) reaches the publish steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)