### PR TITLE
docs: redesign landing comparison and onboarding flow

### DIFF
--- a/docs/content/docs/getting-started/introduction.mdx
+++ b/docs/content/docs/getting-started/introduction.mdx
@@ -1,23 +1,19 @@
 ---
-title: Introduction
-description: What is noddde and why use it
+title: Concepts at a Glance
+description: A one-screen summary of the building blocks — aggregates, projections, sagas, and how they fit together
 ---
 
-## What is noDDDe?
+This page is a quick reference. If you have not run the [Quick Start](/docs/getting-started/quick-start) yet, do that first — the concepts make a lot more sense once you have seen them work.
 
-noDDDe is a TypeScript framework for building applications using **Domain-Driven Design (DDD)**, **Command Query Responsibility Segregation (CQRS)**, and **Event Sourcing** patterns.
+## The four building blocks
 
-It provides building blocks — not an opinionated runtime. You define your domain as typed objects and pure functions, and noDDDe gives you the type infrastructure to wire them together safely.
+### Aggregate
 
-## Core Ideas
-
-### Aggregates
-
-Aggregates are consistency boundaries — the units that process commands and enforce business rules. In noDDDe, an aggregate is defined using the functional [Decider pattern](/docs/core-concepts/decider-pattern):
+A consistency boundary. Processes commands, enforces invariants, produces events. Defined as `initialState + decide + evolve`:
 
 ```ts
 const BankAccount = defineAggregate<BankAccountDef>({
-  initialState: { balance: 0, transactions: [] },
+  initialState: { balance: 0 },
   decide: {
     AuthorizeTransaction: (command, state, infra) => {
       /* return events */
@@ -31,11 +27,11 @@ const BankAccount = defineAggregate<BankAccountDef>({
 });
 ```
 
-No base class. No decorators. No `this`. Just an object with handler maps.
+`decide` decides; `evolve` evolves state from events. Both are pure functions of their arguments. → [Defining Aggregates](/docs/modeling/defining-aggregates)
 
-### Commands
+### Command
 
-Commands express **intent to change state**. They are typed messages with a `name`, a `targetAggregateId` (for routing), and an optional `payload`:
+Imperative. The thing the user is asking the aggregate to do.
 
 ```ts
 type BankAccountCommand = DefineCommands<{
@@ -44,9 +40,11 @@ type BankAccountCommand = DefineCommands<{
 }>;
 ```
 
-### Events
+Carries a `name`, a `targetAggregateId`, and an optional `payload`. → [Messages & Types](/docs/core-concepts/messages-and-types)
 
-Events are **immutable facts about what happened**. They use past tense and are produced by decide handlers:
+### Event
+
+Past-tense fact. The thing that actually happened.
 
 ```ts
 type BankAccountEvent = DefineEvents<{
@@ -55,16 +53,15 @@ type BankAccountEvent = DefineEvents<{
 }>;
 ```
 
-### Projections
+Immutable. Persisted. Replayed by `evolve` to rebuild state on load.
 
-Projections build **read-optimized views** from event streams. They are the query side of CQRS:
+### Projection
+
+The query side of CQRS. Builds read-optimized views from event streams.
 
 ```ts
 const BankAccountProjection = defineProjection<BankAccountProjectionDef>({
   on: {
-    BankAccountCreated: {
-      reduce: (event, view) => ({ ...view, id: event.payload.id }),
-    },
     TransactionAuthorized: {
       reduce: (event, view) => ({
         ...view,
@@ -78,9 +75,11 @@ const BankAccountProjection = defineProjection<BankAccountProjectionDef>({
 });
 ```
 
-### Sagas
+→ [Projections](/docs/read-model/projections)
 
-Sagas are **event-driven process managers** that coordinate workflows across multiple aggregates. They are the structural inverse of aggregates — events in, commands out:
+### Saga
+
+Process manager. Listens to events, emits commands. The structural inverse of an aggregate.
 
 ```ts
 const OrderFulfillmentSaga = defineSaga<OrderFulfillmentSagaDef>({
@@ -91,67 +90,33 @@ const OrderFulfillmentSaga = defineSaga<OrderFulfillmentSagaDef>({
       id: (event) => event.payload.orderId,
       handle: (event, state) => ({
         state: { ...state, status: "awaiting_payment" },
-        commands: { name: "RequestPayment", targetAggregateId: "...", payload: { ... } },
+        commands: { name: "RequestPayment" /* ... */ },
       }),
     },
   },
 });
 ```
 
-### Domain Configuration
+→ [Sagas](/docs/process-managers/sagas)
 
-`defineDomain` captures the domain structure and `wireDomain` connects it to infrastructure to create a running domain:
+## How they fit together
+
+`defineDomain` captures the structure; `wireDomain` plugs in infrastructure:
 
 ```ts
-import { defineDomain, wireDomain } from "@noddde/engine";
-
 const myDomain = defineDomain({
   writeModel: { aggregates: { BankAccount } },
   readModel: { projections: { BankAccount: BankAccountProjection } },
   processModel: { sagas: { OrderFulfillment: OrderFulfillmentSaga } },
 });
 
-const domain = await wireDomain(myDomain, {
-  infrastructure: () => ({
-    /* custom infra */
-  }),
-  aggregates: {
-    persistence: () => new InMemoryEventSourcedAggregatePersistence(),
-  },
-  buses: () => ({
-    commandBus: new InMemoryCommandBus(),
-    eventBus: new EventEmitterEventBus(),
-    queryBus: new InMemoryQueryBus(),
-  }),
-});
+const domain = await wireDomain(myDomain);
 ```
 
-## How noDDDe Differs
+With no second argument you get in-memory defaults. Swap to real persistence with [adapters](/docs/running/persistence-adapters).
 
-|                   | Traditional DDD                   | noDDDe                                       |
-| ----------------- | --------------------------------- | -------------------------------------------- |
-| Aggregates        | Classes extending `AggregateRoot` | Plain objects via `defineAggregate`          |
-| State changes     | `this.apply(event)` mutates state | evolve handlers return new state (immutable) |
-| Command handling  | Decorated methods                 | Typed handler maps                           |
-| Type safety       | Manual generic parameters         | Inferred from `AggregateTypes` bundle        |
-| Event definitions | Enum + interface + union          | `DefineEvents<{ ... }>` single declaration   |
-| Testing           | Requires framework setup          | Call functions directly                      |
-| Infrastructure    | Decorator-based injection         | Function parameter injection                 |
+## What's next
 
-noDDDe draws inspiration from modern TypeScript API design (Zod, tRPC, Drizzle) — declarative, inference-heavy, zero-boilerplate.
-
-## Who Is This For?
-
-noDDDe is for TypeScript developers building **event-driven** or **domain-rich** applications who want:
-
-- Type-safe domain modeling without class hierarchies
-- Testable business logic without mock frameworks
-- Flexible persistence (event sourcing or state storage) with built-in adapters for [Drizzle, Prisma, and TypeORM](/docs/running/persistence-adapters)
-- A functional approach to DDD patterns
-- Production observability out of the box — native [OpenTelemetry tracing](/docs/running/observability) with zero-config span creation and W3C Trace Context propagation
-
-## Next Steps
-
-- [Quick Start](/docs/getting-started/quick-start) — Install noDDDe and build your first aggregate
-- [CLI](/docs/getting-started/cli) — Scaffold a project from the command line
-- [Core Concepts](/docs/core-concepts/messages-and-types) — Understand the foundations
+- [Quick Start](/docs/getting-started/quick-start) — see all of this in one runnable file
+- [Core Concepts](/docs/core-concepts/messages-and-types) — the deeper foundations
+- [Why noddde](/docs/getting-started/why-noddde) — how this compares to NestJS CQRS, hand-rolled, Effect, Wolkenkit

--- a/docs/content/docs/getting-started/meta.json
+++ b/docs/content/docs/getting-started/meta.json
@@ -1,4 +1,10 @@
 {
   "title": "Getting Started",
-  "pages": ["introduction", "quick-start", "cli", "project-structure"]
+  "pages": [
+    "why-noddde",
+    "quick-start",
+    "introduction",
+    "cli",
+    "project-structure"
+  ]
 }

--- a/docs/content/docs/getting-started/quick-start.mdx
+++ b/docs/content/docs/getting-started/quick-start.mdx
@@ -1,11 +1,13 @@
 ---
 title: Quick Start
-description: Install noddde and build your first aggregate — a bank account with commands, events, and domain configuration
+description: A complete noddde program in one file — copy, run, then read the walkthrough
 ---
 
-## Installation
+This page shows a complete noddde program first, then unpacks it. If you only have five minutes, copy the file, run it, and come back later for the walkthrough.
 
-Want to skip manual setup? Use the [CLI](/docs/getting-started/cli) to scaffold a complete project:
+## Install
+
+Use the CLI to scaffold a complete project:
 
 ```bash
 npx @noddde/cli new project my-app
@@ -17,9 +19,9 @@ Or install the packages manually:
 npm install @noddde/core @noddde/engine
 ```
 
-`@noddde/core` provides the type definitions, identity functions, and interfaces for defining your domain. `@noddde/engine` provides the runtime — `defineDomain`, `wireDomain`, in-memory buses, and persistence.
+`@noddde/core` provides types and identity functions (zero deps). `@noddde/engine` provides the runtime — `defineDomain`, `wireDomain`, in-memory buses and persistence.
 
-**Requirements**: Node.js >= 18, TypeScript >= 5.3 with strict mode enabled:
+**Requirements**: Node.js >= 18, TypeScript >= 5.3 with strict mode:
 
 ```json
 {
@@ -32,24 +34,17 @@ npm install @noddde/core @noddde/engine
 }
 ```
 
-For production persistence with a real database, see [Persistence Adapters](/docs/running/persistence-adapters).
+## The complete program
 
-## What We Will Build
+A bank account that supports creating an account and authorizing transactions, with two outcomes: authorized or declined. Copy this into `account.ts`:
 
-A bank account that supports:
+```ts title="account.ts"
+import { defineAggregate, DefineCommands, DefineEvents } from "@noddde/core";
+import { defineDomain, wireDomain } from "@noddde/engine";
+import { randomUUID } from "crypto";
 
-- **Creating** a new account
-- **Authorizing transactions** (with balance validation)
-- Two possible outcomes: authorized or declined
-
-## Step 1: Define Events
-
-Events are immutable facts about what happened. Use `DefineEvents` to declare them:
-
-```ts
-import { DefineEvents } from "@noddde/core";
-
-export type BankAccountEvent = DefineEvents<{
+// 1. Events — past-tense facts
+type BankAccountEvent = DefineEvents<{
   BankAccountCreated: { id: string };
   TransactionAuthorized: {
     id: string;
@@ -64,31 +59,15 @@ export type BankAccountEvent = DefineEvents<{
     merchant: string;
   };
 }>;
-```
 
-Each key becomes the event's `name` discriminant. The value becomes the `payload` type. `DefineEvents` builds a discriminated union from this map.
-
-## Step 2: Define Commands
-
-Commands express intent. Use `DefineCommands`:
-
-```ts
-import { DefineCommands } from "@noddde/core";
-
-export type BankAccountCommand = DefineCommands<{
+// 2. Commands — imperatives
+type BankAccountCommand = DefineCommands<{
   CreateBankAccount: void;
   AuthorizeTransaction: { amount: number; merchant: string };
 }>;
-```
 
-`void` means `CreateBankAccount` has no payload — just a name and a `targetAggregateId`.
-
-## Step 3: Define State
-
-The aggregate state holds everything needed for business decisions:
-
-```ts
-export interface BankAccountState {
+// 3. State — what decide handlers read from
+interface BankAccountState {
   balance: number;
   availableBalance: number;
   transactions: Array<{
@@ -99,41 +78,19 @@ export interface BankAccountState {
     status: "pending" | "processed" | "declined";
   }>;
 }
-```
 
-Note: the aggregate ID is **not** part of state. It lives on the command as `targetAggregateId`. See [Why ID Not in State](/docs/design-decisions/why-id-not-in-state).
-
-## Step 4: Bundle Types
-
-Create an `AggregateTypes` bundle that ties everything together:
-
-```ts
+// 4. The Def bundle — drives all type inference
 type BankAccountDef = {
   state: BankAccountState;
   events: BankAccountEvent;
   commands: BankAccountCommand;
-  infrastructure: {}; // No custom infrastructure for this example
+  infrastructure: {};
 };
-```
 
-This single type replaces five positional generic parameters. Learn more in [Why AggregateTypes Bundle](/docs/design-decisions/why-aggregate-types).
+// 5. The aggregate — initialState + decide + evolve
+const BankAccount = defineAggregate<BankAccountDef>({
+  initialState: { balance: 0, availableBalance: 0, transactions: [] },
 
-## Step 5: Define the Aggregate
-
-Use `defineAggregate` to create the aggregate definition:
-
-```ts
-import { defineAggregate } from "@noddde/core";
-
-export const BankAccount = defineAggregate<BankAccountDef>({
-  // The state before any events
-  initialState: {
-    balance: 0,
-    availableBalance: 0,
-    transactions: [],
-  },
-
-  // Decide handlers — decide what events to produce
   decide: {
     CreateBankAccount: (command) => ({
       name: "BankAccountCreated",
@@ -167,7 +124,6 @@ export const BankAccount = defineAggregate<BankAccountDef>({
     },
   },
 
-  // Evolve handlers — evolve state from events (pure functions)
   evolve: {
     BankAccountCreated: () => ({
       balance: 0,
@@ -193,45 +149,23 @@ export const BankAccount = defineAggregate<BankAccountDef>({
     }),
   },
 });
-```
 
-## Step 6: Define and Wire the Domain
-
-Define the domain structure, then wire it with in-memory infrastructure:
-
-```ts
-import { defineDomain, wireDomain } from "@noddde/engine";
-
-// Define the domain structure (pure, sync)
-const bankingDomain = defineDomain({
-  writeModel: {
-    aggregates: { BankAccount },
-  },
-  readModel: {
-    projections: {},
-  },
+// 6. The domain — wire it with in-memory defaults
+const banking = defineDomain({
+  writeModel: { aggregates: { BankAccount } },
+  readModel: { projections: {} },
 });
 
-// Wire with infrastructure and get a running Domain instance
-const domain = await wireDomain(bankingDomain);
-```
+const domain = await wireDomain(banking);
 
-That is it -- `wireDomain` with no second argument uses in-memory defaults for everything: persistence, buses, and infrastructure. This is the fastest path to a working domain.
-
-## Step 7: Dispatch Commands
-
-```ts
-import { randomUUID } from "crypto";
-
+// 7. Dispatch commands
 const accountId = randomUUID();
 
-// Create the bank account
 await domain.dispatchCommand({
   name: "CreateBankAccount",
   targetAggregateId: accountId,
 });
 
-// Authorize a transaction
 await domain.dispatchCommand({
   name: "AuthorizeTransaction",
   targetAggregateId: accountId,
@@ -239,28 +173,144 @@ await domain.dispatchCommand({
 });
 ```
 
-## What Just Happened?
+Run it:
 
-The full flow for each `dispatchCommand` call:
+```bash
+npx tsx account.ts
+```
 
-1. **Command dispatched** — `{ name: "AuthorizeTransaction", targetAggregateId: "...", payload: { amount: 100, merchant: "Amazon" } }`
-2. **State loaded** — Framework loads the aggregate's event history and replays through evolve handlers
-3. **Decide handler called** — `decide.AuthorizeTransaction(command, currentState, infrastructure)`
-4. **Event returned** — Handler decides: `TransactionAuthorized` or `TransactionDeclined`
-5. **Event persisted** — Saved to the event store
-6. **State updated** — Evolve handler called: `evolve.TransactionAuthorized(event, state)` returns new state
-7. **Event published** — Sent to EventBus for projections to consume
+The first command creates the account; the second is declined (zero available balance) and recorded as a `TransactionDeclined` event. Change `amount: 100` to `amount: 0` to see it authorized instead.
 
-This example uses optimistic concurrency with no retries (the default). For high-contention aggregates, you can configure automatic retries or pessimistic locking — see [Concurrency Strategies](/docs/running/persistence#concurrency-control).
+That is the full shape: one Def per aggregate, `decide` produces events from state, `evolve` folds events back into state.
 
-## Next Steps
+## What just happened
 
-- [Core Concepts](/docs/core-concepts/messages-and-types) — Understand the foundational patterns
-- [Modeling Your Domain](/docs/modeling/defining-aggregates) — Deep dive into aggregate definitions
-- [Projections](/docs/read-model/projections) — Building read models
-- [Running Your Domain](/docs/running/domain-configuration) — Complete wiring reference
+For each `dispatchCommand` call, the framework:
 
-Ready to explore a full working example? The [hotel booking sample](https://github.com/dogganidhal/noddde/tree/main/samples/sample-hotel-booking) exercises >90% of framework features — 3 aggregates, 3 sagas, 3 projections, Fastify HTTP, and Drizzle/SQLite persistence. Clone the repo and run its tests:
+1. **Receives the command** — `{ name, targetAggregateId, payload }`
+2. **Loads the aggregate** — replays its event history through `evolve` to rebuild current state
+3. **Calls `decide`** — `decide.AuthorizeTransaction(command, state, infrastructure)` returns one or more events
+4. **Persists the events** — appended to the event store under `BankAccount:<id>`
+5. **Updates state** — `evolve` is called once per new event to produce the next state
+6. **Publishes the events** — sent to the event bus where projections and sagas consume them
+
+This example uses optimistic concurrency with no retries. For high-contention aggregates, configure retries or pessimistic locking — see [Concurrency Strategies](/docs/running/persistence#concurrency-control).
+
+## Walkthrough
+
+Now that you have seen the whole file, here is each part on its own.
+
+### 1. Events — `DefineEvents`
+
+Events are immutable facts. `DefineEvents` turns a name → payload map into a discriminated union:
+
+```ts
+type BankAccountEvent = DefineEvents<{
+  BankAccountCreated: { id: string };
+  TransactionAuthorized: {
+    id: string;
+    timestamp: Date;
+    amount: number;
+    merchant: string;
+  };
+}>;
+```
+
+Each key becomes the event's `name` discriminant; the value becomes its `payload`.
+
+### 2. Commands — `DefineCommands`
+
+Commands express intent. `void` means no payload — just a name and a `targetAggregateId`:
+
+```ts
+type BankAccountCommand = DefineCommands<{
+  CreateBankAccount: void;
+  AuthorizeTransaction: { amount: number; merchant: string };
+}>;
+```
+
+### 3. State
+
+State holds everything `decide` reads to make decisions. The aggregate ID is **not** part of state — it lives on the command as `targetAggregateId`. See [Why ID Not in State](/docs/design-decisions/why-id-not-in-state).
+
+```ts
+interface BankAccountState {
+  balance: number;
+  availableBalance: number;
+  transactions: Array<{
+    /* ... */
+  }>;
+}
+```
+
+### 4. The `Def` bundle
+
+One type that ties state, events, commands, and any custom infrastructure together. This single type replaces five positional generic parameters elsewhere in the framework. See [Why AggregateTypes Bundle](/docs/design-decisions/why-aggregate-types).
+
+```ts
+type BankAccountDef = {
+  state: BankAccountState;
+  events: BankAccountEvent;
+  commands: BankAccountCommand;
+  infrastructure: {};
+};
+```
+
+### 5. The aggregate — `defineAggregate`
+
+Three things: `initialState`, a `decide` map (command name → handler returning events), and an `evolve` map (event name → pure state transition).
+
+```ts
+const BankAccount = defineAggregate<BankAccountDef>({
+  initialState: {
+    /* ... */
+  },
+  decide: {
+    /* command handlers */
+  },
+  evolve: {
+    /* event reducers */
+  },
+});
+```
+
+`decide` is where business rules live — it can call infrastructure and return one or many events. `evolve` is pure: same event + state always produces the same next state. The two are different because event sourcing replays `evolve` against historical events to rebuild state on load.
+
+### 6. The domain — `defineDomain` + `wireDomain`
+
+`defineDomain` captures the static structure (which aggregates, projections, sagas exist). `wireDomain` connects it to infrastructure. With no second argument, you get in-memory defaults for everything:
+
+```ts
+const banking = defineDomain({
+  writeModel: { aggregates: { BankAccount } },
+  readModel: { projections: {} },
+});
+
+const domain = await wireDomain(banking);
+```
+
+Swap to a real database with [persistence adapters](/docs/running/persistence-adapters).
+
+### 7. Dispatching commands
+
+`dispatchCommand` is fully typed against the domain — `name`, `targetAggregateId`, and `payload` are inferred per command:
+
+```ts
+await domain.dispatchCommand({
+  name: "AuthorizeTransaction",
+  targetAggregateId: accountId,
+  payload: { amount: 100, merchant: "Amazon" },
+});
+```
+
+## Next steps
+
+- [Core Concepts](/docs/core-concepts/messages-and-types) — the foundational patterns
+- [Modeling Your Domain](/docs/modeling/defining-aggregates) — deep dive into aggregate definitions
+- [Projections](/docs/read-model/projections) — building read models
+- [Running Your Domain](/docs/running/domain-configuration) — complete wiring reference
+
+The [hotel booking sample](https://github.com/dogganidhal/noddde/tree/main/samples/sample-hotel-booking) exercises more than 90% of the framework — 3 aggregates, 3 sagas, 3 projections, Fastify HTTP, Drizzle/SQLite persistence:
 
 ```bash
 git clone https://github.com/dogganidhal/noddde.git

--- a/docs/content/docs/getting-started/why-noddde.mdx
+++ b/docs/content/docs/getting-started/why-noddde.mdx
@@ -39,9 +39,33 @@ Differences in approach:
 | Testing             | Bootstrap a Nest module            | Call functions directly                |
 | Runtime requirement | Nest application + DI container    | None. Engine is opt-in.                |
 
-**Pick noddde over NestJS CQRS when** you want the discipline of pure functions, prefer inference to manual generics, and do not already live inside a Nest application.
+You do not have to leave NestJS to use noddde. [`@noddde/nestjs`](/docs/integrations/nestjs) registers the noddde `Domain` as a global Nest provider, so controllers and services inject and dispatch through standard Nest DI. The choice is between NestJS CQRS's class+decorator shape and noddde's functional shape **inside the same Nest app**, not between Nest and noddde.
 
-**Stay on NestJS CQRS when** the rest of your service is Nest. Mixing two frameworks is not worth the win.
+**Pick noddde over NestJS CQRS when** you want the discipline of pure functions, prefer inference to manual generics, and would rather express domain logic as data than as decorated classes.
+
+**Stay on NestJS CQRS when** the team is fluent in its patterns and the cost of introducing a new abstraction outweighs the gains.
+
+### Emmett
+
+The closest active functional prior art. Like noddde, models commands and events as pure data and decisions as pure functions for TypeScript. Backed by Oskar Dudycz, who has been writing about event sourcing for years.
+
+Differences in practice:
+
+|                      | Emmett                                                     | noddde                                                                    |
+| -------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Persistence          | Event-sourcing first; EventStoreDB and PostgreSQL adapters | Event-sourced and state-stored aggregates as first-class peers            |
+| Type model           | Commands, events, state declared as separate generics      | One `Def` bundle drives every handler's inference                         |
+| Composition          | À-la-carte: assemble the pieces you need                   | `defineDomain` + `wireDomain` as a unified orchestrator                   |
+| Sagas / projections  | First-class but wired up externally                        | Defined in the same `Def` ecosystem; saga reactions return commands       |
+| Adapters             | EventStoreDB, PostgreSQL, in-memory                        | Drizzle, Prisma, TypeORM, in-memory; pluggable event bus                  |
+| Tracing              | Application-level                                          | Native OpenTelemetry; W3C Trace Context propagated through event metadata |
+| Transactional outbox | Application-level                                          | Built into the engine: outbox store + relay loop                          |
+| Command idempotency  | Application-level                                          | Built-in `IdempotencyStore` keyed on `commandId`                          |
+| CLI                  | —                                                          | `@noddde/cli` scaffolds aggregates, projections, sagas, and full domains  |
+
+**Pick noddde over Emmett when** you want one domain definition that wires aggregates, projections, sagas, and infrastructure together, and when state-stored aggregates need to coexist with event-sourced ones in the same domain.
+
+**Pick Emmett when** you prefer a more proven event-sourcing-first library backed by an established author and EventStoreDB community.
 
 ### Effect / a general-purpose effect library
 
@@ -58,7 +82,6 @@ The most direct prior art for "functional CQRS+ES in TypeScript." Wolkenkit pion
 ## When noddde is the wrong choice
 
 - **You need a CRUD app.** DDD/CQRS/ES is overkill for forms-over-data. Use Drizzle and a router.
-- **You are deep in NestJS.** Use NestJS CQRS. Mixing frameworks is more pain than win.
 - **You need a polyglot event store with cross-language consumers.** noddde's event types are TypeScript-shaped. Cross-language consumers can read events, but the schema discipline lives outside the framework.
 - **You want Java-style DDD with rich domain objects.** noddde is functional. Aggregates are state + handler maps, not objects with methods. If `account.deposit(100)` reads more naturally to your team than `decide.Deposit(command, state)`, that is a real preference and noddde will fight you.
 

--- a/docs/content/docs/getting-started/why-noddde.mdx
+++ b/docs/content/docs/getting-started/why-noddde.mdx
@@ -1,0 +1,79 @@
+---
+title: Why noddde
+description: A 90-second read for senior engineers evaluating a TypeScript DDD framework
+---
+
+This page is for engineers evaluating noddde against the alternatives. It is short, opinionated, and does not try to win every argument.
+
+## The 60-second pitch
+
+- **One `Def` type drives everything.** Commands, events, decide handlers, evolve handlers, projection reducers, query handlers, saga reactions — all inferred from a single `AggregateTypes` bundle. No duplicate type declarations to keep in sync.
+- **Pure functions, infrastructure as parameters.** `decide(command, state, infra) => events`, `evolve(event, state) => state`. Handlers are unit-testable as plain functions; tests call them directly without bootstrapping a runtime.
+- **The runtime is a separate package.** `@noddde/core` is types and identity functions, zero deps. `@noddde/engine` plugs in buses, persistence, and OpenTelemetry. You can adopt the patterns without buying the runtime.
+
+## Compared to the obvious alternatives
+
+### Hand-rolled TypeScript DDD
+
+What most teams actually do. You write your own `Command`/`Event` discriminated unions, your own `Aggregate` base class or factory, your own command/event registries, your own persistence interface, your own outbox.
+
+The aggregate file looks roughly the same length as a noddde aggregate. The problem is everything around it: the registries you maintain by hand, the type plumbing between the command bus and the aggregate, the state-stored vs. event-sourced abstraction, the snapshot store, the saga state machine, the projection rebuild, the OTel spans. That is the code noddde replaces — not the aggregate itself.
+
+**Pick noddde over hand-rolling when** you are building more than one aggregate and you do not want to be in the framework-maintenance business.
+
+**Stay hand-rolled when** you have one aggregate, exotic persistence requirements, or you genuinely want full control of the wiring.
+
+### NestJS CQRS
+
+The dominant TypeScript DDD framework. Class-based, decorator-based, DI container, `reflect-metadata`. `@CommandHandler(MyCommand)`, `@EventsHandler(MyEvent)`, classes extending `AggregateRoot`, manual `apply()` calls inside command handlers.
+
+Differences in approach:
+
+|                     | NestJS CQRS                        | noddde                                 |
+| ------------------- | ---------------------------------- | -------------------------------------- |
+| Aggregate           | `class extends AggregateRoot`      | object via `defineAggregate`           |
+| Command handler     | Decorated method on a class        | Entry in a typed `decide` map          |
+| Event application   | `this.apply(event)` mutates `this` | `evolve(event, state) => state` (pure) |
+| State changes       | In-place mutation                  | Immutable new state                    |
+| Type safety         | Manual generics on every class     | Inferred from one `Def` type           |
+| Testing             | Bootstrap a Nest module            | Call functions directly                |
+| Runtime requirement | Nest application + DI container    | None. Engine is opt-in.                |
+
+**Pick noddde over NestJS CQRS when** you want the discipline of pure functions, prefer inference to manual generics, and do not already live inside a Nest application.
+
+**Stay on NestJS CQRS when** the rest of your service is Nest. Mixing two frameworks is not worth the win.
+
+### Effect / a general-purpose effect library
+
+Effect is excellent for typed errors and effect composition. It is not a DDD framework. You can build DDD on top of Effect, but you write the aggregate patterns, the command bus, the projection runtime, the saga state machine, etc. yourself.
+
+**Pick noddde over Effect when** the value you want is the DDD shape (decide/evolve, projections, sagas), not effect composition.
+
+**Use both when** you want noddde's domain shape and Effect's error/effect ergonomics inside your handlers. They compose — `decide` and `evolve` are just functions.
+
+### Wolkenkit
+
+The most direct prior art for "functional CQRS+ES in TypeScript." Wolkenkit pioneered a lot of these ideas. It is largely dormant in 2026 and its runtime is heavier than noddde's. If you liked Wolkenkit's shape, noddde is a smaller, actively-maintained version of the same idea.
+
+## When noddde is the wrong choice
+
+- **You need a CRUD app.** DDD/CQRS/ES is overkill for forms-over-data. Use Drizzle and a router.
+- **You are deep in NestJS.** Use NestJS CQRS. Mixing frameworks is more pain than win.
+- **You need a polyglot event store with cross-language consumers.** noddde's event types are TypeScript-shaped. Cross-language consumers can read events, but the schema discipline lives outside the framework.
+- **You want Java-style DDD with rich domain objects.** noddde is functional. Aggregates are state + handler maps, not objects with methods. If `account.deposit(100)` reads more naturally to your team than `decide.Deposit(command, state)`, that is a real preference and noddde will fight you.
+
+## Why these design decisions
+
+The shape of noddde is the result of specific tradeoffs, each documented:
+
+- [Why the Decider pattern](/docs/design-decisions/why-decider) — pure functions over `this.apply()` mutation
+- [Why a single `AggregateTypes` bundle](/docs/design-decisions/why-aggregate-types) — one `Def` instead of five generic parameters
+- [Why infrastructure is a function parameter](/docs/design-decisions/why-injectable-infrastructure) — handlers receive what they need; tests pass the rest
+- [Why commands return events](/docs/design-decisions/why-commands-return-events) — pushing persistence and publishing out of business logic
+- [Why two persistence strategies](/docs/design-decisions/why-two-persistence-strategies) — event-sourced and state-stored, both first-class
+
+## Next steps
+
+- [Quick Start](/docs/getting-started/quick-start) — see a complete aggregate end-to-end
+- [Core Concepts](/docs/core-concepts/messages-and-types) — the foundational patterns
+- [Hotel booking sample](https://github.com/dogganidhal/noddde/tree/main/samples/sample-hotel-booking) — a real-shaped domain that exercises >90% of the framework

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -3,48 +3,29 @@ title: noDDDe
 description: A TypeScript framework for Domain-Driven Design, CQRS, and Event Sourcing
 ---
 
-**noDDDe** is a TypeScript framework for building business applications using Domain-Driven Design (DDD), Command Query Responsibility Segregation (CQRS), and Event Sourcing patterns.
+**noDDDe** is a TypeScript framework for Domain-Driven Design, CQRS, and Event Sourcing. Aggregates, projections, and sagas are expressed as typed bundles paired with pure functions for state transitions.
 
-It provides a declarative, type-safe way to express domain aggregates using the functional **Decider pattern** — no base classes, no decorators, just typed objects and pure functions.
+The shape: every domain concept is an object with handler maps. State transitions are pure functions of an event and a previous state. Infrastructure is passed to handlers as a parameter. Types flow from a single `Def` bundle, end to end.
 
-## Key Principles
+## Start here
 
-- **Pure functions over class hierarchies** — Aggregates are objects with handler maps, not classes with methods
-- **Type safety via mapped types** — `DefineCommands` and `DefineEvents` build discriminated unions from simple payload maps
-- **The Decider pattern** — `initialState` + `commands` (decide) + `apply` (evolve)
-- **Infrastructure injection** — Dependencies are function parameters, not imports; testable by default
+The fastest path to understanding noddde is to read in this order:
 
-## Choose Your Path
+1. [Why noddde](/docs/getting-started/why-noddde) — 90 seconds. Compares to NestJS CQRS, hand-rolled, Effect, Wolkenkit. Tells you when noddde is the wrong choice.
+2. [Quick Start](/docs/getting-started/quick-start) — a complete bank-account aggregate, working end-to-end. Copy, run, see it work.
+3. [Core Concepts](/docs/core-concepts/messages-and-types) — the four ideas the rest of the docs assume.
 
-### New to DDD / CQRS / Event Sourcing?
+That is the whole on-ramp. Everything else in the sidebar is reference.
 
-Start with the foundational concepts:
+## Already familiar with the patterns?
 
-- [Messaging](/docs/core-concepts/messages-and-types) — How typed messages drive the architecture
-- [The Decider Pattern](/docs/core-concepts/decider-pattern) — The functional foundation
-- [CQRS](/docs/core-concepts/cqrs-and-event-sourcing) — Separating reads from writes
-- [Event Sourcing](/docs/core-concepts/cqrs-and-event-sourcing) — Storing events, not state
+If you have shipped CQRS+ES in TypeScript before, jump straight to:
 
-### Want to build something?
+- [Defining Aggregates](/docs/modeling/defining-aggregates) — the `defineAggregate` function and the `AggregateTypes` bundle
+- [Domain Configuration](/docs/running/domain-configuration) — `defineDomain` + `wireDomain`
+- [Persistence Adapters](/docs/running/persistence-adapters) — Drizzle, Prisma, TypeORM
+- [Design Decisions](/docs/design-decisions/why-decider) — the tradeoffs, one page each
 
-Jump into the hands-on guides:
+## Looking for a real-shaped example?
 
-- [Installation](/docs/getting-started/installation) — Get `@noddde/core` installed
-- [Quick Start](/docs/getting-started/quick-start) — Build a bank account aggregate step by step
-
-### Know the patterns?
-
-Go directly to the reference:
-
-- [Defining Aggregates](/docs/modeling/defining-aggregates) — The `defineAggregate` function
-- [Defining Commands](/docs/modeling/defining-aggregates) — The `DefineCommands` utility type
-- [Defining Events](/docs/modeling/defining-aggregates) — The `DefineEvents` utility type
-- [Domain Configuration](/docs/running/domain-configuration) — Wiring everything together
-
-### Understand the design
-
-Learn why noddde is built the way it is:
-
-- [Why the Decider Pattern?](/docs/design-decisions/why-decider) — Pure functions vs. OOP
-- [Why DefineCommands/Events?](/docs/design-decisions/why-define-commands-events) — Mapped types vs. enums
-- [Why Injectable Infrastructure?](/docs/design-decisions/why-injectable-infrastructure) — Testability by design
+The [hotel booking sample](https://github.com/dogganidhal/noddde/tree/main/samples/sample-hotel-booking) exercises more than 90% of the framework: 3 aggregates, 3 sagas, 3 projections, Fastify HTTP, Drizzle/SQLite persistence. It is the closest reference to a production codebase.

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -1,7 +1,7 @@
 {
   "title": "Documentation",
   "pages": [
-    "---Getting Started---",
+    "---Start Here---",
     "...getting-started",
     "---Core Concepts---",
     "...core-concepts",
@@ -13,12 +13,12 @@
     "...process-managers",
     "---Running Your Domain---",
     "...running",
-    "---Integrations---",
-    "...integrations",
     "---Testing---",
     "...testing",
     "---Patterns & Examples---",
     "...patterns",
+    "---Integrations---",
+    "...integrations",
     "---Design Decisions---",
     "...design-decisions"
   ]

--- a/docs/content/docs/modeling/defining-aggregates.mdx
+++ b/docs/content/docs/modeling/defining-aggregates.mdx
@@ -7,7 +7,7 @@ description: How to define a complete aggregate in noddde — events, commands, 
 
 An aggregate is a **consistency boundary** in your domain. It groups together the state and business rules that must always be consistent with each other. When you dispatch a command, a single aggregate instance validates the rules, makes a decision, and produces events that record what happened.
 
-noddde models aggregates using the [Decider pattern](/docs/core-concepts/decider-pattern): commands go in, events come out, and a pure function evolves state. There are no base classes and no decorators -- an aggregate is a plain typed object with three properties: `initialState`, `decide`, and `evolve`.
+noddde models aggregates using the [Decider pattern](/docs/core-concepts/decider-pattern): commands go in, events come out, and a pure function evolves state. An aggregate is a typed object with three properties: `initialState`, `decide`, and `evolve`.
 
 An aggregate definition is a **blueprint**, not a singleton. You define the behavior once, and the framework creates as many instances as needed at runtime, each identified by a unique `targetAggregateId`.
 

--- a/docs/content/docs/testing/overview.mdx
+++ b/docs/content/docs/testing/overview.mdx
@@ -3,7 +3,7 @@ title: Testing Overview
 description: How noddde's functional design and @noddde/testing toolkit make testing natural and straightforward.
 ---
 
-noddde's functional architecture is built for testability. Decide handlers are functions. evolve handlers are pure functions. Projection reducers are pure functions. Saga handlers return data. There is no framework to boot, no container to configure, and no decorators to mock.
+noddde's functional architecture is built for testability. Decide handlers are functions. Evolve handlers are pure functions. Projection reducers are pure functions. Saga handlers return data. Tests call the handlers directly with sample inputs and assert on the events or state they return.
 
 The `@noddde/testing` package provides type-safe test harnesses that eliminate boilerplate and express tests in the natural **Given-When-Then** pattern of the Decider.
 

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -15,14 +15,16 @@ const jetbrainsMono = JetBrains_Mono({
   variable: "--font-mono",
 });
 
+const SITE_DESCRIPTION =
+  "A TypeScript framework for Domain-Driven Design, CQRS, and Event Sourcing. Aggregates, projections, and sagas modeled as typed bundles and pure functions, with end-to-end inference.";
+
 export const metadata: Metadata = {
   metadataBase: new URL("https://noddde.dev"),
   title: {
     default: "noddde — Functional DDD Framework for TypeScript",
     template: "%s | noddde",
   },
-  description:
-    "Build business applications with aggregates, projections, and sagas using the Decider pattern. No base classes. No decorators. No DI container.",
+  description: SITE_DESCRIPTION,
   openGraph: {
     type: "website",
     siteName: "noddde",
@@ -30,8 +32,7 @@ export const metadata: Metadata = {
       default: "noddde — Functional DDD Framework for TypeScript",
       template: "%s | noddde",
     },
-    description:
-      "Build business applications with aggregates, projections, and sagas using the Decider pattern. No base classes. No decorators. No DI container.",
+    description: SITE_DESCRIPTION,
     url: "https://noddde.dev",
     images: [
       {
@@ -45,8 +46,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "noddde — Functional DDD Framework for TypeScript",
-    description:
-      "Build business applications with aggregates, projections, and sagas using the Decider pattern. No base classes. No decorators. No DI container.",
+    description: SITE_DESCRIPTION,
     images: ["https://noddde.dev/og-image.png"],
   },
   verification: {
@@ -69,8 +69,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
               "@context": "https://schema.org",
               "@type": "SoftwareSourceCode",
               name: "noddde",
-              description:
-                "Build business applications with aggregates, projections, and sagas using the Decider pattern. No base classes. No decorators. No DI container.",
+              description: SITE_DESCRIPTION,
               url: "https://noddde.dev",
               codeRepository: "https://github.com/dogganidhal/noddde",
               programmingLanguage: "TypeScript",

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -2,6 +2,7 @@ import { HomeLayout } from "fumadocs-ui/layouts/home";
 import Image from "next/image";
 import type { Metadata } from "next";
 import { Hero } from "@/components/landing/hero";
+import { Comparison } from "@/components/landing/comparison";
 import { Features } from "@/components/landing/features";
 import { Footer } from "@/components/landing/footer";
 
@@ -47,6 +48,7 @@ export default function HomePage() {
       githubUrl="https://github.com/dogganidhal/noddde"
     >
       <Hero />
+      <Comparison />
       <Features />
       <Footer />
     </HomeLayout>

--- a/docs/src/components/landing/comparison.tsx
+++ b/docs/src/components/landing/comparison.tsx
@@ -1,0 +1,282 @@
+import { highlight } from "fumadocs-core/highlight";
+import { CodeBlock, Pre } from "fumadocs-ui/components/codeblock";
+import type { ReactNode } from "react";
+
+const CLASSICAL = `type DomainEvent = { type: "Deposited"; amount: number };
+
+export class Account {
+  private balance = 0;
+  private uncommitted: DomainEvent[] = [];
+
+  static rehydrate(history: DomainEvent[]) {
+    const account = new Account();
+    history.forEach((e) => account.apply(e));
+    return account;
+  }
+
+  deposit(amount: number) {
+    if (amount <= 0) {
+      throw new Error("Amount must be positive");
+    }
+    this.apply({ type: "Deposited", amount });
+  }
+
+  private apply(event: DomainEvent) {
+    if (event.type === "Deposited") {
+      this.balance += event.amount;
+    }
+    this.uncommitted.push(event);
+  }
+
+  pullEvents(): DomainEvent[] {
+    const out = this.uncommitted;
+    this.uncommitted = [];
+    return out;
+  }
+}
+
+export class DepositMoney {
+  constructor(
+    private readonly accounts: AccountRepository,
+    private readonly events: EventBus,
+  ) {}
+
+  async execute(cmd: { accountId: string; amount: number }) {
+    const account = await this.accounts.findById(cmd.accountId);
+    account.deposit(cmd.amount);
+    await this.accounts.save(account);
+    for (const event of account.pullEvents()) {
+      await this.events.publish(event);
+    }
+  }
+}`;
+
+const NODDDE = `type AccountDef = {
+  state: { balance: number };
+  commands: DefineCommands<{ Deposit: { amount: number } }>;
+  events: DefineEvents<{ Deposited: { amount: number } }>;
+  infrastructure: {};
+};
+
+const Account = defineAggregate<AccountDef>({
+  initialState: { balance: 0 },
+
+  decide: {
+    Deposit: (cmd) => {
+      if (cmd.payload.amount <= 0) {
+        throw new Error("Amount must be positive");
+      }
+      return { name: "Deposited", payload: cmd.payload };
+    },
+  },
+
+  evolve: {
+    Deposited: ({ amount }, state) => ({
+      balance: state.balance + amount,
+    }),
+  },
+});
+
+// Anywhere you need to deposit money:
+await domain.dispatchCommand({
+  name: "Deposit",
+  targetAggregateId: accountId,
+  payload: { amount: 100 },
+});`;
+
+type LifecycleStep = {
+  name: string;
+  without: ReactNode;
+  with: ReactNode;
+  byFramework?: boolean;
+};
+
+const STEPS: LifecycleStep[] = [
+  {
+    name: "Hydrate",
+    without: (
+      <>
+        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">
+          accounts.findById(id)
+        </code>{" "}
+        — your repository loads events and replays them through{" "}
+        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">apply</code>.
+      </>
+    ),
+    with: (
+      <>
+        Framework loads events from the configured persistence and folds them
+        through{" "}
+        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">evolve</code>{" "}
+        before calling{" "}
+        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">decide</code>.
+      </>
+    ),
+    byFramework: true,
+  },
+  {
+    name: "Decide",
+    without: (
+      <>
+        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">
+          account.deposit(amount)
+        </code>{" "}
+        — invariants live inside the instance method.
+      </>
+    ),
+    with: (
+      <>
+        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">
+          decide.Deposit(cmd, state, infra) =&gt; events
+        </code>{" "}
+        — pure function returning the events to record.
+      </>
+    ),
+  },
+  {
+    name: "Update state",
+    without: (
+      <>
+        Mutation hidden inside{" "}
+        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">apply</code>,
+        which also accumulates events on the instance.
+      </>
+    ),
+    with: (
+      <>
+        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">
+          evolve.Deposited(payload, state) =&gt; state
+        </code>{" "}
+        — pure function called once per recorded event.
+      </>
+    ),
+  },
+  {
+    name: "Publish",
+    without: (
+      <>
+        Drain{" "}
+        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">
+          pullEvents()
+        </code>{" "}
+        from the use-case and hand each event to your event bus.
+      </>
+    ),
+    with: (
+      <>
+        Framework appends to the event store and dispatches to the event bus in
+        the same transaction.
+      </>
+    ),
+    byFramework: true,
+  },
+];
+
+export async function Comparison() {
+  const [classical, noddde] = await Promise.all([
+    highlight(CLASSICAL, {
+      lang: "typescript",
+      themes: { light: "github-light", dark: "github-dark" },
+    }),
+    highlight(NODDDE, {
+      lang: "typescript",
+      themes: { light: "github-light", dark: "github-dark" },
+    }),
+  ]);
+
+  return (
+    <section className="border-t border-fd-border py-16 lg:py-24">
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-fd-foreground">
+            The same domain, mapped step by step
+          </h2>
+          <p className="mx-auto mt-4 max-w-2xl text-fd-muted-foreground">
+            Both sides handle the same four-step lifecycle — hydrate the
+            aggregate, decide what events to produce, update state, publish. The
+            difference is who writes which step.
+          </p>
+        </div>
+
+        <div className="mt-12 grid gap-6 lg:grid-cols-2">
+          <div className="flex min-w-0 flex-col">
+            <div className="mb-3 flex items-center gap-2">
+              <span className="inline-flex items-center rounded-full border border-fd-border bg-fd-card px-3 py-1 text-xs font-medium text-fd-muted-foreground">
+                Without noddde
+              </span>
+              <span className="text-xs text-fd-muted-foreground">
+                aggregate, repository-loaded use-case, manual publishing
+              </span>
+            </div>
+            <CodeBlock title="account.ts" keepBackground>
+              <Pre>{classical}</Pre>
+            </CodeBlock>
+          </div>
+
+          <div className="flex min-w-0 flex-col">
+            <div className="mb-3 flex items-center gap-2">
+              <span className="inline-flex items-center rounded-full border border-fd-primary/40 bg-fd-primary/10 px-3 py-1 text-xs font-medium text-fd-primary">
+                With noddde
+              </span>
+              <span className="text-xs text-fd-muted-foreground">
+                decide and evolve; the framework owns the rest
+              </span>
+            </div>
+            <CodeBlock title="account.ts" keepBackground>
+              <Pre>{noddde}</Pre>
+            </CodeBlock>
+          </div>
+        </div>
+
+        <div className="mt-12 overflow-hidden rounded-xl border border-fd-border">
+          <div className="grid grid-cols-[140px_1fr_1fr] gap-x-4 border-b border-fd-border bg-fd-muted/40 px-6 py-3 text-xs font-medium uppercase tracking-wide text-fd-muted-foreground">
+            <div>Step</div>
+            <div>Without noddde</div>
+            <div>With noddde</div>
+          </div>
+          {STEPS.map((step, idx) => (
+            <div
+              key={step.name}
+              className={`grid grid-cols-[140px_1fr_1fr] gap-x-4 px-6 py-4 text-sm ${
+                idx < STEPS.length - 1 ? "border-b border-fd-border" : ""
+              }`}
+            >
+              <div className="font-semibold text-fd-foreground">
+                {step.name}
+              </div>
+              <div className="leading-relaxed text-fd-muted-foreground">
+                {step.without}
+              </div>
+              <div
+                className={`leading-relaxed ${
+                  step.byFramework
+                    ? "text-fd-foreground"
+                    : "text-fd-muted-foreground"
+                }`}
+              >
+                {step.byFramework && (
+                  <span className="mr-2 inline-flex items-center rounded-full border border-fd-primary/40 bg-fd-primary/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-fd-primary">
+                    framework
+                  </span>
+                )}
+                {step.with}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <p className="mx-auto mt-8 max-w-3xl text-center text-sm leading-relaxed text-fd-muted-foreground">
+          You write{" "}
+          <code className="rounded bg-fd-muted px-1.5 py-0.5 text-xs">
+            decide
+          </code>{" "}
+          and{" "}
+          <code className="rounded bg-fd-muted px-1.5 py-0.5 text-xs">
+            evolve
+          </code>
+          . Hydration and publishing become configuration.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/docs/src/components/landing/comparison.tsx
+++ b/docs/src/components/landing/comparison.tsx
@@ -1,188 +1,109 @@
 import { highlight } from "fumadocs-core/highlight";
 import { CodeBlock, Pre } from "fumadocs-ui/components/codeblock";
+import { ArrowRight, Sparkles } from "lucide-react";
 import type { ReactNode } from "react";
 
-const CLASSICAL = `type DomainEvent = { type: "Deposited"; amount: number };
-
-export class Account {
-  private balance = 0;
-  private uncommitted: DomainEvent[] = [];
-
-  static rehydrate(history: DomainEvent[]) {
-    const account = new Account();
-    history.forEach((e) => account.apply(e));
-    return account;
-  }
-
-  deposit(amount: number) {
-    if (amount <= 0) {
-      throw new Error("Amount must be positive");
-    }
-    this.apply({ type: "Deposited", amount });
-  }
-
-  private apply(event: DomainEvent) {
-    if (event.type === "Deposited") {
-      this.balance += event.amount;
-    }
-    this.uncommitted.push(event);
-  }
-
-  pullEvents(): DomainEvent[] {
-    const out = this.uncommitted;
-    this.uncommitted = [];
-    return out;
-  }
-}
-
-export class DepositMoney {
-  constructor(
-    private readonly accounts: AccountRepository,
-    private readonly events: EventBus,
-  ) {}
-
-  async execute(cmd: { accountId: string; amount: number }) {
-    const account = await this.accounts.findById(cmd.accountId);
-    account.deposit(cmd.amount);
-    await this.accounts.save(account);
-    for (const event of account.pullEvents()) {
-      await this.events.publish(event);
-    }
-  }
-}`;
-
-const NODDDE = `type AccountDef = {
-  state: { balance: number };
-  commands: DefineCommands<{ Deposit: { amount: number } }>;
-  events: DefineEvents<{ Deposited: { amount: number } }>;
-  infrastructure: {};
+type StepDef = {
+  step: number;
+  name: string;
+  description: string;
+  without: { code: string; note: ReactNode };
+  with: { code?: string; framework?: boolean; note: ReactNode };
 };
 
-const Account = defineAggregate<AccountDef>({
-  initialState: { balance: 0 },
-
-  decide: {
-    Deposit: (cmd) => {
-      if (cmd.payload.amount <= 0) {
-        throw new Error("Amount must be positive");
-      }
-      return { name: "Deposited", payload: cmd.payload };
+const STEPS: StepDef[] = [
+  {
+    step: 1,
+    name: "Hydrate",
+    description: "Load the aggregate's state before deciding anything.",
+    without: {
+      code: `const account = await this.accounts.findById(cmd.accountId);`,
+      note: "Your repository loads events and replays them through apply().",
+    },
+    with: {
+      framework: true,
+      note: "Framework loads events from the configured persistence and folds them through evolve before calling decide.",
     },
   },
-
-  evolve: {
-    Deposited: ({ amount }, state) => ({
-      balance: state.balance + amount,
-    }),
-  },
-});
-
-// Anywhere you need to deposit money:
-await domain.dispatchCommand({
-  name: "Deposit",
-  targetAggregateId: accountId,
-  payload: { amount: 100 },
-});`;
-
-type LifecycleStep = {
-  name: string;
-  without: ReactNode;
-  with: ReactNode;
-  byFramework?: boolean;
-};
-
-const STEPS: LifecycleStep[] = [
   {
-    name: "Hydrate",
-    without: (
-      <>
-        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">
-          accounts.findById(id)
-        </code>{" "}
-        — your repository loads events and replays them through{" "}
-        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">apply</code>.
-      </>
-    ),
-    with: (
-      <>
-        Framework loads events from the configured persistence and folds them
-        through{" "}
-        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">evolve</code>{" "}
-        before calling{" "}
-        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">decide</code>.
-      </>
-    ),
-    byFramework: true,
-  },
-  {
+    step: 2,
     name: "Decide",
-    without: (
-      <>
-        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">
-          account.deposit(amount)
-        </code>{" "}
-        — invariants live inside the instance method.
-      </>
-    ),
-    with: (
-      <>
-        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">
-          decide.Deposit(cmd, state, infra) =&gt; events
-        </code>{" "}
-        — pure function returning the events to record.
-      </>
-    ),
+    description: "Run business rules and produce events.",
+    without: {
+      code: `deposit(amount: number) {
+  if (amount <= 0) {
+    throw new Error("Amount must be positive");
+  }
+  this.apply({ type: "Deposited", amount });
+}`,
+      note: "Invariant and event recording live inside an instance method that mutates this.",
+    },
+    with: {
+      code: `decide: {
+  Deposit: (cmd) => {
+    if (cmd.payload.amount <= 0) {
+      throw new Error("Amount must be positive");
+    }
+    return { name: "Deposited", payload: cmd.payload };
+  },
+}`,
+      note: "Pure function: same command + state produces the same events every time.",
+    },
   },
   {
+    step: 3,
     name: "Update state",
-    without: (
-      <>
-        Mutation hidden inside{" "}
-        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">apply</code>,
-        which also accumulates events on the instance.
-      </>
-    ),
-    with: (
-      <>
-        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">
-          evolve.Deposited(payload, state) =&gt; state
-        </code>{" "}
-        — pure function called once per recorded event.
-      </>
-    ),
+    description: "Fold each event into the next state.",
+    without: {
+      code: `private apply(event: DomainEvent) {
+  if (event.type === "Deposited") {
+    this.balance += event.amount;
+  }
+  this.uncommitted.push(event);
+}`,
+      note: "Mutation hidden inside apply(), which also accumulates events on the instance.",
+    },
+    with: {
+      code: `evolve: {
+  Deposited: ({ amount }, state) => ({
+    balance: state.balance + amount,
+  }),
+}`,
+      note: "Pure function called once per recorded event; no instance state to track.",
+    },
   },
   {
+    step: 4,
     name: "Publish",
-    without: (
-      <>
-        Drain{" "}
-        <code className="rounded bg-fd-muted px-1 py-0.5 text-xs">
-          pullEvents()
-        </code>{" "}
-        from the use-case and hand each event to your event bus.
-      </>
-    ),
-    with: (
-      <>
-        Framework appends to the event store and dispatches to the event bus in
-        the same transaction.
-      </>
-    ),
-    byFramework: true,
+    description: "Hand events to the event bus for projections and sagas.",
+    without: {
+      code: `for (const event of account.pullEvents()) {
+  await this.events.publish(event);
+}`,
+      note: "Drain pullEvents() and call the event bus from the use-case.",
+    },
+    with: {
+      framework: true,
+      note: "Framework appends to the event store and dispatches to the event bus in the same transaction.",
+    },
   },
 ];
 
+const HIGHLIGHT_OPTS = {
+  lang: "typescript",
+  themes: { light: "github-light", dark: "github-dark" },
+} as const;
+
 export async function Comparison() {
-  const [classical, noddde] = await Promise.all([
-    highlight(CLASSICAL, {
-      lang: "typescript",
-      themes: { light: "github-light", dark: "github-dark" },
-    }),
-    highlight(NODDDE, {
-      lang: "typescript",
-      themes: { light: "github-light", dark: "github-dark" },
-    }),
-  ]);
+  const rendered = await Promise.all(
+    STEPS.map(async (s) => ({
+      ...s,
+      withoutNode: await highlight(s.without.code, HIGHLIGHT_OPTS),
+      withNode: s.with.code
+        ? await highlight(s.with.code, HIGHLIGHT_OPTS)
+        : null,
+    })),
+  );
 
   return (
     <section className="border-t border-fd-border py-16 lg:py-24">
@@ -192,80 +113,63 @@ export async function Comparison() {
             The same domain, mapped step by step
           </h2>
           <p className="mx-auto mt-4 max-w-2xl text-fd-muted-foreground">
-            Both sides handle the same four-step lifecycle — hydrate the
+            Both sides handle the same four-step lifecycle &mdash; hydrate the
             aggregate, decide what events to produce, update state, publish. The
             difference is who writes which step.
           </p>
         </div>
 
-        <div className="mt-12 grid gap-6 lg:grid-cols-2">
-          <div className="flex min-w-0 flex-col">
-            <div className="mb-3 flex items-center gap-2">
-              <span className="inline-flex items-center rounded-full border border-fd-border bg-fd-card px-3 py-1 text-xs font-medium text-fd-muted-foreground">
-                Without noddde
-              </span>
-              <span className="text-xs text-fd-muted-foreground">
-                aggregate, repository-loaded use-case, manual publishing
-              </span>
-            </div>
-            <CodeBlock title="account.ts" keepBackground>
-              <Pre>{classical}</Pre>
-            </CodeBlock>
-          </div>
-
-          <div className="flex min-w-0 flex-col">
-            <div className="mb-3 flex items-center gap-2">
-              <span className="inline-flex items-center rounded-full border border-fd-primary/40 bg-fd-primary/10 px-3 py-1 text-xs font-medium text-fd-primary">
-                With noddde
-              </span>
-              <span className="text-xs text-fd-muted-foreground">
-                decide and evolve; the framework owns the rest
-              </span>
-            </div>
-            <CodeBlock title="account.ts" keepBackground>
-              <Pre>{noddde}</Pre>
-            </CodeBlock>
-          </div>
-        </div>
-
-        <div className="mt-12 overflow-hidden rounded-xl border border-fd-border">
-          <div className="grid grid-cols-[140px_1fr_1fr] gap-x-4 border-b border-fd-border bg-fd-muted/40 px-6 py-3 text-xs font-medium uppercase tracking-wide text-fd-muted-foreground">
-            <div>Step</div>
-            <div>Without noddde</div>
-            <div>With noddde</div>
-          </div>
-          {STEPS.map((step, idx) => (
-            <div
-              key={step.name}
-              className={`grid grid-cols-[140px_1fr_1fr] gap-x-4 px-6 py-4 text-sm ${
-                idx < STEPS.length - 1 ? "border-b border-fd-border" : ""
-              }`}
+        <div className="mt-14 space-y-12">
+          {rendered.map((s) => (
+            <article
+              key={s.step}
+              className="grid gap-6 lg:grid-cols-[240px_1fr] lg:items-start"
             >
-              <div className="font-semibold text-fd-foreground">
-                {step.name}
+              <header>
+                <div className="flex items-center gap-3">
+                  <StepBadge step={s.step} />
+                  <h3 className="text-lg font-semibold text-fd-foreground">
+                    {s.name}
+                  </h3>
+                </div>
+                <p className="mt-2 text-sm leading-relaxed text-fd-muted-foreground">
+                  {s.description}
+                </p>
+              </header>
+
+              <div className="grid gap-4 lg:grid-cols-[1fr_auto_1fr] lg:items-start">
+                <Cell
+                  variant="muted"
+                  label="Without noddde"
+                  note={s.without.note}
+                >
+                  <CodeBlock keepBackground>
+                    <Pre>{s.withoutNode}</Pre>
+                  </CodeBlock>
+                </Cell>
+
+                <div className="hidden items-center justify-center pt-12 lg:flex">
+                  <ArrowRight
+                    className="size-5 text-fd-muted-foreground/70"
+                    aria-hidden
+                  />
+                </div>
+
+                <Cell variant="primary" label="With noddde" note={s.with.note}>
+                  {s.withNode ? (
+                    <CodeBlock keepBackground>
+                      <Pre>{s.withNode}</Pre>
+                    </CodeBlock>
+                  ) : (
+                    <FrameworkPanel />
+                  )}
+                </Cell>
               </div>
-              <div className="leading-relaxed text-fd-muted-foreground">
-                {step.without}
-              </div>
-              <div
-                className={`leading-relaxed ${
-                  step.byFramework
-                    ? "text-fd-foreground"
-                    : "text-fd-muted-foreground"
-                }`}
-              >
-                {step.byFramework && (
-                  <span className="mr-2 inline-flex items-center rounded-full border border-fd-primary/40 bg-fd-primary/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-fd-primary">
-                    framework
-                  </span>
-                )}
-                {step.with}
-              </div>
-            </div>
+            </article>
           ))}
         </div>
 
-        <p className="mx-auto mt-8 max-w-3xl text-center text-sm leading-relaxed text-fd-muted-foreground">
+        <p className="mx-auto mt-14 max-w-3xl text-center text-sm leading-relaxed text-fd-muted-foreground">
           You write{" "}
           <code className="rounded bg-fd-muted px-1.5 py-0.5 text-xs">
             decide
@@ -278,5 +182,54 @@ export async function Comparison() {
         </p>
       </div>
     </section>
+  );
+}
+
+function StepBadge({ step }: { step: number }) {
+  return (
+    <span className="inline-flex h-8 min-w-8 items-center justify-center rounded-full border border-fd-primary/40 bg-fd-primary/10 px-2 text-sm font-semibold tabular-nums text-fd-primary">
+      {step}
+    </span>
+  );
+}
+
+function Cell({
+  variant,
+  label,
+  note,
+  children,
+}: {
+  variant: "muted" | "primary";
+  label: string;
+  note: ReactNode;
+  children: ReactNode;
+}) {
+  const labelClasses =
+    variant === "primary"
+      ? "border-fd-primary/40 bg-fd-primary/10 text-fd-primary"
+      : "border-fd-border bg-fd-card text-fd-muted-foreground";
+  return (
+    <div className="min-w-0">
+      <span
+        className={`mb-2 inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium ${labelClasses}`}
+      >
+        {label}
+      </span>
+      {children}
+      <p className="mt-3 text-xs leading-relaxed text-fd-muted-foreground">
+        {note}
+      </p>
+    </div>
+  );
+}
+
+function FrameworkPanel() {
+  return (
+    <div className="flex min-h-[64px] items-center justify-center rounded-lg border border-dashed border-fd-primary/40 bg-fd-primary/5 px-4 py-6">
+      <span className="inline-flex items-center gap-2 text-sm font-medium text-fd-primary">
+        <Sparkles className="size-4" aria-hidden />
+        Handled by the framework
+      </span>
+    </div>
   );
 }

--- a/docs/src/components/landing/comparison.tsx
+++ b/docs/src/components/landing/comparison.tsx
@@ -27,8 +27,8 @@ const STEPS: StepDef[] = [
   },
   {
     step: 2,
-    name: "Decide",
-    description: "Run business rules and produce events.",
+    name: "Enforce invariants",
+    description: "Check business rules and produce the resulting events.",
     without: {
       code: `deposit(amount: number) {
   if (amount <= 0) {
@@ -114,8 +114,8 @@ export async function Comparison() {
           </h2>
           <p className="mx-auto mt-4 max-w-2xl text-fd-muted-foreground">
             Both sides handle the same four-step lifecycle &mdash; hydrate the
-            aggregate, decide what events to produce, update state, publish. The
-            difference is who writes which step.
+            aggregate, enforce invariants, update state, publish. The difference
+            is who writes which step.
           </p>
         </div>
 

--- a/docs/src/components/landing/features.tsx
+++ b/docs/src/components/landing/features.tsx
@@ -43,7 +43,7 @@ const features = [
     icon: <ShieldCheck className="size-5" />,
     title: "Type-Safe",
     description:
-      "Full TypeScript inference from end to end. Zero decorators. Zero runtime magic.",
+      "Inference flows from a single Def bundle through commands, events, handlers, and the dispatch API.",
   },
 ];
 
@@ -55,8 +55,8 @@ export function Features() {
           Everything you need to model your domain
         </h2>
         <p className="mx-auto mt-4 max-w-2xl text-fd-muted-foreground">
-          Aggregates, projections, and sagas — using plain objects and pure
-          functions. No base classes. No decorators. No DI container.
+          Aggregates, projections, and sagas — typed objects with handler maps
+          and pure functions for every state transition.
         </p>
         <div className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {features.map((feature) => (

--- a/docs/src/components/landing/hero.tsx
+++ b/docs/src/components/landing/hero.tsx
@@ -16,31 +16,33 @@ export function Hero() {
           </span>
 
           <h1 className="mt-6 text-4xl font-bold tracking-tight text-fd-foreground lg:text-5xl">
-            Build business logic with{" "}
-            <span className="text-fd-primary">pure functions</span>
+            Domain logic as{" "}
+            <span className="text-fd-primary">types and pure functions</span>
           </h1>
 
           <p className="mt-4 text-lg leading-relaxed text-fd-muted-foreground">
-            Define aggregates, projections, and sagas using the Decider
-            pattern&nbsp;&mdash; typed objects and plain functions, no magic.
+            Aggregates, projections, and sagas as typed bundles paired with pure
+            functions for state transitions. Inference flows end to end from a
+            single <code className="font-mono text-base">Def</code> per
+            aggregate.
           </p>
 
           <div className="mt-8">
             <InstallCommand />
           </div>
 
-          <div className="mt-6 flex gap-4">
+          <div className="mt-6 flex flex-wrap gap-3">
             <Link
-              href="/docs/getting-started/introduction"
+              href="/docs/getting-started/quick-start"
               className="rounded-lg bg-fd-primary px-6 py-3 text-sm font-medium text-fd-primary-foreground transition-colors hover:bg-fd-primary/90"
             >
-              Get Started
+              Quick Start
             </Link>
             <Link
-              href="/docs"
+              href="/docs/getting-started/why-noddde"
               className="rounded-lg border border-fd-border px-6 py-3 text-sm font-medium text-fd-foreground transition-colors hover:bg-fd-card"
             >
-              Documentation
+              Why noddde?
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Reshape the docs on-ramp so senior engineers can evaluate noddde in ~90 seconds and mid-level engineers can copy-run a complete `account.ts` from the Quick Start.
- Replace the docs index's 4-path "choose your adventure" hub with a single linear path: Why noddde → Quick Start → Core Concepts.
- New landing **Comparison** section: per-step lifecycle layout (Hydrate / Enforce invariants / Update state / Publish), pairing realistic "without noddde" snippets (aggregate class + repository + use-case service + manual publishing) with the noddde definition. Framework-handled steps render a "Handled by the framework" panel rather than code.
- New **`why-noddde.mdx`** page: 90-second pitch and tradeoff tables for NestJS CQRS, Emmett, Effect, Wolkenkit, plus an honest "when noddde is the wrong choice" section. The Emmett comparison covers persistence model, type model, composition, sagas/projections, adapters, tracing, transactional outbox, command idempotency, and CLI.
- The **NestJS** section reflects the `@noddde/nestjs` integration — noddde runs inside an existing Nest app via the dynamic module, so the choice is between two shapes inside the same Nest app, not between two frameworks.
- **Quick Start inverted**: complete runnable file at the top, step-by-step walkthrough below.
- `introduction.mdx` reduced to a one-screen "Concepts at a Glance" cheat sheet (was a 158-line glossary duplicating Why noddde / Core Concepts).
- Sidebar relabeled "Start Here" instead of "Getting Started".
- Tone sweep across the landing and reference docs: stripped repetitive "no decorators / no DI container / no base classes" lists in favor of describing what noddde is. Design-decision pages where the contrast is the substantive argument were left untouched.

## Test plan

- [x] Prettier passes on all changed files.
- [x] `tsc --noEmit` is clean for changes (the 3 pre-existing fumadocs API-drift errors in `app/docs/[[...slug]]/page.tsx` and `lib/source.ts` are unrelated).
- [x] Dev server hot-reloads and serves the landing, why-noddde, quick-start, introduction pages with 200.
- [x] Quick Start `account.ts` snippet matches the engine's `wireDomain` and `dispatchCommand` API; `wireDomain` accepts a default empty wiring.
- [ ] Manual review of the landing comparison at `lg`+ and below the breakpoint (responsive collapse).
- [ ] Manual review of the why-noddde page (Emmett table, NestJS framing, "wrong choice" list).
- [ ] Manual review of the inverted Quick Start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)