### PR TITLE
docs: rewrite Why noddde pitch to cover the full surface area

### DIFF
--- a/docs/content/docs/getting-started/introduction.mdx
+++ b/docs/content/docs/getting-started/introduction.mdx
@@ -5,7 +5,7 @@ description: A one-screen summary of the building blocks — aggregates, project
 
 This page is a quick reference. If you have not run the [Quick Start](/docs/getting-started/quick-start) yet, do that first — the concepts make a lot more sense once you have seen them work.
 
-## The four building blocks
+## The five building blocks
 
 ### Aggregate
 

--- a/docs/content/docs/getting-started/why-noddde.mdx
+++ b/docs/content/docs/getting-started/why-noddde.mdx
@@ -1,15 +1,18 @@
 ---
 title: Why noddde
-description: A 90-second read for senior engineers evaluating a TypeScript DDD framework
+description: A 90-second read for engineers evaluating a TypeScript DDD framework
 ---
 
 This page is for engineers evaluating noddde against the alternatives. It is short, opinionated, and does not try to win every argument.
 
-## The 60-second pitch
+## The pitch
 
-- **One `Def` type drives everything.** Commands, events, decide handlers, evolve handlers, projection reducers, query handlers, saga reactions — all inferred from a single `AggregateTypes` bundle. No duplicate type declarations to keep in sync.
-- **Pure functions, infrastructure as parameters.** `decide(command, state, infra) => events`, `evolve(event, state) => state`. Handlers are unit-testable as plain functions; tests call them directly without bootstrapping a runtime.
-- **The runtime is a separate package.** `@noddde/core` is types and identity functions, zero deps. `@noddde/engine` plugs in buses, persistence, and OpenTelemetry. You can adopt the patterns without buying the runtime.
+- **Type safety.** A single typed bundle drives every handler signature — commands, events, evolve, projections, queries, saga reactions — and the discriminated unions reach `dispatchCommand` and `dispatchQuery` without a single manual generic.
+- **Pure `decide` and `evolve`.** `decide(command, state, infra) => events`, `evolve(event, state) => state`. Infrastructure is a parameter; tests call handlers directly, no runtime to bootstrap.
+- **CQRS and process management as first-class citizens.** Aggregates, projections (views + queries), and sagas (event-driven process managers) are peers — same definition pattern, same wiring. Event-sourced and state-stored aggregates coexist in one domain.
+- **Production runtime, included.** Kafka / NATS / RabbitMQ buses with broker resilience. Drizzle / Prisma / TypeORM persistence. Transactional outbox with at-least-once delivery, command idempotency, snapshot stores, optimistic or pessimistic concurrency, and typed upcaster chains for event versioning.
+- **Audit and tracing, native.** Every event ships with `eventId`, `correlationId`, `causationId`, `userId`, `aggregateId`, and `sequenceNumber`. OpenTelemetry is dynamically detected — install `@opentelemetry/api` and W3C Trace Context propagates through event metadata; without it, every span call is a zero-cost no-op.
+- **Adopt as much as you want.** `@noddde/core` is types and identity functions, zero dependencies. `@noddde/engine` is the runtime. `@noddde/nestjs` exposes the `Domain` as a global Nest provider. `@noddde/cli` scaffolds aggregates, projections, sagas — and emits Mermaid / DOT / JSON diagrams of your domain's command / event / query graph.
 
 ## Compared to the obvious alternatives
 


### PR DESCRIPTION
## Summary

- Rewrites the **Pitch** section of `why-noddde.mdx` so it actually reflects the framework's surface area instead of stopping at type inference and the core/engine split.
- The pitch is now six tight bullets:
  1. **Type safety** — single typed bundle drives every handler signature; inference reaches `dispatchCommand` / `dispatchQuery`.
  2. **Pure `decide` and `evolve`** — handler signatures with infrastructure as a parameter.
  3. **CQRS and process management as first-class citizens** — aggregates, projections (views + queries), and sagas (event-driven process managers) as peers; event-sourced and state-stored aggregates coexist in the same domain.
  4. **Production runtime, included** — Kafka / NATS / RabbitMQ buses with broker resilience, Drizzle / Prisma / TypeORM persistence, transactional outbox with at-least-once delivery, command idempotency, snapshot stores with strategies, optimistic or pessimistic concurrency, typed upcaster chains.
  5. **Audit and tracing, native** — every event carries `eventId`, `correlationId`, `causationId`, `userId`, `aggregateId`, `sequenceNumber`; OpenTelemetry is detected at runtime with W3C Trace Context propagating through event metadata; zero-cost no-op when absent.
  6. **Adopt as much as you want** — `@noddde/core` (types only), `@noddde/engine` (runtime), `@noddde/nestjs` (global Nest provider), `@noddde/cli` (scaffolding + Mermaid / DOT / JSON diagram emission).
- Drop "for senior engineers" from the page subtitle so the page reads as relevant to anyone evaluating noddde.

## Test plan

- [x] Prettier passes.
- [x] Dev server hot-reloads cleanly.
- [ ] Manual review of `/docs/getting-started/why-noddde` in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)