### PR TITLE
refactor(core): move defineDomain from engine to core

### DIFF
--- a/docs/content/docs/core-concepts/cqrs-and-event-sourcing.mdx
+++ b/docs/content/docs/core-concepts/cqrs-and-event-sourcing.mdx
@@ -39,7 +39,8 @@ The write model is where domain logic lives. Its primary building blocks are **a
 In the domain definition, the write model is declared under the `writeModel` key:
 
 ```typescript
-import { defineDomain, wireDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 const bankingDomain = defineDomain({
   writeModel: {

--- a/docs/content/docs/design-decisions/why-two-persistence-strategies.mdx
+++ b/docs/content/docs/design-decisions/why-two-persistence-strategies.mdx
@@ -82,7 +82,8 @@ Benefits:
 ## Example
 
 ```ts
-import { defineDomain, wireDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 const myDomain = defineDomain({
   /* writeModel and readModel */

--- a/docs/content/docs/getting-started/quick-start.mdx
+++ b/docs/content/docs/getting-started/quick-start.mdx
@@ -19,7 +19,7 @@ Or install the packages manually:
 npm install @noddde/core @noddde/engine
 ```
 
-`@noddde/core` provides types and identity functions (zero deps). `@noddde/engine` provides the runtime — `defineDomain`, `wireDomain`, in-memory buses and persistence.
+`@noddde/core` provides types and identity functions — `defineAggregate`, `defineDomain`, and friends (zero deps). `@noddde/engine` provides the runtime — `wireDomain`, in-memory buses and persistence. For backward compatibility, `@noddde/engine` also re-exports `defineDomain`, so older code importing `defineDomain` from `@noddde/engine` keeps working.
 
 **Requirements**: Node.js >= 18, TypeScript >= 5.3 with strict mode:
 
@@ -39,8 +39,13 @@ npm install @noddde/core @noddde/engine
 A bank account that supports creating an account and authorizing transactions, with two outcomes: authorized or declined. Copy this into `account.ts`:
 
 ```ts title="account.ts"
-import { defineAggregate, DefineCommands, DefineEvents } from "@noddde/core";
-import { defineDomain, wireDomain } from "@noddde/engine";
+import {
+  defineAggregate,
+  defineDomain,
+  DefineCommands,
+  DefineEvents,
+} from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 import { randomUUID } from "crypto";
 
 // 1. Events — past-tense facts

--- a/docs/content/docs/integrations/nestjs.mdx
+++ b/docs/content/docs/integrations/nestjs.mdx
@@ -74,7 +74,7 @@ The module is registered as `@Global()` — you can inject the `Domain` from any
 Use `InferDomain` to derive a fully typed `Domain` from your definition. This gives you type-safe `dispatchCommand()` and `dispatchQuery()` — command names, payloads, and query results are all narrowed at compile time:
 
 ```ts title="src/domain/index.ts"
-import { defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
 import type { InferDomain } from "@noddde/nestjs";
 import { Order, Inventory } from "./aggregates";
 import { OrderSummary } from "./projections";

--- a/docs/content/docs/modeling/routing-and-dispatch.mdx
+++ b/docs/content/docs/modeling/routing-and-dispatch.mdx
@@ -10,7 +10,8 @@ When you call `domain.dispatchCommand()`, the framework executes a deterministic
 The entry point for all command processing is `domain.dispatchCommand()`. You pass a command object with a `name`, a `targetAggregateId`, and optionally a `payload`:
 
 ```typescript
-import { defineDomain, wireDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 const bankingDomain = defineDomain({
   // ... definition

--- a/docs/content/docs/patterns/auction-domain.mdx
+++ b/docs/content/docs/patterns/auction-domain.mdx
@@ -267,7 +267,8 @@ The aggregate records that the bid happened (as an event) but the state remains 
 ## Running the Example
 
 ```ts
-import { defineDomain, wireDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 const auctionDomain = defineDomain({
   writeModel: { aggregates: { Auction } },

--- a/docs/content/docs/patterns/clock-pattern.mdx
+++ b/docs/content/docs/patterns/clock-pattern.mdx
@@ -140,7 +140,8 @@ describe("PlaceBid", () => {
 In production, provide `SystemClock` via the `infrastructure` field in `wireDomain`:
 
 ```ts
-import { defineDomain, wireDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 const auctionDomain = defineDomain({
   writeModel: { aggregates: { Auction } },

--- a/docs/content/docs/patterns/flash-sale.mdx
+++ b/docs/content/docs/patterns/flash-sale.mdx
@@ -130,8 +130,8 @@ export const FlashSaleItem = defineAggregate<FlashSaleItemTypes>({
 ## Domain Configuration
 
 ```ts
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   InMemoryCommandBus,
   InMemoryQueryBus,

--- a/docs/content/docs/patterns/hotel-booking.mdx
+++ b/docs/content/docs/patterns/hotel-booking.mdx
@@ -610,8 +610,8 @@ The domain configuration uses `defineDomain` to capture the pure domain structur
 ```ts
 // src/main.ts
 import { DrizzleAdapter } from "@noddde/drizzle";
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   InMemoryCommandBus,
   InMemoryQueryBus,

--- a/docs/content/docs/process-managers/sagas.mdx
+++ b/docs/content/docs/process-managers/sagas.mdx
@@ -423,8 +423,8 @@ The full saga runtime lifecycle proceeds as follows:
 Sagas are registered in the `processModel` section of `defineDomain` -- a dedicated top-level key separate from `writeModel` and `readModel`:
 
 ```ts
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   InMemorySagaPersistence,
 } from "@noddde/engine";

--- a/docs/content/docs/process-managers/standalone-commands.mdx
+++ b/docs/content/docs/process-managers/standalone-commands.mdx
@@ -57,7 +57,8 @@ Key differences from aggregate decide handlers:
 Standalone command handlers are registered in the `writeModel.standaloneCommandHandlers` map of your domain configuration:
 
 ```typescript
-import { defineDomain, wireDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 const bankingDomain = defineDomain({
   writeModel: {

--- a/docs/content/docs/process-managers/standalone-events.mdx
+++ b/docs/content/docs/process-managers/standalone-events.mdx
@@ -40,7 +40,7 @@ Key characteristics:
 Standalone event handlers are registered in the `processModel.standaloneEventHandlers` map of your domain configuration:
 
 ```typescript
-import { defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
 
 const definition = defineDomain({
   writeModel: { aggregates: { Order } },

--- a/docs/content/docs/read-model/projections.mdx
+++ b/docs/content/docs/read-model/projections.mdx
@@ -402,7 +402,8 @@ This is useful for building views that span multiple domain concepts, such as an
 Projections are registered in the `readModel.projections` map of the domain configuration:
 
 ```ts
-import { defineDomain, wireDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 const bankingDomain = defineDomain({
   writeModel: {

--- a/docs/content/docs/read-model/view-persistence.mdx
+++ b/docs/content/docs/read-model/view-persistence.mdx
@@ -195,7 +195,8 @@ const AccountProjection = defineProjection<AccountProjectionDef>({
 
 ```ts title="domain.ts"
 // In domain wiring -- a ViewStoreFactory is provided here
-import { defineDomain, wireDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 import { PrismaAccountViewStoreFactory } from "./infrastructure/prisma-account-view-store-factory";
 
 const definition = defineDomain({

--- a/docs/content/docs/running/domain-configuration.mdx
+++ b/docs/content/docs/running/domain-configuration.mdx
@@ -20,10 +20,10 @@ This separation allows domain definitions to be shared, tested, and analyzed ind
 
 ## Defining the Domain
 
-`defineDomain` is a sync identity function -- it returns the input unchanged with full type inference. Consistent with `defineAggregate`, `defineProjection`, `defineSaga`.
+`defineDomain` is a sync identity function -- it returns the input unchanged with full type inference. Consistent with `defineAggregate`, `defineProjection`, `defineSaga`. It lives in `@noddde/core` (and is re-exported from `@noddde/engine` for backward compatibility).
 
 ```ts
-import { defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
 
 const bankingDomain = defineDomain({
   writeModel: {
@@ -504,8 +504,8 @@ When a saga dispatches commands in response to an event, the engine automaticall
 Here is a full domain configuration for a banking application using `defineDomain` + `wireDomain`:
 
 ```ts
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,

--- a/docs/content/docs/running/persistence-adapters.mdx
+++ b/docs/content/docs/running/persistence-adapters.mdx
@@ -106,7 +106,8 @@ import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { DrizzleAdapter } from "@noddde/drizzle";
 import { everyNEvents } from "@noddde/core";
-import { defineDomain, wireDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 const db = drizzle(new Database("app.db"));
 const adapter = new DrizzleAdapter(db);
@@ -318,7 +319,8 @@ Then run `prisma generate` and your preferred migration command.
 import { PrismaClient } from "@prisma/client";
 import { PrismaAdapter } from "@noddde/prisma";
 import { everyNEvents } from "@noddde/core";
-import { defineDomain, wireDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 const prisma = new PrismaClient();
 const adapter = new PrismaAdapter(prisma);
@@ -461,7 +463,8 @@ For production, use TypeORM migrations instead of `synchronize: true`.
 ```ts
 import { TypeORMAdapter } from "@noddde/typeorm";
 import { everyNEvents } from "@noddde/core";
-import { defineDomain, wireDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 const adapter = new TypeORMAdapter(dataSource);
 
@@ -1054,7 +1057,8 @@ class MongoAdapter implements PersistenceAdapter {
 #### Step 4: Wire It Up
 
 ```ts
-import { wireDomain, defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 import { MongoClient } from "mongodb";
 
 const client = new MongoClient(process.env.MONGODB_URI!);

--- a/docs/content/docs/running/persistence.mdx
+++ b/docs/content/docs/running/persistence.mdx
@@ -107,12 +107,11 @@ With `wireDomain`, snapshots are configured as part of the aggregate wiring -- e
 
 ```ts
 import {
-  defineDomain,
   wireDomain,
   InMemoryEventSourcedAggregatePersistence,
   InMemorySnapshotStore,
 } from "@noddde/engine";
-import { everyNEvents } from "@noddde/core";
+import { defineDomain, everyNEvents } from "@noddde/core";
 
 const domain = await wireDomain(myDomain, {
   // Global: snapshots for all event-sourced aggregates

--- a/docs/content/docs/testing/overview.mdx
+++ b/docs/content/docs/testing/overview.mdx
@@ -75,7 +75,7 @@ expect(spy.publishedEvents).toContainEqual({
 
 ### Level 3: Integration Tests
 
-Use `defineDomain` and `wireDomain` from `@noddde/engine` directly when you need full control over persistence, custom buses, or production-like wiring.
+Use `defineDomain` from `@noddde/core` and `wireDomain` from `@noddde/engine` directly when you need full control over persistence, custom buses, or production-like wiring.
 
 ## The Given-When-Then Pattern
 

--- a/docs/content/docs/testing/testing-domains.mdx
+++ b/docs/content/docs/testing/testing-domains.mdx
@@ -213,9 +213,9 @@ expect(summary?.status).toBe("confirmed");
 | ------------------------------------ | --------------------------------------------------- |
 | Testing handler logic in isolation   | `testAggregate`, `testProjection`, `testSaga`       |
 | Testing multiple components together | `testDomain`                                        |
-| Custom persistence strategies        | `defineDomain` + `wireDomain` from `@noddde/engine` |
-| Custom bus implementations           | `defineDomain` + `wireDomain` from `@noddde/engine` |
-| Production-like environment tests    | `defineDomain` + `wireDomain` from `@noddde/engine` |
+| Custom persistence strategies        | `defineDomain` from `@noddde/core` + `wireDomain` from `@noddde/engine` |
+| Custom bus implementations           | `defineDomain` from `@noddde/core` + `wireDomain` from `@noddde/engine` |
+| Production-like environment tests    | `defineDomain` from `@noddde/core` + `wireDomain` from `@noddde/engine` |
 
 ## Next Steps
 

--- a/docs/src/content/docs/api/README.md
+++ b/docs/src/content/docs/api/README.md
@@ -46,6 +46,7 @@ title: "@noddde/core"
 
 - [AggregateTypes](/api/type-aliases/aggregatetypes/)
 - [DecideHandler](/api/type-aliases/decidehandler/)
+- [DomainDefinition](/api/type-aliases/domaindefinition/)
 - [EvolveHandler](/api/type-aliases/evolvehandler/)
 - [DefineCommands](/api/type-aliases/definecommands/)
 - [DefineEvents](/api/type-aliases/defineevents/)
@@ -84,6 +85,7 @@ title: "@noddde/core"
 ## Functions
 
 - [defineAggregate](/api/functions/defineaggregate/)
+- [defineDomain](/api/functions/definedomain/)
 - [defineProjection](/api/functions/defineprojection/)
 - [defineSaga](/api/functions/definesaga/)
 - [everyNEvents](/api/functions/everynevents/)

--- a/docs/src/content/docs/api/functions/defineDomain.md
+++ b/docs/src/content/docs/api/functions/defineDomain.md
@@ -1,0 +1,40 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "defineDomain"
+---
+
+> **defineDomain**\<`T`\>(`definition`): `T`
+
+Defined in: [ddd/domain-definition.ts:131](https://github.com/dogganidhal/noddde/blob/main/packages/core/src/ddd/domain-definition.ts#L131)
+
+Pure, sync identity function that creates a domain definition with full type inference. Captures the structural shape of a domain — aggregates, projections, sagas, and handler registrations — without any runtime or infrastructure concerns. Pass the result to `wireDomain` (from `@noddde/engine`) to obtain a running `Domain`.
+
+Consistent with [`defineAggregate`](/api/functions/defineaggregate/), [`defineProjection`](/api/functions/defineprojection/), and [`defineSaga`](/api/functions/definesaga/).
+
+For backward compatibility, `@noddde/engine` re-exports `defineDomain` from `@noddde/core`, so existing `import { defineDomain } from "@noddde/engine"` keeps working.
+
+## Type Parameters
+
+### T
+
+`T` _extends_ [`DomainDefinition`](/api/type-aliases/domaindefinition/)\<`any`, `any`, `any`, `any`, `any`, `any`\>
+
+## Parameters
+
+### definition
+
+`T`
+
+## Returns
+
+`T`
+
+The same definition object, unchanged (reference equality with the input).
+
+## Legacy Overload
+
+> **defineDomain**\<`TInfrastructure`, `TStandaloneCommand`, `TStandaloneQuery`, `TAggregates`, `TStandaloneEvent`, `TProjections`\>(`definition`): [`DomainDefinition`](/api/type-aliases/domaindefinition/)\<...\>
+
+A legacy overload accepting explicit type parameters is available but `@deprecated`. Prefer calling `defineDomain({...})` without explicit generics — typed dispatch downstream is only available with the inferred form.

--- a/docs/src/content/docs/api/type-aliases/DomainDefinition.md
+++ b/docs/src/content/docs/api/type-aliases/DomainDefinition.md
@@ -61,10 +61,10 @@ The projection map. Inferred narrow type preserves typed query dispatch downstre
 
 The write side: aggregates and standalone command handlers.
 
-| Property                     | Type                                                       | Description                                           |
-| :--------------------------- | :--------------------------------------------------------- | :---------------------------------------------------- |
+| Property                     | Type                                                       | Description                                             |
+| :--------------------------- | :--------------------------------------------------------- | :------------------------------------------------------ |
 | `aggregates`                 | `TAggregates`                                              | A map of aggregate definitions keyed by aggregate name. |
-| `standaloneCommandHandlers?` | _Optional_ map of `StandaloneCommandHandler` keyed by name | Standalone command handlers (file-private map type).  |
+| `standaloneCommandHandlers?` | _Optional_ map of `StandaloneCommandHandler` keyed by name | Standalone command handlers (file-private map type).    |
 
 ---
 
@@ -74,10 +74,10 @@ The write side: aggregates and standalone command handlers.
 
 The read side: projections and standalone query handlers.
 
-| Property                   | Type                                              | Description                                            |
-| :------------------------- | :------------------------------------------------ | :----------------------------------------------------- |
-| `projections`              | `TProjections`                                    | A map of projection definitions keyed by name.         |
-| `standaloneQueryHandlers?` | _Optional_ map of `QueryHandler` keyed by name    | Standalone query handlers (file-private map type).     |
+| Property                   | Type                                           | Description                                        |
+| :------------------------- | :--------------------------------------------- | :------------------------------------------------- |
+| `projections`              | `TProjections`                                 | A map of projection definitions keyed by name.     |
+| `standaloneQueryHandlers?` | _Optional_ map of `QueryHandler` keyed by name | Standalone query handlers (file-private map type). |
 
 ---
 
@@ -87,7 +87,7 @@ The read side: projections and standalone query handlers.
 
 Process model: sagas and standalone event handlers. Optional — omit if the domain has no cross-aggregate workflows or event-driven side effects.
 
-| Property                    | Type                                              | Description                                            |
-| :-------------------------- | :------------------------------------------------ | :----------------------------------------------------- |
-| `sagas?`                    | _Optional_ map of `Saga` keyed by name            | A map of saga definitions. Omit if no sagas.           |
-| `standaloneEventHandlers?`  | _Optional_ map of `EventHandler` keyed by name    | Standalone event handlers (file-private map type).     |
+| Property                   | Type                                           | Description                                        |
+| :------------------------- | :--------------------------------------------- | :------------------------------------------------- |
+| `sagas?`                   | _Optional_ map of `Saga` keyed by name         | A map of saga definitions. Omit if no sagas.       |
+| `standaloneEventHandlers?` | _Optional_ map of `EventHandler` keyed by name | Standalone event handlers (file-private map type). |

--- a/docs/src/content/docs/api/type-aliases/DomainDefinition.md
+++ b/docs/src/content/docs/api/type-aliases/DomainDefinition.md
@@ -1,0 +1,93 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "DomainDefinition"
+---
+
+> **DomainDefinition**\<`TInfrastructure`, `TStandaloneCommand`, `TStandaloneQuery`, `TAggregates`, `TStandaloneEvent`, `TProjections`\> = `object`
+
+Defined in: [ddd/domain-definition.ts:63](https://github.com/dogganidhal/noddde/blob/main/packages/core/src/ddd/domain-definition.ts#L63)
+
+Pure structural definition of a domain. Contains aggregates, projections, sagas, and handler registrations — no runtime or infrastructure concerns.
+
+Created via [`defineDomain`](/api/functions/definedomain/). Pass to `wireDomain` (from `@noddde/engine`) along with infrastructure wiring to create a running `Domain` instance.
+
+For backward compatibility, `@noddde/engine` re-exports `DomainDefinition` from `@noddde/core`, so existing `import type { DomainDefinition } from "@noddde/engine"` keeps working.
+
+## Type Parameters
+
+### TInfrastructure
+
+`TInfrastructure` _extends_ [`Infrastructure`](/api/type-aliases/infrastructure/) = [`Infrastructure`](/api/type-aliases/infrastructure/)
+
+The custom infrastructure type referenced by handler signatures. The definition itself does not hold an infrastructure value — it is wired separately by `wireDomain`.
+
+### TStandaloneCommand
+
+`TStandaloneCommand` _extends_ [`Command`](/api/interfaces/command/) = [`Command`](/api/interfaces/command/)
+
+The discriminated union of standalone command types.
+
+### TStandaloneQuery
+
+`TStandaloneQuery` _extends_ [`Query`](/api/interfaces/query/)\<`any`\> = [`Query`](/api/interfaces/query/)\<`any`\>
+
+The discriminated union of standalone query types.
+
+### TAggregates
+
+`TAggregates` _extends_ `Record<string | symbol, Aggregate<any>>` = `Record<string | symbol, Aggregate<any>>`
+
+The aggregate map. Inferred narrow type preserves typed dispatch downstream.
+
+### TStandaloneEvent
+
+`TStandaloneEvent` _extends_ [`Event`](/api/interfaces/event/) = [`Event`](/api/interfaces/event/)
+
+The discriminated union of standalone event types.
+
+### TProjections
+
+`TProjections` _extends_ `Record<string | symbol, Projection<any>>` = `Record<string | symbol, Projection<any>>`
+
+The projection map. Inferred narrow type preserves typed query dispatch downstream.
+
+## Properties
+
+### writeModel
+
+> **writeModel**: `object`
+
+The write side: aggregates and standalone command handlers.
+
+| Property                     | Type                                                       | Description                                           |
+| :--------------------------- | :--------------------------------------------------------- | :---------------------------------------------------- |
+| `aggregates`                 | `TAggregates`                                              | A map of aggregate definitions keyed by aggregate name. |
+| `standaloneCommandHandlers?` | _Optional_ map of `StandaloneCommandHandler` keyed by name | Standalone command handlers (file-private map type).  |
+
+---
+
+### readModel
+
+> **readModel**: `object`
+
+The read side: projections and standalone query handlers.
+
+| Property                   | Type                                              | Description                                            |
+| :------------------------- | :------------------------------------------------ | :----------------------------------------------------- |
+| `projections`              | `TProjections`                                    | A map of projection definitions keyed by name.         |
+| `standaloneQueryHandlers?` | _Optional_ map of `QueryHandler` keyed by name    | Standalone query handlers (file-private map type).     |
+
+---
+
+### processModel?
+
+> _Optional_ **processModel**: `object`
+
+Process model: sagas and standalone event handlers. Optional — omit if the domain has no cross-aggregate workflows or event-driven side effects.
+
+| Property                    | Type                                              | Description                                            |
+| :-------------------------- | :------------------------------------------------ | :----------------------------------------------------- |
+| `sagas?`                    | _Optional_ map of `Saga` keyed by name            | A map of saga definitions. Omit if no sagas.           |
+| `standaloneEventHandlers?`  | _Optional_ map of `EventHandler` keyed by name    | Standalone event handlers (file-private map type).     |

--- a/packages/adapters/drizzle/src/index.ts
+++ b/packages/adapters/drizzle/src/index.ts
@@ -97,7 +97,8 @@ export interface DrizzlePersistenceInfrastructure {
  * import Database from "better-sqlite3";
  * import { createDrizzlePersistence } from "@noddde/drizzle";
  * import { events, aggregateStates, sagaStates } from "@noddde/drizzle/sqlite";
- * import { defineDomain, wireDomain } from "@noddde/engine";
+ * import { defineDomain } from "@noddde/core";
+ * import { wireDomain } from "@noddde/engine";
  *
  * const db = drizzle(new Database("app.db"));
  * const infra = createDrizzlePersistence(db, { events, aggregateStates, sagaStates });

--- a/packages/adapters/prisma/src/index.ts
+++ b/packages/adapters/prisma/src/index.ts
@@ -59,7 +59,8 @@ export interface PrismaPersistenceInfrastructure {
  * ```ts
  * import { PrismaClient } from "@prisma/client";
  * import { createPrismaPersistence } from "@noddde/prisma";
- * import { defineDomain, wireDomain } from "@noddde/engine";
+ * import { defineDomain } from "@noddde/core";
+ * import { wireDomain } from "@noddde/engine";
  *
  * const prisma = new PrismaClient();
  * const infra = createPrismaPersistence(prisma);

--- a/packages/adapters/typeorm/src/index.ts
+++ b/packages/adapters/typeorm/src/index.ts
@@ -70,7 +70,8 @@ export interface TypeORMPersistenceInfrastructure {
  *   NodddeSagaStateEntity,
  *   NodddeSnapshotEntity,
  * } from "@noddde/typeorm";
- * import { defineDomain, wireDomain } from "@noddde/engine";
+ * import { defineDomain } from "@noddde/core";
+ * import { wireDomain } from "@noddde/engine";
  *
  * const dataSource = new DataSource({
  *   type: "sqlite",

--- a/packages/cli/src/templates/domain/domain-wiring.ts
+++ b/packages/cli/src/templates/domain/domain-wiring.ts
@@ -3,7 +3,7 @@ import type { EventBusAdapter } from "../../utils/event-bus.js";
 
 /** Template for domain/domain.ts — defineDomain() call. */
 export function domainDefinitionTemplate(ctx: TemplateContext): string {
-  return `import { defineDomain } from "@noddde/engine";
+  return `import { defineDomain } from "@noddde/core";
 import { ${ctx.name} } from "./write-model/aggregates/${ctx.kebabName}/index.js";
 import { ${ctx.name}Projection } from "./read-model/projections/${ctx.kebabName}/index.js";
 import type { ${ctx.name}Infrastructure } from "../infrastructure/index.js";

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -19,6 +19,7 @@ npm install @noddde/core
 - **Aggregate definitions** (`defineAggregate`) with the Decider pattern: `initialState`, `decide`, `evolve`
 - **Saga definitions** (`defineSaga`) for orchestrating cross-aggregate workflows as pure functions
 - **Projection definitions** (`defineProjection`) for building read models from event streams
+- **Domain definitions** (`defineDomain`) — a pure, sync identity function that captures the structural shape of a domain (aggregates, projections, sagas, handlers) without any runtime or infrastructure
 - **CQRS abstractions** for command and query buses, handlers, and typed messages
 - **Event-driven types** for event buses, event handlers, and domain events with metadata
 - **Persistence interfaces** for event-sourced and state-stored strategies

--- a/packages/core/src/__tests__/ddd/domain-definition.test.ts
+++ b/packages/core/src/__tests__/ddd/domain-definition.test.ts
@@ -1,0 +1,136 @@
+// Step 1: defineDomain returns the input unchanged with type inference
+import { describe, it, expect } from "vitest";
+import { defineDomain, defineAggregate } from "@noddde/core";
+import type {
+  AggregateTypes,
+  DefineCommands,
+  DefineEvents,
+  Infrastructure,
+} from "@noddde/core";
+
+type CounterState = { count: number };
+type CounterEvent = DefineEvents<{ Incremented: { by: number } }>;
+type CounterCommand = DefineCommands<{ Increment: { by: number } }>;
+type CounterTypes = AggregateTypes & {
+  state: CounterState;
+  events: CounterEvent;
+  commands: CounterCommand;
+  infrastructure: Infrastructure;
+};
+
+const Counter = defineAggregate<CounterTypes>({
+  initialState: { count: 0 },
+  decide: {
+    Increment: (cmd) => ({
+      name: "Incremented",
+      payload: { by: cmd.payload.by },
+    }),
+  },
+  evolve: {
+    Incremented: (payload, state) => ({ count: state.count + payload.by }),
+  },
+});
+
+describe("defineDomain (core)", () => {
+  it("returns the same object reference (identity)", () => {
+    const input = {
+      writeModel: { aggregates: { Counter } },
+      readModel: { projections: {} },
+    };
+
+    const definition = defineDomain(input);
+
+    expect(definition).toBe(input);
+  });
+
+  it("preserves writeModel, readModel, and processModel as provided", () => {
+    const definition = defineDomain({
+      writeModel: { aggregates: { Counter } },
+      readModel: { projections: {} },
+    });
+
+    expect(definition.writeModel.aggregates).toEqual({ Counter });
+    expect(definition.readModel.projections).toEqual({});
+    expect(definition.processModel).toBeUndefined();
+  });
+
+  it("accepts an empty domain (no aggregates, no projections, no process model)", () => {
+    const definition = defineDomain({
+      writeModel: { aggregates: {} },
+      readModel: { projections: {} },
+    });
+
+    expect(definition.writeModel.aggregates).toEqual({});
+    expect(definition.readModel.projections).toEqual({});
+    expect(definition.processModel).toBeUndefined();
+  });
+
+  it("returns a fresh reference per call", () => {
+    const a = defineDomain({
+      writeModel: { aggregates: {} },
+      readModel: { projections: {} },
+    });
+    const b = defineDomain({
+      writeModel: { aggregates: {} },
+      readModel: { projections: {} },
+    });
+
+    expect(a).not.toBe(b);
+  });
+});
+
+// Step 2: defineDomain accepts the legacy explicit-generic overload
+describe("defineDomain (core) — legacy overload", () => {
+  it("accepts an explicit TInfrastructure generic and returns the input", () => {
+    const input = {
+      writeModel: { aggregates: {} },
+      readModel: { projections: {} },
+    };
+
+    const definition = defineDomain<Infrastructure>(input);
+
+    expect(definition).toBe(input);
+  });
+});
+
+// Step 3: defineDomain supports processModel with sagas and standalone event handlers
+describe("defineDomain (core) — processModel", () => {
+  it("accepts processModel with sagas omitted but standaloneEventHandlers present", () => {
+    const handler = async () => {};
+    const definition = defineDomain({
+      writeModel: { aggregates: {} },
+      readModel: { projections: {} },
+      processModel: {
+        standaloneEventHandlers: {
+          SomethingHappened: handler,
+        },
+      },
+    });
+
+    expect(definition.processModel).toBeDefined();
+    expect(definition.processModel?.sagas).toBeUndefined();
+    expect(definition.processModel?.standaloneEventHandlers).toEqual({
+      SomethingHappened: handler,
+    });
+  });
+
+  it("accepts processModel as an empty object", () => {
+    const definition = defineDomain({
+      writeModel: { aggregates: {} },
+      readModel: { projections: {} },
+      processModel: {},
+    });
+
+    expect(definition.processModel).toEqual({});
+  });
+});
+
+// Step 4: @noddde/engine re-exports defineDomain and DomainDefinition from @noddde/core
+import { defineDomain as coreDefineDomain } from "@noddde/core";
+import { defineDomain as engineDefineDomain } from "@noddde/engine";
+
+describe("defineDomain re-export from @noddde/engine", () => {
+  it("the engine package re-exports the same function reference as core", () => {
+    expect(engineDefineDomain).toBe(coreDefineDomain);
+  });
+});

--- a/packages/core/src/ddd/domain-definition.ts
+++ b/packages/core/src/ddd/domain-definition.ts
@@ -1,0 +1,176 @@
+/* eslint-disable no-redeclare */
+/* eslint-disable no-unused-vars */
+import type { Aggregate } from "./aggregate-root";
+import type { Projection } from "./projection";
+import type { Saga } from "./saga";
+import type { Command } from "../cqrs/command/command";
+import type { StandaloneCommandHandler } from "../cqrs/command/command-handler";
+import type { Query } from "../cqrs/query/query";
+import type { QueryHandler } from "../cqrs/query/query-handler";
+import type { Event } from "../edd/event";
+import type { EventHandler } from "../edd/event-handler";
+import type { Infrastructure } from "../infrastructure";
+
+/**
+ * Maps command names to standalone command handlers. File-private — exposed
+ * only as part of DomainDefinition's writeModel.standaloneCommandHandlers.
+ */
+type StandaloneCommandHandlerMap<
+  TInfrastructure extends Infrastructure,
+  TStandaloneCommand extends Command,
+> = {
+  [CommandName in TStandaloneCommand["name"]]?: StandaloneCommandHandler<
+    TInfrastructure,
+    Extract<TStandaloneCommand, { name: CommandName }>
+  >;
+};
+
+/**
+ * Maps query names to standalone query handlers. File-private — exposed
+ * only as part of DomainDefinition's readModel.standaloneQueryHandlers.
+ */
+type StandaloneQueryHandlerMap<
+  TInfrastructure extends Infrastructure,
+  TStandaloneQuery extends Query<any>,
+> = {
+  [QueryName in TStandaloneQuery["name"]]?: QueryHandler<
+    TInfrastructure,
+    Extract<TStandaloneQuery, { name: QueryName }>
+  >;
+};
+
+/**
+ * Maps event names to standalone event handlers. File-private — exposed
+ * only as part of DomainDefinition's processModel.standaloneEventHandlers.
+ */
+type StandaloneEventHandlerMap<
+  TInfrastructure extends Infrastructure,
+  TStandaloneEvent extends Event,
+> = {
+  [EventName in TStandaloneEvent["name"]]?: EventHandler<
+    Extract<TStandaloneEvent, { name: EventName }>,
+    TInfrastructure
+  >;
+};
+
+/**
+ * Pure structural definition of a domain. Contains aggregates, projections,
+ * sagas, and handler registrations — no runtime or infrastructure concerns.
+ *
+ * Created via {@link defineDomain}. Pass to `wireDomain` (from `@noddde/engine`)
+ * along with infrastructure wiring to create a running `Domain` instance.
+ */
+export type DomainDefinition<
+  TInfrastructure extends Infrastructure = Infrastructure,
+  TStandaloneCommand extends Command = Command,
+  TStandaloneQuery extends Query<any> = Query<any>,
+  TAggregates extends Record<string | symbol, Aggregate<any>> = Record<
+    string | symbol,
+    Aggregate<any>
+  >,
+  TStandaloneEvent extends Event = Event,
+  TProjections extends Record<string | symbol, Projection<any>> = Record<
+    string | symbol,
+    Projection<any>
+  >,
+> = {
+  /** The write side: aggregates and standalone command handlers. */
+  writeModel: {
+    /** A map of aggregate definitions keyed by aggregate name. */
+    aggregates: TAggregates;
+    /** Optional map of standalone command handlers keyed by command name. */
+    standaloneCommandHandlers?: StandaloneCommandHandlerMap<
+      TInfrastructure,
+      TStandaloneCommand
+    >;
+  };
+  /** The read side: projections and standalone query handlers. */
+  readModel: {
+    /** A map of projection definitions keyed by projection name. */
+    projections: TProjections;
+    /** Optional map of standalone query handlers keyed by query name. */
+    standaloneQueryHandlers?: StandaloneQueryHandlerMap<
+      TInfrastructure,
+      TStandaloneQuery
+    >;
+  };
+  /**
+   * Process model: sagas and standalone event handlers. Optional — omit if
+   * the domain has no cross-aggregate workflows or event-driven side effects.
+   */
+  processModel?: {
+    /** A map of saga definitions keyed by saga name. Optional — omit if no sagas. */
+    sagas?: Record<string | symbol, Saga<any, any>>;
+    /** Optional map of standalone event handlers keyed by event name. */
+    standaloneEventHandlers?: StandaloneEventHandlerMap<
+      TInfrastructure,
+      TStandaloneEvent
+    >;
+  };
+};
+
+/**
+ * Creates a pure, sync domain definition with full type inference.
+ * Consistent with {@link defineAggregate}, {@link defineProjection}, {@link defineSaga}.
+ *
+ * **Preferred usage** (no explicit generics — enables typed dispatch):
+ * ```ts
+ * const domain = defineDomain({
+ *   writeModel: { aggregates: { Counter, Todo } },
+ *   readModel: { projections: { CounterView } },
+ * });
+ * ```
+ *
+ * **Legacy usage** (explicit infrastructure generic — typed dispatch is NOT available):
+ * ```ts
+ * const domain = defineDomain<MyInfrastructure>({...});
+ * ```
+ *
+ * @returns The same definition object, fully typed.
+ */
+export function defineDomain<
+  T extends DomainDefinition<any, any, any, any, any, any>,
+>(definition: T): T;
+/**
+ * Legacy overload: explicit infrastructure generic. Standalone handler
+ * infrastructure is typed, but typed dispatch (narrowed command/query names)
+ * is NOT available because TypeScript cannot infer TAggregates/TProjections
+ * when explicit generics are provided.
+ *
+ * @deprecated Prefer calling `defineDomain({...})` without explicit generics.
+ */
+export function defineDomain<
+  TInfrastructure extends Infrastructure,
+  TStandaloneCommand extends Command = Command,
+  TStandaloneQuery extends Query<any> = Query<any>,
+  TAggregates extends Record<string | symbol, Aggregate<any>> = Record<
+    string | symbol,
+    Aggregate<any>
+  >,
+  TStandaloneEvent extends Event = Event,
+  TProjections extends Record<string | symbol, Projection<any>> = Record<
+    string | symbol,
+    Projection<any>
+  >,
+>(
+  definition: DomainDefinition<
+    TInfrastructure,
+    TStandaloneCommand,
+    TStandaloneQuery,
+    TAggregates,
+    TStandaloneEvent,
+    TProjections
+  >,
+): DomainDefinition<
+  TInfrastructure,
+  TStandaloneCommand,
+  TStandaloneQuery,
+  TAggregates,
+  TStandaloneEvent,
+  TProjections
+>;
+export function defineDomain(definition: DomainDefinition): DomainDefinition {
+  return definition;
+}
+/* eslint-enable no-redeclare */
+/* eslint-enable no-unused-vars */

--- a/packages/core/src/ddd/index.ts
+++ b/packages/core/src/ddd/index.ts
@@ -1,3 +1,4 @@
 export * from "./aggregate-root";
 export * from "./projection";
 export * from "./saga";
+export * from "./domain-definition";

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -5,6 +5,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@noddde/core": path.resolve(__dirname, "src/index.ts"),
+      "@noddde/engine": path.resolve(__dirname, "../engine/src/index.ts"),
     },
   },
   test: {

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -16,7 +16,7 @@ npm install @noddde/core @noddde/engine
 
 `@noddde/engine` provides:
 
-- **Domain orchestration** (`defineDomain`, `wireDomain`) to compose aggregates, projections, and sagas into a running domain
+- **Domain orchestration** (`wireDomain`) to compose aggregates, projections, and sagas into a running domain (the `defineDomain` structural helper lives in `@noddde/core` and is re-exported here for backward compatibility)
 - **In-memory implementations** for all infrastructure contracts: command bus, query bus, event bus, aggregate persistence, saga persistence, snapshot store, outbox store, unit of work, locking, and idempotency
 - **Outbox relay** for reliable event publishing
 - **Logger** with pluggable backends
@@ -26,7 +26,8 @@ The in-memory implementations are useful for development, testing, and prototypi
 ## Usage
 
 ```typescript
-import { defineDomain, wireDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 import { BankAccount } from "./aggregates/bank-account";
 import { BalanceProjection } from "./projections/balance";
 

--- a/packages/engine/src/__tests__/engine/domain-shutdown.test.ts
+++ b/packages/engine/src/__tests__/engine/domain-shutdown.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   wireDomain,
-  defineDomain,
   DomainShutdownError,
   InMemoryOutboxStore,
 } from "@noddde/engine";
-import { defineAggregate } from "@noddde/core";
+import { defineAggregate, defineDomain } from "@noddde/core";
 import type { Closeable } from "@noddde/core";
 
 describe("Domain.shutdown", () => {

--- a/packages/engine/src/__tests__/engine/domain.test.ts
+++ b/packages/engine/src/__tests__/engine/domain.test.ts
@@ -10,9 +10,15 @@ import type {
   ProjectionTypes,
   SagaTypes,
 } from "@noddde/core";
-import { defineAggregate, defineProjection, defineSaga } from "@noddde/core";
 import {
+  createViewStoreFactory,
+  defineAggregate,
   defineDomain,
+  defineProjection,
+  defineSaga,
+  everyNEvents,
+} from "@noddde/core";
+import {
   wireDomain,
   createInMemoryUnitOfWork,
   Domain,
@@ -27,7 +33,6 @@ import {
   InMemoryStateStoredAggregatePersistence,
   InMemoryViewStore,
 } from "@noddde/engine";
-import { createViewStoreFactory, everyNEvents } from "@noddde/core";
 
 // ============================================================
 // wireDomain creates and initializes a domain

--- a/packages/engine/src/__tests__/engine/tracing.test.ts
+++ b/packages/engine/src/__tests__/engine/tracing.test.ts
@@ -6,7 +6,12 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-import { defineAggregate, defineProjection, defineSaga } from "@noddde/core";
+import {
+  defineAggregate,
+  defineDomain,
+  defineProjection,
+  defineSaga,
+} from "@noddde/core";
 import type {
   AggregateTypes,
   ProjectionTypes,
@@ -17,11 +22,7 @@ import type {
   Infrastructure,
   CQRSInfrastructure,
 } from "@noddde/core";
-import {
-  defineDomain,
-  wireDomain,
-  InMemoryViewStoreFactory,
-} from "@noddde/engine";
+import { wireDomain, InMemoryViewStoreFactory } from "@noddde/engine";
 import { detectOTel, Instrumentation } from "../../tracing";
 import { MetadataEnricher } from "../../executors/metadata-enricher";
 import type { MetadataContext } from "../../domain";

--- a/packages/engine/src/__tests__/engine/typed-dispatch.test.ts
+++ b/packages/engine/src/__tests__/engine/typed-dispatch.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-unused-vars */
 import { describe, it, expect } from "vitest";
 import { expectTypeOf } from "vitest";
-import { defineDomain, wireDomain, Domain } from "../../domain";
+import { wireDomain, Domain } from "../../domain";
+import { defineDomain } from "@noddde/core";
 import { InMemoryViewStoreFactory } from "../../implementations/in-memory-view-store-factory";
 import {
   defineAggregate,

--- a/packages/engine/src/__tests__/integration/adapter-wiring.test.ts
+++ b/packages/engine/src/__tests__/integration/adapter-wiring.test.ts
@@ -8,9 +8,13 @@ import type {
   PersistenceAdapter,
   SagaTypes,
 } from "@noddde/core";
-import { defineAggregate, defineSaga, everyNEvents } from "@noddde/core";
 import {
+  defineAggregate,
   defineDomain,
+  defineSaga,
+  everyNEvents,
+} from "@noddde/core";
+import {
   wireDomain,
   createInMemoryUnitOfWork,
   InMemoryEventSourcedAggregatePersistence,

--- a/packages/engine/src/__tests__/integration/command-dispatch-lifecycle.test.ts
+++ b/packages/engine/src/__tests__/integration/command-dispatch-lifecycle.test.ts
@@ -1,9 +1,8 @@
 /* eslint-disable no-unused-vars */
 import { describe, expect, it, vi } from "vitest";
 import type { DefineCommands, DefineEvents } from "@noddde/core";
-import { defineAggregate } from "@noddde/core";
+import { defineAggregate, defineDomain, everyNEvents } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,
@@ -12,7 +11,6 @@ import {
   InMemorySnapshotStore,
   InMemoryStateStoredAggregatePersistence,
 } from "@noddde/engine";
-import { everyNEvents } from "@noddde/core";
 
 // ---- Shared counter aggregate ----
 

--- a/packages/engine/src/__tests__/integration/domain-bootstrap.test.ts
+++ b/packages/engine/src/__tests__/integration/domain-bootstrap.test.ts
@@ -6,9 +6,13 @@ import type {
   DefineQueries,
   Infrastructure,
 } from "@noddde/core";
-import { defineAggregate, defineProjection, defineSaga } from "@noddde/core";
 import {
+  defineAggregate,
   defineDomain,
+  defineProjection,
+  defineSaga,
+} from "@noddde/core";
+import {
   wireDomain,
   InMemoryEventSourcedAggregatePersistence,
   InMemorySagaPersistence,

--- a/packages/engine/src/__tests__/integration/event-projection-flow.test.ts
+++ b/packages/engine/src/__tests__/integration/event-projection-flow.test.ts
@@ -4,10 +4,10 @@ import type { DefineCommands, DefineEvents, DefineQueries } from "@noddde/core";
 import {
   createViewStoreFactory,
   defineAggregate,
+  defineDomain,
   defineProjection,
 } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,

--- a/packages/engine/src/__tests__/integration/event-upcasting.test.ts
+++ b/packages/engine/src/__tests__/integration/event-upcasting.test.ts
@@ -3,11 +3,12 @@ import { describe, expect, it, vi } from "vitest";
 import type { DefineCommands, DefineEvents, Event } from "@noddde/core";
 import {
   defineAggregate,
+  defineDomain,
   defineEventUpcasterChain,
   defineUpcasters,
+  everyNEvents,
 } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,
@@ -15,7 +16,6 @@ import {
   InMemoryQueryBus,
   InMemorySnapshotStore,
 } from "@noddde/engine";
-import { everyNEvents } from "@noddde/core";
 
 // ---- V2 aggregate: current schema has `status` on Created ----
 

--- a/packages/engine/src/__tests__/integration/outbox-delivery.test.ts
+++ b/packages/engine/src/__tests__/integration/outbox-delivery.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import type { DefineCommands, DefineEvents } from "@noddde/core";
-import { defineAggregate } from "@noddde/core";
+import { defineAggregate, defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   InMemoryOutboxStore,
   EventEmitterEventBus,

--- a/packages/engine/src/__tests__/integration/projection-delete-view.test.ts
+++ b/packages/engine/src/__tests__/integration/projection-delete-view.test.ts
@@ -7,9 +7,13 @@ import type {
   Infrastructure,
   Query,
 } from "@noddde/core";
-import { DeleteView, defineAggregate, defineProjection } from "@noddde/core";
 import {
+  DeleteView,
+  defineAggregate,
   defineDomain,
+  defineProjection,
+} from "@noddde/core";
+import {
   EventEmitterEventBus,
   InMemoryCommandBus,
   InMemoryEventSourcedAggregatePersistence,

--- a/packages/engine/src/__tests__/integration/projection-error-isolation.test.ts
+++ b/packages/engine/src/__tests__/integration/projection-error-isolation.test.ts
@@ -3,9 +3,8 @@
 
 import { describe, expect, it, vi } from "vitest";
 import type { DefineCommands, DefineEvents, DefineQueries } from "@noddde/core";
-import { defineAggregate, defineProjection } from "@noddde/core";
+import { defineAggregate, defineDomain, defineProjection } from "@noddde/core";
 import {
-  defineDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,
   InMemoryEventSourcedAggregatePersistence,

--- a/packages/engine/src/__tests__/integration/projection-rebuild.test.ts
+++ b/packages/engine/src/__tests__/integration/projection-rebuild.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from "vitest";
 import {
   DeleteView,
   defineAggregate,
+  defineDomain,
   defineProjection,
   type DefineEvents,
   type DefineCommands,
   type DefineQueries,
 } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   InMemoryViewStoreFactory,
   ProjectionNotFoundError,

--- a/packages/engine/src/__tests__/integration/saga-error-isolation.test.ts
+++ b/packages/engine/src/__tests__/integration/saga-error-isolation.test.ts
@@ -3,9 +3,13 @@
 
 import { describe, expect, it, vi } from "vitest";
 import type { DefineCommands, DefineEvents, DefineQueries } from "@noddde/core";
-import { defineAggregate, defineProjection, defineSaga } from "@noddde/core";
 import {
+  defineAggregate,
   defineDomain,
+  defineProjection,
+  defineSaga,
+} from "@noddde/core";
+import {
   EventEmitterEventBus,
   InMemoryCommandBus,
   InMemoryEventSourcedAggregatePersistence,

--- a/packages/engine/src/__tests__/integration/saga-orchestration.test.ts
+++ b/packages/engine/src/__tests__/integration/saga-orchestration.test.ts
@@ -1,9 +1,8 @@
 /* eslint-disable no-unused-vars */
 import { describe, expect, it, vi } from "vitest";
 import type { DefineCommands, DefineEvents } from "@noddde/core";
-import { defineSaga } from "@noddde/core";
+import { defineDomain, defineSaga } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,

--- a/packages/engine/src/__tests__/integration/view-store-factory.test.ts
+++ b/packages/engine/src/__tests__/integration/view-store-factory.test.ts
@@ -10,11 +10,7 @@ import type {
   ViewStore,
   ViewStoreFactory,
 } from "@noddde/core";
-import {
-  defineAggregate,
-  defineDomain,
-  defineProjection,
-} from "@noddde/core";
+import { defineAggregate, defineDomain, defineProjection } from "@noddde/core";
 import {
   wireDomain,
   EventEmitterEventBus,

--- a/packages/engine/src/__tests__/integration/view-store-factory.test.ts
+++ b/packages/engine/src/__tests__/integration/view-store-factory.test.ts
@@ -10,9 +10,12 @@ import type {
   ViewStore,
   ViewStoreFactory,
 } from "@noddde/core";
-import { defineAggregate, defineProjection } from "@noddde/core";
 import {
+  defineAggregate,
   defineDomain,
+  defineProjection,
+} from "@noddde/core";
+import {
   wireDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,

--- a/packages/engine/src/domain.ts
+++ b/packages/engine/src/domain.ts
@@ -38,7 +38,15 @@ import type {
   OutboxEntry,
 } from "@noddde/core";
 import type { AggregateLocker, Closeable } from "@noddde/core";
-import { isCloseable, isConnectable, DeleteView } from "@noddde/core";
+import {
+  isCloseable,
+  isConnectable,
+  DeleteView,
+  defineDomain,
+} from "@noddde/core";
+import type { DomainDefinition } from "@noddde/core";
+export { defineDomain } from "@noddde/core";
+export type { DomainDefinition } from "@noddde/core";
 import { OutboxRelay } from "./outbox-relay";
 import type { OutboxRelayOptions } from "./outbox-relay";
 import { uuidv7 } from "./uuid";
@@ -125,6 +133,7 @@ type ProjectionMap = Record<string | symbol, Projection<any>>;
 
 type SagaMap = Record<string | symbol, Saga<any, any>>;
 
+/** @internal File-private alias used by ExtractStandaloneCommand. */
 type StandaloneCommandHandlerMap<
   TInfrastructure extends Infrastructure,
   TStandaloneCommand extends Command,
@@ -135,33 +144,14 @@ type StandaloneCommandHandlerMap<
   >;
 };
 
+/** @internal File-private alias used by ExtractStandaloneQuery. */
 type StandaloneQueryHandlerMap<
   TInfrastructure extends Infrastructure,
   TStandaloneQuery extends Query<any>,
 > = {
   [QueryName in TStandaloneQuery["name"]]?: QueryHandler<
     TInfrastructure,
-    Extract<
-      TStandaloneQuery,
-      {
-        name: QueryName;
-      }
-    >
-  >;
-};
-
-/**
- * Maps event names to standalone event handlers. Each handler receives the
- * full event and infrastructure. Follows the same pattern as
- * StandaloneCommandHandlerMap and StandaloneQueryHandlerMap.
- */
-type StandaloneEventHandlerMap<
-  TInfrastructure extends Infrastructure,
-  TStandaloneEvent extends Event,
-> = {
-  [EventName in TStandaloneEvent["name"]]?: EventHandler<
-    Extract<TStandaloneEvent, { name: EventName }>,
-    TInfrastructure
+    Extract<TStandaloneQuery, { name: QueryName }>
   >;
 };
 
@@ -310,56 +300,6 @@ export type ProjectionWiring = {
 };
 
 /**
- * Pure structural definition of a domain. Contains aggregates, projections,
- * sagas, and handler registrations — no runtime or infrastructure concerns.
- *
- * Created via {@link defineDomain}. Pass to {@link wireDomain} along with
- * infrastructure wiring to create a running {@link Domain}.
- */
-export type DomainDefinition<
-  TInfrastructure extends Infrastructure = Infrastructure,
-  TStandaloneCommand extends Command = Command,
-  TStandaloneQuery extends Query<any> = Query<any>,
-  TAggregates extends AggregateMap = AggregateMap,
-  TStandaloneEvent extends Event = Event,
-  TProjections extends ProjectionMap = ProjectionMap,
-> = {
-  /** The write side: aggregates and standalone command handlers. */
-  writeModel: {
-    /** A map of aggregate definitions keyed by aggregate name. */
-    aggregates: TAggregates;
-    /** Optional map of standalone command handlers keyed by command name. */
-    standaloneCommandHandlers?: StandaloneCommandHandlerMap<
-      TInfrastructure,
-      TStandaloneCommand
-    >;
-  };
-  /** The read side: projections and standalone query handlers. */
-  readModel: {
-    /** A map of projection definitions keyed by projection name. */
-    projections: TProjections;
-    /** Optional map of standalone query handlers keyed by query name. */
-    standaloneQueryHandlers?: StandaloneQueryHandlerMap<
-      TInfrastructure,
-      TStandaloneQuery
-    >;
-  };
-  /**
-   * Process model: sagas and standalone event handlers. Optional — omit if
-   * the domain has no cross-aggregate workflows or event-driven side effects.
-   */
-  processModel?: {
-    /** A map of saga definitions keyed by saga name. Optional — omit if no sagas. */
-    sagas?: SagaMap;
-    /** Optional map of standalone event handlers keyed by event name. */
-    standaloneEventHandlers?: StandaloneEventHandlerMap<
-      TInfrastructure,
-      TStandaloneEvent
-    >;
-  };
-};
-
-/**
  * Runtime infrastructure wiring for a domain. Connects a {@link DomainDefinition}
  * to persistence, buses, concurrency, snapshots, and user-provided services.
  *
@@ -411,66 +351,6 @@ export type DomainWiring<
   /** Framework logger. Defaults to NodddeLogger at 'warn' level. */
   logger?: Logger;
 };
-
-/* eslint-disable no-redeclare */
-/**
- * Creates a pure, sync domain definition with full type inference.
- * Consistent with {@link defineAggregate}, {@link defineProjection}, {@link defineSaga}.
- *
- * **Preferred usage** (no explicit generics — enables typed dispatch):
- * ```ts
- * const domain = defineDomain({
- *   writeModel: { aggregates: { Counter, Todo } },
- *   readModel: { projections: { CounterView } },
- * });
- * ```
- *
- * **Legacy usage** (explicit infrastructure generic — typed dispatch is NOT available):
- * ```ts
- * const domain = defineDomain<MyInfrastructure>({...});
- * ```
- *
- * @returns The same definition object, fully typed.
- */
-export function defineDomain<
-  T extends DomainDefinition<any, any, any, any, any, any>,
->(definition: T): T;
-/**
- * Legacy overload: explicit infrastructure generic. Standalone handler
- * infrastructure is typed, but typed dispatch (narrowed command/query names)
- * is NOT available because TypeScript cannot infer TAggregates/TProjections
- * when explicit generics are provided.
- *
- * @deprecated Prefer calling `defineDomain({...})` without explicit generics.
- */
-export function defineDomain<
-  TInfrastructure extends Infrastructure,
-  TStandaloneCommand extends Command = Command,
-  TStandaloneQuery extends Query<any> = Query<any>,
-  TAggregates extends AggregateMap = AggregateMap,
-  TStandaloneEvent extends Event = Event,
-  TProjections extends ProjectionMap = ProjectionMap,
->(
-  definition: DomainDefinition<
-    TInfrastructure,
-    TStandaloneCommand,
-    TStandaloneQuery,
-    TAggregates,
-    TStandaloneEvent,
-    TProjections
-  >,
-): DomainDefinition<
-  TInfrastructure,
-  TStandaloneCommand,
-  TStandaloneQuery,
-  TAggregates,
-  TStandaloneEvent,
-  TProjections
->;
-export function defineDomain(definition: DomainDefinition): DomainDefinition {
-  return definition;
-}
-/* eslint-enable no-redeclare */
 
 /**
  * Internal context passed by wireDomain to Domain, carrying pre-computed

--- a/packages/integrations/nestjs/src/__tests__/noddde-module.test.ts
+++ b/packages/integrations/nestjs/src/__tests__/noddde-module.test.ts
@@ -11,7 +11,7 @@ import {
   NodddeMetadataInterceptor,
 } from "../noddde.module";
 import type { MetadataExtractor } from "../noddde.module";
-import { defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
 import type { Domain } from "@noddde/engine";
 
 describe("NodddeModule", () => {

--- a/packages/testing/src/domain-harness.ts
+++ b/packages/testing/src/domain-harness.ts
@@ -1,15 +1,15 @@
 /* eslint-disable no-unused-vars */
-import type {
-  Aggregate,
-  Projection,
-  Saga,
-  Infrastructure,
-  Command,
-  Event,
-  ViewStoreFactory,
-} from "@noddde/core";
 import {
   defineDomain,
+  type Aggregate,
+  type Projection,
+  type Saga,
+  type Infrastructure,
+  type Command,
+  type Event,
+  type ViewStoreFactory,
+} from "@noddde/core";
+import {
   wireDomain,
   type Domain,
   EventEmitterEventBus,

--- a/samples/sample-auction/src/main.ts
+++ b/samples/sample-auction/src/main.ts
@@ -4,8 +4,8 @@
  * Demonstrates @noddde with Prisma Adapter + SQLite for persistence,
  * including a projection and upcasters.
  */
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,

--- a/samples/sample-flash-sale/src/main-optimistic.ts
+++ b/samples/sample-flash-sale/src/main-optimistic.ts
@@ -9,8 +9,8 @@ import {
   NodddeSnapshotEntity,
   NodddeOutboxEntryEntity,
 } from "@noddde/typeorm";
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,

--- a/samples/sample-flash-sale/src/main-pessimistic.ts
+++ b/samples/sample-flash-sale/src/main-pessimistic.ts
@@ -21,8 +21,8 @@ import {
   NodddeSnapshotEntity,
   NodddeOutboxEntryEntity,
 } from "@noddde/typeorm";
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,

--- a/samples/sample-hotel-booking/src/__tests__/integration/setup.ts
+++ b/samples/sample-hotel-booking/src/__tests__/integration/setup.ts
@@ -15,7 +15,6 @@ import {
 } from "@noddde/drizzle/sqlite";
 import { createRoomStateMapper } from "../../infrastructure/persistence/room-state-mapper";
 import {
-  defineDomain,
   wireDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,
@@ -23,7 +22,7 @@ import {
   InMemoryIdempotencyStore,
   InMemoryViewStore,
 } from "@noddde/engine";
-import { createViewStoreFactory } from "@noddde/core";
+import { createViewStoreFactory, defineDomain } from "@noddde/core";
 import type { HotelInfrastructure } from "../../infrastructure/types";
 import type {
   GuestHistoryView,

--- a/samples/sample-hotel-booking/src/main.ts
+++ b/samples/sample-hotel-booking/src/main.ts
@@ -14,8 +14,8 @@
 import pg from "pg";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { DrizzleAdapter } from "@noddde/drizzle";
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,

--- a/specs/core/ddd/domain-definition.spec.md
+++ b/specs/core/ddd/domain-definition.spec.md
@@ -1,0 +1,393 @@
+---
+title: "DomainDefinition & defineDomain"
+module: ddd/domain-definition
+source_file: packages/core/src/ddd/domain-definition.ts
+status: implemented
+exports: [DomainDefinition, defineDomain]
+depends_on:
+  - ddd/aggregate-root
+  - ddd/projection
+  - ddd/saga
+  - cqrs/command/command
+  - cqrs/command/command-handler
+  - cqrs/query/query
+  - cqrs/query/query-handler
+  - edd/event
+  - edd/event-handler
+  - infrastructure
+docs:
+  - getting-started/quick-start.mdx
+  - running/domain-configuration.mdx
+  - modeling/routing-and-dispatch.mdx
+---
+
+# DomainDefinition & defineDomain
+
+> The pure, structural side of the domain API: a typed object describing aggregates, projections, sagas, and handler registrations, and a sync identity function that returns it with full type inference. No runtime, no infrastructure, no I/O — just the **shape** of a domain. This separation lets domain definitions be authored, shared, tested, and analyzed in `@noddde/core` independent of how (or whether) they are later wired to runtime infrastructure via `@noddde/engine`.
+
+## Type Contract
+
+```ts
+/**
+ * Maps command names to standalone command handlers. File-private — exposed
+ * only as part of DomainDefinition's writeModel.standaloneCommandHandlers.
+ */
+type StandaloneCommandHandlerMap<
+  TInfrastructure extends Infrastructure,
+  TStandaloneCommand extends Command,
+> = {
+  [CommandName in TStandaloneCommand["name"]]?: StandaloneCommandHandler<
+    TInfrastructure,
+    Extract<TStandaloneCommand, { name: CommandName }>
+  >;
+};
+
+/**
+ * Maps query names to standalone query handlers. File-private — exposed
+ * only as part of DomainDefinition's readModel.standaloneQueryHandlers.
+ */
+type StandaloneQueryHandlerMap<
+  TInfrastructure extends Infrastructure,
+  TStandaloneQuery extends Query<any>,
+> = {
+  [QueryName in TStandaloneQuery["name"]]?: QueryHandler<
+    TInfrastructure,
+    Extract<TStandaloneQuery, { name: QueryName }>
+  >;
+};
+
+/**
+ * Maps event names to standalone event handlers. File-private — exposed
+ * only as part of DomainDefinition's processModel.standaloneEventHandlers.
+ */
+type StandaloneEventHandlerMap<
+  TInfrastructure extends Infrastructure,
+  TStandaloneEvent extends Event,
+> = {
+  [EventName in TStandaloneEvent["name"]]?: EventHandler<
+    Extract<TStandaloneEvent, { name: EventName }>,
+    TInfrastructure
+  >;
+};
+
+/**
+ * Pure structural definition of a domain. Contains aggregates, projections,
+ * sagas, and handler registrations — no runtime or infrastructure concerns.
+ *
+ * Created via {@link defineDomain}. Pass to `wireDomain` (from `@noddde/engine`)
+ * along with infrastructure wiring to create a running `Domain` instance.
+ */
+type DomainDefinition<
+  TInfrastructure extends Infrastructure = Infrastructure,
+  TStandaloneCommand extends Command = Command,
+  TStandaloneQuery extends Query<any> = Query<any>,
+  TAggregates extends Record<string | symbol, Aggregate<any>> = Record<
+    string | symbol,
+    Aggregate<any>
+  >,
+  TStandaloneEvent extends Event = Event,
+  TProjections extends Record<string | symbol, Projection<any>> = Record<
+    string | symbol,
+    Projection<any>
+  >,
+> = {
+  /** The write side: aggregates and standalone command handlers. */
+  writeModel: {
+    /** A map of aggregate definitions keyed by aggregate name. */
+    aggregates: TAggregates;
+    /** Optional map of standalone command handlers keyed by command name. */
+    standaloneCommandHandlers?: StandaloneCommandHandlerMap<
+      TInfrastructure,
+      TStandaloneCommand
+    >;
+  };
+  /** The read side: projections and standalone query handlers. */
+  readModel: {
+    /** A map of projection definitions keyed by projection name. */
+    projections: TProjections;
+    /** Optional map of standalone query handlers keyed by query name. */
+    standaloneQueryHandlers?: StandaloneQueryHandlerMap<
+      TInfrastructure,
+      TStandaloneQuery
+    >;
+  };
+  /**
+   * Process model: sagas and standalone event handlers. Optional — omit if
+   * the domain has no cross-aggregate workflows or event-driven side effects.
+   */
+  processModel?: {
+    /** A map of saga definitions keyed by saga name. Optional — omit if no sagas. */
+    sagas?: Record<string | symbol, Saga<any, any>>;
+    /** Optional map of standalone event handlers keyed by event name. */
+    standaloneEventHandlers?: StandaloneEventHandlerMap<
+      TInfrastructure,
+      TStandaloneEvent
+    >;
+  };
+};
+
+/**
+ * Creates a pure, sync domain definition with full type inference.
+ * Consistent with defineAggregate, defineProjection, defineSaga.
+ *
+ * Overload 1 (preferred): Infers all types from the definition object,
+ * preserving narrow aggregate/projection types for typed dispatch
+ * downstream (in wireDomain / Domain).
+ *
+ * Overload 2 (legacy, deprecated): Explicit infrastructure generic for
+ * standalone handler typing. Typed dispatch is NOT available because
+ * TypeScript cannot infer TAggregates/TProjections when explicit
+ * generics are provided.
+ */
+function defineDomain<T extends DomainDefinition<any, any, any, any, any, any>>(
+  definition: T,
+): T;
+/** @deprecated Prefer calling defineDomain({...}) without explicit generics. */
+function defineDomain<
+  TInfrastructure extends Infrastructure,
+  TStandaloneCommand extends Command = Command,
+  TStandaloneQuery extends Query<any> = Query<any>,
+  TAggregates extends Record<string | symbol, Aggregate<any>> = Record<
+    string | symbol,
+    Aggregate<any>
+  >,
+  TStandaloneEvent extends Event = Event,
+  TProjections extends Record<string | symbol, Projection<any>> = Record<
+    string | symbol,
+    Projection<any>
+  >,
+>(
+  definition: DomainDefinition<
+    TInfrastructure,
+    TStandaloneCommand,
+    TStandaloneQuery,
+    TAggregates,
+    TStandaloneEvent,
+    TProjections
+  >,
+): DomainDefinition<
+  TInfrastructure,
+  TStandaloneCommand,
+  TStandaloneQuery,
+  TAggregates,
+  TStandaloneEvent,
+  TProjections
+>;
+```
+
+- **`DomainDefinition<TInfrastructure, TStandaloneCommand, TStandaloneQuery, TAggregates, TStandaloneEvent, TProjections>`** captures the pure domain structure: write model (aggregates + standalone command handlers), read model (projections + standalone query handlers), and optional process model (sagas + standalone event handlers).
+- `TInfrastructure` is a type parameter only — handler signatures reference it but no infrastructure value is present in the definition. Infrastructure is wired separately by `wireDomain` (`@noddde/engine`).
+- `TAggregates` and `TProjections` carry the typed maps inferred from `writeModel.aggregates` and `readModel.projections`. Their narrow inference is what enables `wireDomain` to compute typed `dispatchCommand` and `dispatchQuery` signatures.
+- The internal types `StandaloneCommandHandlerMap`, `StandaloneQueryHandlerMap`, and `StandaloneEventHandlerMap` are file-private structural helpers — they are not exported.
+- **`defineDomain`** is a sync identity function with two overloads:
+  - **Overload 1 (preferred)**: A single type parameter `T extends DomainDefinition<any, any, any, any, any, any>` — TypeScript infers `T` from the definition argument, preserving the narrow aggregate/projection types required for typed dispatch downstream.
+  - **Overload 2 (legacy, deprecated)**: Six explicit type parameters matching `DomainDefinition`'s shape. Standalone handler infrastructure is typed, but `TAggregates`/`TProjections` cannot be inferred when explicit generics are provided — typed dispatch is therefore unavailable in this form. Use only for backward compatibility with existing call sites.
+- Both overloads return the exact input definition object — no copy, no transformation. The implementation is `(definition) => definition`.
+
+## Behavioral Requirements
+
+### defineDomain() — Identity Function
+
+1. Accept a `DomainDefinition` object.
+2. Return the **same** object unchanged (reference equality with the input).
+3. This is a **sync** function — no async, no side effects, no factories called, no I/O.
+4. Consistent with `defineAggregate`, `defineProjection`, `defineSaga`.
+
+### Type inference (Overload 1, preferred)
+
+1. With no explicit type arguments, TypeScript infers `T` from the definition argument.
+2. The narrow shapes of `writeModel.aggregates` and `readModel.projections` are preserved on the return value.
+3. `processModel` may be omitted; its absence is reflected on the result type.
+
+### Type inference (Overload 2, legacy)
+
+1. When the caller specifies explicit generics — at minimum `TInfrastructure` — the second overload matches.
+2. The handler maps within `writeModel.standaloneCommandHandlers`, `readModel.standaloneQueryHandlers`, and `processModel.standaloneEventHandlers` are typed against the supplied `TStandaloneCommand` / `TStandaloneQuery` / `TStandaloneEvent`.
+3. The narrow aggregate/projection types are widened to the constraint defaults (`Record<string | symbol, Aggregate<any>>` / `Record<string | symbol, Projection<any>>`) because explicit generics block inference. Typed dispatch downstream is therefore unavailable.
+4. The overload is marked `@deprecated`.
+
+## Invariants
+
+- `defineDomain` is sync, pure, and has no side effects. It returns the input unchanged.
+- `defineDomain(x) === x` — reference equality with the input.
+- No runtime work happens in `defineDomain`. No infrastructure is touched, no factory is called.
+- `DomainDefinition` is a structural type only — there is no associated class, instance, or runtime object.
+- `DomainDefinition.writeModel.aggregates` and `DomainDefinition.readModel.projections` are required. They may be empty objects (`{}`).
+- `DomainDefinition.processModel` is optional. When omitted entirely, the domain has no sagas and no standalone event handlers.
+- The three handler maps (`standaloneCommandHandlers`, `standaloneQueryHandlers`, `standaloneEventHandlers`) are file-private to the source file — they are not exported and exist only as the type of the corresponding fields on `DomainDefinition`.
+
+## Edge Cases
+
+- **`defineDomain` called multiple times** — Each call returns a fresh reference (whatever the caller passed in). No state is shared between calls.
+- **Empty maps** — `writeModel.aggregates: {}` and `readModel.projections: {}` are valid; the result is a domain definition with no commands routed to aggregates and no projections.
+- **`processModel` omitted vs. `processModel: {}`** — Both are valid. `{}` is shorthand for "process model exists but is empty"; downstream wiring treats them identically (no sagas, no standalone event handlers).
+- **`processModel.sagas` omitted but `standaloneEventHandlers` set** — Valid: the domain has standalone event handlers but no sagas.
+- **`writeModel.standaloneCommandHandlers` empty object (`{}`)** — Valid. Equivalent to omitting the field.
+- **Handler key not in the standalone command/query/event union** — TypeScript rejects the call at compile time because the mapped type only permits keys from the union.
+- **Calling Overload 2 with explicit `TInfrastructure` but no other generics** — The remaining generics default to the broadest constraints. Standalone handlers are typed; typed dispatch downstream is unavailable.
+- **Definition object mutated after `defineDomain` returns** — Mutations are visible on the returned reference (the function is a pure identity, not a copy). Callers should treat the definition as immutable.
+
+## Integration Points
+
+- **`@noddde/engine`** — `wireDomain` accepts a `DomainDefinition` and produces a running `Domain` instance. `wireDomain` reads the narrow `TAggregates` and `TProjections` inferred by Overload 1 of `defineDomain` to compute the typed `dispatchCommand` and `dispatchQuery` signatures on the returned `Domain`. For backward compatibility, `@noddde/engine` re-exports both `DomainDefinition` and `defineDomain` from `@noddde/core`, so existing imports `from "@noddde/engine"` continue to work.
+- **`@noddde/core/ddd`** — `defineDomain` composes the four "definition" primitives (`defineAggregate`, `defineProjection`, `defineSaga`, and standalone handler functions) into a single domain shape. The handler-signature types (`StandaloneCommandHandler`, `QueryHandler`, `EventHandler`) come from the existing core modules.
+- **CLI scaffolding (`@noddde/cli`)** — Templates that scaffold a `defineDomain(...)` call may import from either `@noddde/core` (canonical) or `@noddde/engine` (back-compat). The template choice is a downstream decision; this spec does not mandate one.
+
+## Test Scenarios
+
+### defineDomain returns the input unchanged with type inference
+
+```ts
+import { describe, it, expect } from "vitest";
+import { defineDomain, defineAggregate } from "@noddde/core";
+import type {
+  AggregateTypes,
+  DefineCommands,
+  DefineEvents,
+  Infrastructure,
+} from "@noddde/core";
+
+type CounterState = { count: number };
+type CounterEvent = DefineEvents<{ Incremented: { by: number } }>;
+type CounterCommand = DefineCommands<{ Increment: { by: number } }>;
+type CounterTypes = AggregateTypes & {
+  state: CounterState;
+  events: CounterEvent;
+  commands: CounterCommand;
+  infrastructure: Infrastructure;
+};
+
+const Counter = defineAggregate<CounterTypes>({
+  initialState: { count: 0 },
+  decide: {
+    Increment: (cmd) => ({
+      name: "Incremented",
+      payload: { by: cmd.payload.by },
+    }),
+  },
+  evolve: {
+    Incremented: (payload, state) => ({ count: state.count + payload.by }),
+  },
+});
+
+describe("defineDomain (core)", () => {
+  it("returns the same object reference (identity)", () => {
+    const input = {
+      writeModel: { aggregates: { Counter } },
+      readModel: { projections: {} },
+    };
+
+    const definition = defineDomain(input);
+
+    expect(definition).toBe(input);
+  });
+
+  it("preserves writeModel, readModel, and processModel as provided", () => {
+    const definition = defineDomain({
+      writeModel: { aggregates: { Counter } },
+      readModel: { projections: {} },
+    });
+
+    expect(definition.writeModel.aggregates).toEqual({ Counter });
+    expect(definition.readModel.projections).toEqual({});
+    expect(definition.processModel).toBeUndefined();
+  });
+
+  it("accepts an empty domain (no aggregates, no projections, no process model)", () => {
+    const definition = defineDomain({
+      writeModel: { aggregates: {} },
+      readModel: { projections: {} },
+    });
+
+    expect(definition.writeModel.aggregates).toEqual({});
+    expect(definition.readModel.projections).toEqual({});
+    expect(definition.processModel).toBeUndefined();
+  });
+
+  it("returns a fresh reference per call", () => {
+    const a = defineDomain({
+      writeModel: { aggregates: {} },
+      readModel: { projections: {} },
+    });
+    const b = defineDomain({
+      writeModel: { aggregates: {} },
+      readModel: { projections: {} },
+    });
+
+    expect(a).not.toBe(b);
+  });
+});
+```
+
+### defineDomain accepts the legacy explicit-generic overload
+
+```ts
+import { describe, it, expect } from "vitest";
+import { defineDomain } from "@noddde/core";
+import type { Infrastructure } from "@noddde/core";
+
+describe("defineDomain (core) — legacy overload", () => {
+  it("accepts an explicit TInfrastructure generic and returns the input", () => {
+    const input = {
+      writeModel: { aggregates: {} },
+      readModel: { projections: {} },
+    };
+
+    const definition = defineDomain<Infrastructure>(input);
+
+    expect(definition).toBe(input);
+  });
+});
+```
+
+### defineDomain supports processModel with sagas and standalone event handlers
+
+```ts
+import { describe, it, expect } from "vitest";
+import { defineDomain } from "@noddde/core";
+
+describe("defineDomain (core) — processModel", () => {
+  it("accepts processModel with sagas omitted but standaloneEventHandlers present", () => {
+    const handler = async () => {};
+    const definition = defineDomain({
+      writeModel: { aggregates: {} },
+      readModel: { projections: {} },
+      processModel: {
+        standaloneEventHandlers: {
+          SomethingHappened: handler,
+        },
+      },
+    });
+
+    expect(definition.processModel).toBeDefined();
+    expect(definition.processModel?.sagas).toBeUndefined();
+    expect(definition.processModel?.standaloneEventHandlers).toEqual({
+      SomethingHappened: handler,
+    });
+  });
+
+  it("accepts processModel as an empty object", () => {
+    const definition = defineDomain({
+      writeModel: { aggregates: {} },
+      readModel: { projections: {} },
+      processModel: {},
+    });
+
+    expect(definition.processModel).toEqual({});
+  });
+});
+```
+
+### @noddde/engine re-exports defineDomain and DomainDefinition from @noddde/core
+
+```ts
+import { describe, it, expect } from "vitest";
+import { defineDomain as coreDefineDomain } from "@noddde/core";
+import { defineDomain as engineDefineDomain } from "@noddde/engine";
+
+describe("defineDomain re-export from @noddde/engine", () => {
+  it("the engine package re-exports the same function reference as core", () => {
+    expect(engineDefineDomain).toBe(coreDefineDomain);
+  });
+});
+```

--- a/specs/core/ddd/projection.spec.md
+++ b/specs/core/ddd/projection.spec.md
@@ -1168,9 +1168,13 @@ describe("Reducer return type with DeleteView", () => {
 ```ts
 import { describe, expect, it, vi } from "vitest";
 import type { DefineCommands, DefineEvents, DefineQueries } from "@noddde/core";
-import { DeleteView, defineAggregate, defineProjection } from "@noddde/core";
 import {
+  DeleteView,
+  defineAggregate,
   defineDomain,
+  defineProjection,
+} from "@noddde/core";
+import {
   EventEmitterEventBus,
   InMemoryCommandBus,
   InMemoryEventSourcedAggregatePersistence,
@@ -1564,9 +1568,13 @@ describe("Strong-consistency projection error propagation", () => {
 ```ts
 import { describe, expect, it, vi } from "vitest";
 import type { DefineCommands, DefineEvents, DefineQueries } from "@noddde/core";
-import { DeleteView, defineAggregate, defineProjection } from "@noddde/core";
 import {
+  DeleteView,
+  defineAggregate,
   defineDomain,
+  defineProjection,
+} from "@noddde/core";
+import {
   EventEmitterEventBus,
   InMemoryCommandBus,
   InMemoryEventSourcedAggregatePersistence,

--- a/specs/core/ddd/projection.spec.md
+++ b/specs/core/ddd/projection.spec.md
@@ -1342,9 +1342,8 @@ describe("DeleteView idempotency", () => {
 ```ts
 import { describe, expect, it, vi } from "vitest";
 import type { DefineCommands, DefineEvents, DefineQueries } from "@noddde/core";
-import { defineAggregate, defineProjection } from "@noddde/core";
+import { defineAggregate, defineDomain, defineProjection } from "@noddde/core";
 import {
-  defineDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,
   InMemoryEventSourcedAggregatePersistence,
@@ -1469,9 +1468,8 @@ describe("Eventual-consistency projection error isolation", () => {
 ```ts
 import { describe, expect, it, vi } from "vitest";
 import type { DefineCommands, DefineEvents, DefineQueries } from "@noddde/core";
-import { defineAggregate, defineProjection } from "@noddde/core";
+import { defineAggregate, defineDomain, defineProjection } from "@noddde/core";
 import {
-  defineDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,
   InMemoryEventSourcedAggregatePersistence,

--- a/specs/core/edd/event-handler.spec.md
+++ b/specs/core/edd/event-handler.spec.md
@@ -142,9 +142,8 @@ describe("EventHandler sync/async", () => {
 ```ts
 import { describe, expect, it, vi } from "vitest";
 import type { DefineCommands, DefineEvents } from "@noddde/core";
-import { defineAggregate } from "@noddde/core";
+import { defineAggregate, defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   EventEmitterEventBus,
   InMemoryCommandBus,
   InMemoryEventSourcedAggregatePersistence,

--- a/specs/core/persistence/adapter.spec.md
+++ b/specs/core/persistence/adapter.spec.md
@@ -272,7 +272,8 @@ expect(isPersistenceAdapter({ unitOfWorkFactory: "not-a-function" })).toBe(
 ### Adapter defaults resolve for aggregate persistence
 
 ```ts
-import { defineDomain, wireDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 import type { PersistenceAdapter } from "@noddde/core";
 
 // Minimal aggregate for testing

--- a/specs/engine/domain-shutdown.spec.md
+++ b/specs/engine/domain-shutdown.spec.md
@@ -122,7 +122,8 @@ class Domain<TInfrastructure, TStandaloneCommand, TStandaloneQuery> {
 
 ```ts
 import { describe, it, expect } from "vitest";
-import { wireDomain, defineDomain, DomainShutdownError } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain, DomainShutdownError } from "@noddde/engine";
 import { defineAggregate } from "@noddde/core";
 
 describe("Domain.shutdown", () => {
@@ -168,7 +169,8 @@ describe("Domain.shutdown", () => {
 
 ```ts
 import { describe, it, expect } from "vitest";
-import { wireDomain, defineDomain, DomainShutdownError } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain, DomainShutdownError } from "@noddde/engine";
 
 describe("Domain.shutdown", () => {
   it("should reject queries after shutdown", async () => {
@@ -192,7 +194,8 @@ describe("Domain.shutdown", () => {
 
 ```ts
 import { describe, it, expect, vi } from "vitest";
-import { wireDomain, defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 import { defineAggregate } from "@noddde/core";
 
 describe("Domain.shutdown", () => {
@@ -271,7 +274,8 @@ describe("Domain.shutdown", () => {
 
 ```ts
 import { describe, it, expect } from "vitest";
-import { wireDomain, defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 describe("Domain.shutdown", () => {
   it("should return the same promise when called twice", async () => {
@@ -297,7 +301,8 @@ describe("Domain.shutdown", () => {
 
 ```ts
 import { describe, it, expect, vi } from "vitest";
-import { wireDomain, defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 import type { Closeable } from "@noddde/core";
 
 describe("Domain.shutdown", () => {
@@ -331,7 +336,8 @@ describe("Domain.shutdown", () => {
 
 ```ts
 import { describe, it, expect, vi } from "vitest";
-import { wireDomain, defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 describe("Domain.shutdown", () => {
   it("should close infrastructure in reverse order", async () => {
@@ -374,7 +380,8 @@ describe("Domain.shutdown", () => {
 
 ```ts
 import { describe, it, expect } from "vitest";
-import { wireDomain, defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 import { defineAggregate } from "@noddde/core";
 
 describe("Domain.shutdown", () => {
@@ -419,7 +426,8 @@ describe("Domain.shutdown", () => {
 
 ```ts
 import { describe, it, expect, vi } from "vitest";
-import { wireDomain, defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 describe("Domain.shutdown", () => {
   it("should continue closing remaining infrastructure if one close() throws", async () => {
@@ -466,7 +474,8 @@ describe("Domain.shutdown", () => {
 
 ```ts
 import { describe, it, expect, vi } from "vitest";
-import { wireDomain, defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 import { defineAggregate } from "@noddde/core";
 
 describe("Domain.shutdown", () => {
@@ -526,7 +535,8 @@ describe("Domain.shutdown", () => {
 
 ```ts
 import { describe, it, expect } from "vitest";
-import { wireDomain, defineDomain, DomainShutdownError } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain, DomainShutdownError } from "@noddde/engine";
 
 describe("Domain.shutdown", () => {
   it("should reject withUnitOfWork calls after shutdown", async () => {
@@ -550,7 +560,8 @@ describe("Domain.shutdown", () => {
 
 ```ts
 import { describe, it, expect } from "vitest";
-import { wireDomain, defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 describe("Domain.shutdown", () => {
   it("should resolve immediately when no operations are in-flight", async () => {
@@ -591,7 +602,8 @@ describe("DomainShutdownError", () => {
 
 ```ts
 import { describe, it, expect, vi } from "vitest";
-import { wireDomain, defineDomain, InMemoryOutboxStore } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain, InMemoryOutboxStore } from "@noddde/engine";
 import { defineAggregate } from "@noddde/core";
 import type { Event } from "@noddde/core";
 

--- a/specs/engine/domain.spec.md
+++ b/specs/engine/domain.spec.md
@@ -1,20 +1,21 @@
 ---
-title: "Domain Definition & Wiring"
+title: "Domain Wiring"
 module: engine/domain
 source_file: packages/engine/src/domain.ts
 status: implemented
 exports:
   [
     Domain,
-    DomainDefinition,
-    defineDomain,
     AggregateWiring,
     ProjectionWiring,
     DomainWiring,
     wireDomain,
+    InferDomain,
     InferAggregateMapCommands,
     InferProjectionMapQueries,
   ]
+re_exports:
+  - { from: "@noddde/core", names: [DomainDefinition, defineDomain] }
 depends_on:
   - engine/implementations/ee-event-bus
   - engine/implementations/in-memory-command-bus
@@ -31,6 +32,7 @@ depends_on:
   - ddd/aggregate-root
   - ddd/projection
   - ddd/saga
+  - ddd/domain-definition
   - cqrs/command/command
   - cqrs/query/query
   - edd/event
@@ -45,9 +47,9 @@ docs:
   - read-model/projection-rebuild.mdx
 ---
 
-# Domain Definition & Wiring
+# Domain Wiring
 
-> The domain API is split into two phases: **definition** (`defineDomain`) captures the pure domain structure (aggregates, projections, sagas, handlers) as a sync identity function, while **wiring** (`wireDomain`) connects that definition to infrastructure (persistence, buses, concurrency, snapshots) and returns a running `Domain` instance. This separation allows domain definitions to be shared, tested, and analyzed independently of runtime concerns. The `Domain` class remains the central runtime orchestrator.
+> The domain API is split into two phases. The **definition** phase (`defineDomain` + `DomainDefinition`) captures the pure domain structure (aggregates, projections, sagas, handlers) as a sync identity function and is owned by `@noddde/core` — see [`ddd/domain-definition`](../core/ddd/domain-definition.spec.md). This spec covers the **wiring** phase: `wireDomain` connects a `DomainDefinition` to infrastructure (persistence, buses, concurrency, snapshots) and returns a running `Domain` instance. The `Domain` class is the central runtime orchestrator. For backward compatibility, `@noddde/engine` re-exports `DomainDefinition` and `defineDomain` from `@noddde/core`, so existing `import { defineDomain } from "@noddde/engine"` continues to work.
 
 ## Type Contract
 
@@ -69,97 +71,12 @@ type InferProjectionMapQueries<
 > = TMap[keyof TMap] extends Projection<infer U> ? U["queries"] : never;
 
 /**
- * Pure structural definition of a domain. Contains aggregates, projections,
- * sagas, and handler registrations — no runtime or infrastructure concerns.
+ * `DomainDefinition` and `defineDomain` are owned by `@noddde/core` — see
+ * the [ddd/domain-definition spec](../core/ddd/domain-definition.spec.md).
+ * `@noddde/engine` re-exports both for backward compatibility, so existing
+ * `import { defineDomain, DomainDefinition } from "@noddde/engine"` calls
+ * keep working. New code should prefer `from "@noddde/core"`.
  */
-type DomainDefinition<
-  TInfrastructure extends Infrastructure = Infrastructure,
-  TStandaloneCommand extends Command = Command,
-  TStandaloneQuery extends Query<any> = Query<any>,
-  TAggregates extends AggregateMap = AggregateMap,
-  TStandaloneEvent extends Event = Event,
-  TProjections extends ProjectionMap = ProjectionMap,
-> = {
-  writeModel: {
-    aggregates: TAggregates;
-    standaloneCommandHandlers?: StandaloneCommandHandlerMap<
-      TInfrastructure,
-      TStandaloneCommand
-    >;
-  };
-  readModel: {
-    projections: TProjections;
-    standaloneQueryHandlers?: StandaloneQueryHandlerMap<
-      TInfrastructure,
-      TStandaloneQuery
-    >;
-  };
-  processModel?: {
-    /** A map of saga definitions keyed by saga name. Optional — omit if no sagas. */
-    sagas?: SagaMap;
-    /** Optional map of standalone event handlers keyed by event name. */
-    standaloneEventHandlers?: StandaloneEventHandlerMap<
-      TInfrastructure,
-      TStandaloneEvent
-    >;
-  };
-};
-
-/**
- * Maps event names to standalone event handlers. Each handler receives the
- * full event and infrastructure. Follows the same pattern as
- * StandaloneCommandHandlerMap and StandaloneQueryHandlerMap.
- */
-type StandaloneEventHandlerMap<
-  TInfrastructure extends Infrastructure,
-  TStandaloneEvent extends Event,
-> = {
-  [EventName in TStandaloneEvent["name"]]?: EventHandler<
-    Extract<TStandaloneEvent, { name: EventName }>,
-    TInfrastructure
-  >;
-};
-
-/**
- * Sync identity function that creates a domain definition with full type
- * inference. Consistent with defineAggregate, defineProjection, defineSaga.
- *
- * Overload 1 (preferred): Infers all types from the definition object,
- * preserving narrow aggregate/projection types for typed dispatch.
- *
- * Overload 2 (legacy, deprecated): Explicit infrastructure generic for
- * standalone handler typing. Typed dispatch is NOT available because
- * TypeScript cannot infer TAggregates/TProjections when explicit
- * generics are provided.
- */
-function defineDomain<T extends DomainDefinition<any, any, any, any, any, any>>(
-  definition: T,
-): T;
-/** @deprecated Prefer calling defineDomain({...}) without explicit generics. */
-function defineDomain<
-  TInfrastructure extends Infrastructure,
-  TStandaloneCommand extends Command = Command,
-  TStandaloneQuery extends Query<any> = Query<any>,
-  TAggregates extends AggregateMap = AggregateMap,
-  TStandaloneEvent extends Event = Event,
-  TProjections extends ProjectionMap = ProjectionMap,
->(
-  definition: DomainDefinition<
-    TInfrastructure,
-    TStandaloneCommand,
-    TStandaloneQuery,
-    TAggregates,
-    TStandaloneEvent,
-    TProjections
-  >,
-): DomainDefinition<
-  TInfrastructure,
-  TStandaloneCommand,
-  TStandaloneQuery,
-  TAggregates,
-  TStandaloneEvent,
-  TProjections
->;
 
 /**
  * Per-aggregate runtime configuration. Groups persistence, concurrency,
@@ -326,8 +243,7 @@ class Domain<
 ```
 
 - `InferAggregateMapCommands<TMap>` extracts the union of all command types from a map of aggregates. `InferProjectionMapQueries<TMap>` extracts the union of all query types from a map of projections. Both distribute the corresponding single-aggregate/projection inference across every value in the map.
-- `DomainDefinition` captures the pure domain structure: write model (aggregates + standalone command handlers), read model (projections + standalone query handlers), and process model (sagas). `TInfrastructure` is a type parameter only (handler signatures reference it) — no infrastructure value is present. `TProjections` captures the typed projections map (inferred from `readModel.projections`).
-- `defineDomain` is a sync identity function, consistent with `defineAggregate`, `defineProjection`, `defineSaga`. It returns the input with full type inference. `TAggregates` is inferred from `writeModel.aggregates`, `TProjections` from `readModel.projections`.
+- `DomainDefinition` and `defineDomain` are owned by `@noddde/core`. See [`ddd/domain-definition`](../core/ddd/domain-definition.spec.md) for the full type contract and behavioral requirements. Engine re-exports both names for backward compatibility — they are referenced throughout this spec exactly as if they were defined locally.
 - `AggregateWiring` groups per-aggregate runtime config: persistence, concurrency strategy, and snapshots. All fields optional.
 - `ProjectionWiring` provides per-projection view store wiring. Its `viewStore` field is a {@link ViewStoreFactory} singleton — the only accepted form. The legacy `(infrastructure) => ViewStore` function shorthand has been removed.
 - `DomainWiring` separates user-provided infrastructure (`infrastructure`) from framework plumbing (`aggregates`, `projections`, `sagas`, `buses`, `unitOfWork`, `idempotency`, `outbox`).
@@ -479,10 +395,7 @@ When outbox is configured, after the explicit UoW commits and events are dispatc
 
 ### defineDomain() -- Identity Function
 
-1. Accept a `DomainDefinition` object.
-2. Return the same object unchanged with full type inference.
-3. This is a **sync** function — no async, no side effects, no factories called.
-4. Consistent with `defineAggregate`, `defineProjection`, `defineSaga`.
+`defineDomain` lives in `@noddde/core`. See [`ddd/domain-definition`](../core/ddd/domain-definition.spec.md#behavioral-requirements) for its behavioral requirements. `@noddde/engine` re-exports it unchanged.
 
 ### wireDomain() -- Factory Function
 
@@ -546,7 +459,7 @@ In global mode, the same snapshot config applies to all event-sourced aggregates
 - `dispatchQuery` must not be called before `init()` completes. The `_infrastructure` field (including the query bus) is not assigned until `init()` runs.
 - `init()` must be called exactly once. Calling it multiple times may re-register handlers, causing duplicate processing.
 - `wireDomain` always returns an initialized domain. If `init()` throws, the promise rejects.
-- `defineDomain` is sync, pure, and has no side effects. It returns the input unchanged.
+- `defineDomain` invariants are owned by [`ddd/domain-definition`](../core/ddd/domain-definition.spec.md#invariants). Engine re-exports the function unchanged.
 - The command bus enforces single-handler-per-command-name. If two aggregates define handlers for the same command name, registration must fail.
 - Events are published only after successful persistence. If persistence fails, events must not be published (to avoid inconsistency between the store and downstream subscribers).
 - All events from a command are dispatched sequentially after successful persistence. Event ordering from a single command is preserved — events arrive at consumers in the order they were produced.
@@ -592,7 +505,7 @@ In global mode, the same snapshot config applies to all event-sourced aggregates
 - **wireDomain projection viewStore overrides Projection.viewStore** -- If both `wiring.projections[name].viewStore` and `Projection.viewStore` are set, the wiring version takes priority. Both must be `ViewStoreFactory` instances.
 - **wireDomain projection viewStore not provided for projection with identity** -- Throws an error (same as today when `Projection.viewStore` is missing for a projection with `identity`).
 - **wireDomain projection viewStore as a function** -- Type error at compile time and rejected at runtime: only `ViewStoreFactory` instances (anything with a callable `getForContext` method) are accepted. The legacy `(infra) => ViewStore` shorthand has been removed.
-- **defineDomain called multiple times** -- Each call returns a fresh reference. No state is shared between calls.
+- **defineDomain edge cases** -- See [`ddd/domain-definition`](../core/ddd/domain-definition.spec.md#edge-cases).
 
 ## Integration Points
 
@@ -607,61 +520,14 @@ In global mode, the same snapshot config applies to all event-sourced aggregates
 
 ## Test Scenarios
 
-### defineDomain returns a typed DomainDefinition
-
-```ts
-import { describe, it, expect } from "vitest";
-import { defineDomain, defineAggregate } from "@noddde/engine";
-import type {
-  AggregateTypes,
-  DefineCommands,
-  DefineEvents,
-  Infrastructure,
-} from "@noddde/core";
-
-type CounterState = { count: number };
-type CounterEvent = DefineEvents<{ Incremented: { by: number } }>;
-type CounterCommand = DefineCommands<{ Increment: { by: number } }>;
-type CounterTypes = AggregateTypes & {
-  state: CounterState;
-  events: CounterEvent;
-  commands: CounterCommand;
-  infrastructure: Infrastructure;
-};
-
-const Counter = defineAggregate<CounterTypes>({
-  initialState: { count: 0 },
-  decide: {
-    Increment: (cmd) => ({
-      name: "Incremented",
-      payload: { by: cmd.payload.by },
-    }),
-  },
-  evolve: {
-    Incremented: (payload, state) => ({ count: state.count + payload.by }),
-  },
-});
-
-describe("defineDomain", () => {
-  it("should return the definition unchanged with type inference", () => {
-    const definition = defineDomain<Infrastructure>({
-      writeModel: { aggregates: { Counter } },
-      readModel: { projections: {} },
-    });
-
-    expect(definition.writeModel.aggregates).toEqual({ Counter });
-    expect(definition.readModel.projections).toEqual({});
-    expect(definition.processModel).toBeUndefined();
-  });
-});
-```
+> Test scenarios for `defineDomain` itself (identity, processModel shapes, re-export) live in [`ddd/domain-definition`](../core/ddd/domain-definition.spec.md#test-scenarios). The scenarios below cover `wireDomain` and `Domain` runtime behavior, which exercise `defineDomain` only as a setup primitive.
 
 ### wireDomain creates and initializes a domain from definition + wiring
 
 ```ts
 import { describe, it, expect } from "vitest";
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   Domain,
   EventEmitterEventBus,
@@ -754,8 +620,8 @@ describe("wireDomain", () => {
 
 ```ts
 import { describe, it, expect } from "vitest";
+import { defineDomain, everyNEvents } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   defineAggregate,
   InMemoryEventSourcedAggregatePersistence,
@@ -766,7 +632,6 @@ import {
   InMemoryCommandBus,
   InMemoryQueryBus,
 } from "@noddde/engine";
-import { everyNEvents } from "@noddde/core";
 import type {
   AggregateTypes,
   DefineCommands,
@@ -880,12 +745,8 @@ describe("wireDomain per-aggregate config", () => {
 
 ```ts
 import { describe, it, expect, vi } from "vitest";
-import {
-  defineDomain,
-  wireDomain,
-  Domain,
-  defineAggregate,
-} from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain, Domain, defineAggregate } from "@noddde/engine";
 import type {
   AggregateTypes,
   DefineCommands,
@@ -988,12 +849,8 @@ describe("wireDomain hello world", () => {
 
 ```ts
 import { describe, it, expect } from "vitest";
-import {
-  defineDomain,
-  wireDomain,
-  Domain,
-  defineAggregate,
-} from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain, Domain, defineAggregate } from "@noddde/engine";
 import type {
   AggregateTypes,
   DefineCommands,
@@ -1044,8 +901,8 @@ describe("wireDomain minimal", () => {
 
 ```ts
 import { describe, it, expect } from "vitest";
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   defineAggregate,
   defineProjection,
@@ -1174,8 +1031,8 @@ describe("wireDomain projection wiring", () => {
 
 ```ts
 import { describe, it, expect } from "vitest";
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   defineAggregate,
   EventEmitterEventBus,
@@ -1254,8 +1111,8 @@ describe("wireDomain infrastructure separation", () => {
 
 ```ts
 import { describe, it, expect } from "vitest";
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   defineAggregate,
   EventEmitterEventBus,
@@ -1340,8 +1197,8 @@ describe("standalone event handlers", () => {
 
 ```ts
 import { describe, it, expect, vi } from "vitest";
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   defineAggregate,
   EventEmitterEventBus,
@@ -1420,8 +1277,8 @@ describe("standalone event handlers without sagas", () => {
 
 ```ts
 import { describe, it, expect } from "vitest";
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   defineAggregate,
   EventEmitterEventBus,
@@ -1504,8 +1361,8 @@ describe("async standalone event handler", () => {
 
 ```ts
 import { describe, it, expect } from "vitest";
+import { defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   Domain,
   defineAggregate,
@@ -1571,12 +1428,8 @@ describe("empty standalone event handlers", () => {
 ```ts
 import { describe, it } from "vitest";
 import { expectTypeOf } from "vitest";
-import {
-  defineDomain,
-  wireDomain,
-  defineAggregate,
-  defineProjection,
-} from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain, defineAggregate, defineProjection } from "@noddde/engine";
 import type {
   AggregateTypes,
   DefineCommands,
@@ -1724,7 +1577,8 @@ describe("typed dispatch - aggregate commands", () => {
 ```ts
 import { describe, it } from "vitest";
 import { expectTypeOf } from "vitest";
-import { defineDomain, wireDomain, defineAggregate } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain, defineAggregate } from "@noddde/engine";
 import type {
   AggregateTypes,
   Command,
@@ -1814,7 +1668,8 @@ describe("typed dispatch - standalone commands", () => {
 ```ts
 import { describe, it } from "vitest";
 import { expectTypeOf } from "vitest";
-import { defineDomain, wireDomain, defineProjection } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain, defineProjection } from "@noddde/engine";
 import type {
   DefineEvents,
   DefineQueries,

--- a/specs/engine/executors/saga-executor.spec.md
+++ b/specs/engine/executors/saga-executor.spec.md
@@ -757,9 +757,13 @@ describe("SagaExecutor", () => {
 ```ts
 import { describe, expect, it, vi } from "vitest";
 import type { DefineCommands, DefineEvents, DefineQueries } from "@noddde/core";
-import { defineAggregate, defineProjection, defineSaga } from "@noddde/core";
 import {
+  defineAggregate,
   defineDomain,
+  defineProjection,
+  defineSaga,
+} from "@noddde/core";
+import {
   EventEmitterEventBus,
   InMemoryCommandBus,
   InMemoryEventSourcedAggregatePersistence,

--- a/specs/engine/tracing.spec.md
+++ b/specs/engine/tracing.spec.md
@@ -472,7 +472,8 @@ import type {
   DefineQueries,
   Infrastructure,
 } from "@noddde/core";
-import { defineDomain, wireDomain, InMemoryViewStore } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain, InMemoryViewStore } from "@noddde/engine";
 
 type CounterEvents = DefineEvents<{
   Incremented: { counterId: string };
@@ -605,7 +606,8 @@ import type {
   Infrastructure,
   CQRSInfrastructure,
 } from "@noddde/core";
-import { defineDomain, wireDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
 
 type OrderEvents = DefineEvents<{
   OrderPlaced: { orderId: string };

--- a/specs/integration/outbox-delivery.spec.md
+++ b/specs/integration/outbox-delivery.spec.md
@@ -46,9 +46,8 @@ docs:
 ```ts
 import { describe, it, expect, vi } from "vitest";
 import type { DefineCommands, DefineEvents } from "@noddde/core";
-import { defineAggregate } from "@noddde/core";
+import { defineAggregate, defineDomain } from "@noddde/core";
 import {
-  defineDomain,
   wireDomain,
   InMemoryOutboxStore,
   InMemoryEventSourcedAggregatePersistence,

--- a/specs/integrations/nestjs/noddde-module.spec.md
+++ b/specs/integrations/nestjs/noddde-module.spec.md
@@ -226,8 +226,8 @@ export class NodddeMetadataInterceptor implements NestInterceptor {
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Test } from "@nestjs/testing";
 import { NodddeModule, NODDDE_DOMAIN } from "@noddde/nestjs";
-import { defineDomain, wireDomain } from "@noddde/engine";
-import { defineAggregate, defineProjection } from "@noddde/core";
+import { wireDomain } from "@noddde/engine";
+import { defineAggregate, defineDomain, defineProjection } from "@noddde/core";
 
 describe("NodddeModule", () => {
   it("should create a Domain via forRoot and make it injectable", async () => {
@@ -256,7 +256,7 @@ describe("NodddeModule", () => {
 import { describe, it, expect, vi } from "vitest";
 import { Test } from "@nestjs/testing";
 import { NodddeModule, NODDDE_DOMAIN } from "@noddde/nestjs";
-import { defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
 
 describe("NodddeModule", () => {
   it("should resolve factory with injected deps and create Domain", async () => {
@@ -294,7 +294,7 @@ describe("NodddeModule", () => {
 import { describe, it, expect, vi } from "vitest";
 import { Test } from "@nestjs/testing";
 import { NodddeModule, NODDDE_DOMAIN } from "@noddde/nestjs";
-import { defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
 import type { Domain } from "@noddde/engine";
 
 describe("NodddeModule", () => {
@@ -333,7 +333,7 @@ import {
   NODDDE_QUERY_BUS,
   NODDDE_EVENT_BUS,
 } from "@noddde/nestjs";
-import { defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
 import type { Domain } from "@noddde/engine";
 
 describe("NodddeModule", () => {
@@ -372,7 +372,7 @@ import {
   NODDDE_QUERY_BUS,
   NODDDE_EVENT_BUS,
 } from "@noddde/nestjs";
-import { defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
 
 describe("NodddeModule", () => {
   it("should not register bus tokens when exposeBuses is false", async () => {
@@ -401,7 +401,7 @@ import { describe, it, expect } from "vitest";
 import { Test } from "@nestjs/testing";
 import { Module, Injectable, Inject } from "@nestjs/common";
 import { NodddeModule, NODDDE_DOMAIN } from "@noddde/nestjs";
-import { defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
 import type { Domain } from "@noddde/engine";
 
 @Injectable()
@@ -446,7 +446,7 @@ import {
   NodddeMetadataInterceptor,
 } from "@noddde/nestjs";
 import type { MetadataExtractor } from "@noddde/nestjs";
-import { defineDomain } from "@noddde/engine";
+import { defineDomain } from "@noddde/core";
 import type { Domain } from "@noddde/engine";
 import type { ExecutionContext, CallHandler } from "@nestjs/common";
 import { of } from "rxjs";

--- a/specs/reports/domain-definition.audit-report.md
+++ b/specs/reports/domain-definition.audit-report.md
@@ -1,0 +1,54 @@
+## Audit Report: DomainDefinition & defineDomain — Move to @noddde/core
+
+- **Verdict**: PASS
+- **Cycle**: 1
+- **Spec**: `specs/core/ddd/domain-definition.spec.md`
+- **Build Report**: `specs/reports/domain-definition.build-report.md`
+
+### Mechanical Checks
+
+| Check                 | Result | Details                                                                                         |
+| --------------------- | ------ | ----------------------------------------------------------------------------------------------- |
+| Export coverage       | PASS   | 2/2 exports present (`DomainDefinition`, `defineDomain`); both reachable from `@noddde/core`.   |
+| Stubs remaining       | PASS   | 0 stubs in `packages/core/src/ddd/domain-definition.ts`.                                        |
+| Type check (core)     | PASS   | `npx tsc --noEmit` clean.                                                                       |
+| Type check (engine)   | PASS   | `npx tsc --noEmit` clean.                                                                       |
+| Tests (core)          | PASS   | 27/27 test files, 301/301 tests passing (incl. 8 new domain-definition tests).                  |
+| Tests (engine)        | PASS   | 34/34 test files, 345/345 tests passing.                                                        |
+| Tests (CLI)           | PASS   | 20/20 test files, 191/191 tests passing — template now imports from `@noddde/core`.             |
+| Tests (sample-flash-sale) | PASS | 6/6 test files, 27/27 tests passing.                                                          |
+| Lint                  | PASS   | `yarn lint` zero warnings across all 14 packages.                                               |
+| Re-export check       | PASS   | Engine source re-exports both `defineDomain` and `DomainDefinition` from `@noddde/core`.        |
+| Reference-equality    | PASS   | Verified in production builds via dist (`require('@noddde/engine').defineDomain === require('@noddde/core').defineDomain`); the vitest alias is consistent with this. |
+| Sample compatibility  | PASS   | `samples/sample-flash-sale` tsc + tests pass without any sample code change.                    |
+| Invariants enforced   | PASS   | Identity (reference equality) + sync + pure-no-side-effects all verified by tests.              |
+| Edge cases covered    | PASS   | Empty maps, `processModel` omitted vs `{}`, sagas omitted + standaloneEventHandlers, fresh-reference-per-call. |
+| Prettier (touched src) | PASS  | LF/CRLF differences are a Windows-local working-copy artifact (`core.autocrlf=true`); Git stores LF, so CI sees LF and prettier passes. Confirmed via `git show :file`. |
+
+### Coherence Review
+
+- **Spec intent alignment**: Implementation faithfully reflects the spec's behavioral requirements. `defineDomain` is a single-line identity function `(definition) => definition` with two typed overloads; the `DomainDefinition` shape matches the spec's Type Contract field-for-field. The legacy overload is correctly marked `@deprecated` with a guiding JSDoc.
+- **Unhandled scenarios**: None. All 8 spec scenarios are covered; the four edge-case branches all have either dedicated tests or are covered by passing the same input shape variations through the identity function.
+- **Convention compliance**: Compliant — functional (no classes), JSDoc on `DomainDefinition` and both `defineDomain` overloads, no `console.*`, naming conventions followed (`Define*` identity function pattern matches `defineAggregate`/`defineProjection`/`defineSaga`).
+- **Breaking change propagation**: N/A — this is an additive move. Engine still re-exports both names so all 26 docs pages and the 16 sample files importing `defineDomain` from `@noddde/engine` keep compiling. Build report confirms 14 packages still lint clean and all sample/test suites pass without modification.
+- **Engine spec cross-references**: The engine spec (`specs/engine/domain.spec.md`) now references the core spec at every section where it would otherwise duplicate content (Type Contract block comment, prose discussion below the contract, Behavioral Requirements section header, Invariants, Edge Cases, Test Scenarios preface). No orphan claims about `defineDomain` remain in the engine spec.
+- **File-private helper types**: The three handler-map types (`StandaloneCommandHandlerMap`, `StandaloneQueryHandlerMap`, `StandaloneEventHandlerMap`) are correctly file-private in the new core module (not exported). The engine retains its own private copies of two of them for internal `ExtractStandaloneCommand`/`ExtractStandaloneQuery` inference — they don't conflict because neither is exported from either package, and the two copies are structurally identical, so the engine's inference utilities work the same way regardless of whether they introspect a `DomainDefinition` originating from core or engine.
+- **vitest alias note**: `packages/core/vitest.config.mts` adds `@noddde/engine` → engine source so the re-export reference-equality test resolves at test time. This is a test-config concern only — the property `engineDefineDomain === coreDefineDomain` holds in production too because the engine's runtime export is `export { defineDomain } from "@noddde/core"`, which becomes a live binding in the compiled JS (verified via dist builds: `require('@noddde/engine').defineDomain === require('@noddde/core').defineDomain` returns `true`).
+
+### Documentation
+
+- **Pages updated**: 6
+  - `docs/content/docs/getting-started/quick-start.mdx` — split import: `defineDomain` from `@noddde/core`, `wireDomain` from `@noddde/engine`; updated descriptive paragraph to note canonical location + back-compat.
+  - `docs/content/docs/running/domain-configuration.mdx` — updated `defineDomain` import path to `@noddde/core` (intro section + Complete Example); added one-line note that it lives in core and is re-exported from engine for back-compat.
+  - `docs/content/docs/core-concepts/cqrs-and-event-sourcing.mdx` — split import to show the new canonical location.
+  - `docs/content/docs/modeling/routing-and-dispatch.mdx` — split import similarly.
+  - `packages/engine/README.md` — clarified "What's Inside" bullet: `wireDomain` is the engine's domain-orchestration export; `defineDomain` lives in `@noddde/core` and is re-exported here.
+  - `packages/core/README.md` — added a bullet for `defineDomain` under "What's Inside".
+- **Pages created**: 2
+  - `docs/src/content/docs/api/functions/defineDomain.md` — new function API reference, modeled after `defineAggregate.md`.
+  - `docs/src/content/docs/api/type-aliases/DomainDefinition.md` — new type-alias API reference covering all 6 type parameters and the writeModel/readModel/processModel structure.
+- **API reference index updated**: `docs/src/content/docs/api/README.md` — added `defineDomain` under Functions and `DomainDefinition` under Type Aliases (alphabetically positioned).
+- **CLI template updated**: `packages/cli/src/templates/domain/domain-wiring.ts` — `domainDefinitionTemplate` now generates `import { defineDomain } from "@noddde/core"` so newly scaffolded domains follow the canonical import path. CLI tests still pass (191/191) — the test asserts the symbol is present in output, not its import path.
+- **Pages intentionally not updated**: 22 of 26 `defineDomain`-mentioning docs pages were left alone (low-traffic guides, pattern walkthroughs, testing references, persistence-adapter examples). Per the task calibration ("Update at most the high-traffic pages — don't churn every example"), updates focused on the introductory + canonical pages that readers hit first (quick-start, domain-configuration, CQRS, routing-and-dispatch). The remaining pages continue to work via the engine re-export.
+- **JSDoc examples in adapter packages**: `packages/adapters/{typeorm,prisma,drizzle}/src/index.ts` JSDoc examples still show `import { defineDomain, wireDomain } from "@noddde/engine"`. Skipped per the task calibration (low-priority text updates, technically still correct).
+- **llms.txt**: No structural changes needed — no pages were added, removed, or renamed in `docs/content/docs/`.

--- a/specs/reports/domain-definition.audit-report.md
+++ b/specs/reports/domain-definition.audit-report.md
@@ -7,23 +7,23 @@
 
 ### Mechanical Checks
 
-| Check                 | Result | Details                                                                                         |
-| --------------------- | ------ | ----------------------------------------------------------------------------------------------- |
-| Export coverage       | PASS   | 2/2 exports present (`DomainDefinition`, `defineDomain`); both reachable from `@noddde/core`.   |
-| Stubs remaining       | PASS   | 0 stubs in `packages/core/src/ddd/domain-definition.ts`.                                        |
-| Type check (core)     | PASS   | `npx tsc --noEmit` clean.                                                                       |
-| Type check (engine)   | PASS   | `npx tsc --noEmit` clean.                                                                       |
-| Tests (core)          | PASS   | 27/27 test files, 301/301 tests passing (incl. 8 new domain-definition tests).                  |
-| Tests (engine)        | PASS   | 34/34 test files, 345/345 tests passing.                                                        |
-| Tests (CLI)           | PASS   | 20/20 test files, 191/191 tests passing — template now imports from `@noddde/core`.             |
-| Tests (sample-flash-sale) | PASS | 6/6 test files, 27/27 tests passing.                                                          |
-| Lint                  | PASS   | `yarn lint` zero warnings across all 14 packages.                                               |
-| Re-export check       | PASS   | Engine source re-exports both `defineDomain` and `DomainDefinition` from `@noddde/core`.        |
-| Reference-equality    | PASS   | Verified in production builds via dist (`require('@noddde/engine').defineDomain === require('@noddde/core').defineDomain`); the vitest alias is consistent with this. |
-| Sample compatibility  | PASS   | `samples/sample-flash-sale` tsc + tests pass without any sample code change.                    |
-| Invariants enforced   | PASS   | Identity (reference equality) + sync + pure-no-side-effects all verified by tests.              |
-| Edge cases covered    | PASS   | Empty maps, `processModel` omitted vs `{}`, sagas omitted + standaloneEventHandlers, fresh-reference-per-call. |
-| Prettier (touched src) | PASS  | LF/CRLF differences are a Windows-local working-copy artifact (`core.autocrlf=true`); Git stores LF, so CI sees LF and prettier passes. Confirmed via `git show :file`. |
+| Check                     | Result | Details                                                                                                                                                                 |
+| ------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Export coverage           | PASS   | 2/2 exports present (`DomainDefinition`, `defineDomain`); both reachable from `@noddde/core`.                                                                           |
+| Stubs remaining           | PASS   | 0 stubs in `packages/core/src/ddd/domain-definition.ts`.                                                                                                                |
+| Type check (core)         | PASS   | `npx tsc --noEmit` clean.                                                                                                                                               |
+| Type check (engine)       | PASS   | `npx tsc --noEmit` clean.                                                                                                                                               |
+| Tests (core)              | PASS   | 27/27 test files, 301/301 tests passing (incl. 8 new domain-definition tests).                                                                                          |
+| Tests (engine)            | PASS   | 34/34 test files, 345/345 tests passing.                                                                                                                                |
+| Tests (CLI)               | PASS   | 20/20 test files, 191/191 tests passing — template now imports from `@noddde/core`.                                                                                     |
+| Tests (sample-flash-sale) | PASS   | 6/6 test files, 27/27 tests passing.                                                                                                                                    |
+| Lint                      | PASS   | `yarn lint` zero warnings across all 14 packages.                                                                                                                       |
+| Re-export check           | PASS   | Engine source re-exports both `defineDomain` and `DomainDefinition` from `@noddde/core`.                                                                                |
+| Reference-equality        | PASS   | Verified in production builds via dist (`require('@noddde/engine').defineDomain === require('@noddde/core').defineDomain`); the vitest alias is consistent with this.   |
+| Sample compatibility      | PASS   | `samples/sample-flash-sale` tsc + tests pass without any sample code change.                                                                                            |
+| Invariants enforced       | PASS   | Identity (reference equality) + sync + pure-no-side-effects all verified by tests.                                                                                      |
+| Edge cases covered        | PASS   | Empty maps, `processModel` omitted vs `{}`, sagas omitted + standaloneEventHandlers, fresh-reference-per-call.                                                          |
+| Prettier (touched src)    | PASS   | LF/CRLF differences are a Windows-local working-copy artifact (`core.autocrlf=true`); Git stores LF, so CI sees LF and prettier passes. Confirmed via `git show :file`. |
 
 ### Coherence Review
 

--- a/specs/reports/domain-definition.build-report.md
+++ b/specs/reports/domain-definition.build-report.md
@@ -1,0 +1,118 @@
+# Build Report: DomainDefinition & defineDomain — Move to @noddde/core
+
+**Date**: 2026-05-19
+**Builder**: Claude Sonnet 4.6
+**Spec**: `specs/core/ddd/domain-definition.spec.md`
+**Status**: GREEN
+
+---
+
+## Summary
+
+This is a structural **move**, not new greenfield work. `DomainDefinition` and `defineDomain` (both overloads) were extracted from `packages/engine/src/domain.ts` into a new canonical module `packages/core/src/ddd/domain-definition.ts`. The engine re-exports both from core so all existing `import { defineDomain } from "@noddde/engine"` call sites continue to work without modification.
+
+The `vitest.config.mts` for the core package was updated to alias `@noddde/engine` → the engine source tree, enabling the re-export reference-equality test to pass within the core test suite.
+
+---
+
+## Files Changed
+
+### New Files
+
+- `packages/core/src/ddd/domain-definition.ts` — `DomainDefinition` type, `defineDomain` function (both overloads + implementation), and three file-private helper types (`StandaloneCommandHandlerMap`, `StandaloneQueryHandlerMap`, `StandaloneEventHandlerMap`)
+- `packages/core/src/__tests__/ddd/domain-definition.test.ts` — 8 vitest tests covering all 4 spec scenarios
+
+### Modified Files
+
+- `packages/core/src/ddd/index.ts` — added `export * from "./domain-definition";`
+- `packages/core/vitest.config.mts` — added `@noddde/engine` alias pointing to engine source so cross-package reference-equality test works
+- `packages/engine/src/domain.ts`:
+  - Removed: `DomainDefinition` type, `defineDomain` function (both overloads + implementation), `StandaloneCommandHandlerMap`, `StandaloneQueryHandlerMap`, `StandaloneEventHandlerMap` local type aliases
+  - Added: `import { defineDomain } from "@noddde/core"` and `import type { DomainDefinition } from "@noddde/core"`
+  - Added: `export { defineDomain } from "@noddde/core"` and `export type { DomainDefinition } from "@noddde/core"` (backward-compat re-exports)
+  - Retained: file-private `StandaloneCommandHandlerMap` and `StandaloneQueryHandlerMap` aliases used by `ExtractStandaloneCommand` / `ExtractStandaloneQuery` internal inference utilities
+
+---
+
+## Step 2: Tests Generated (RED)
+
+8 tests generated from spec, grouped into 4 `describe` blocks:
+
+| Scenario heading                                            | Tests | Initial state |
+| ----------------------------------------------------------- | ----- | ------------- |
+| defineDomain (core)                                         | 4     | RED           |
+| defineDomain (core) — legacy overload                       | 1     | RED           |
+| defineDomain (core) — processModel                          | 2     | RED           |
+| defineDomain re-export from @noddde/engine                  | 1     | RED (module resolution issue) |
+
+The re-export test required adding `@noddde/engine` to the core vitest alias config to resolve correctly (without the alias, the test compared source vs. built-dist function instances, which are different objects).
+
+---
+
+## Step 3: Implementation
+
+### Core: `packages/core/src/ddd/domain-definition.ts`
+
+- Three file-private mapped types (`StandaloneCommandHandlerMap`, `StandaloneQueryHandlerMap`, `StandaloneEventHandlerMap`) — identical to the originals in engine but now living in core
+- `DomainDefinition<...>` with inline `Record<string | symbol, Aggregate<any>>` / `Record<string | symbol, Projection<any>>` constraints (not `AggregateMap`/`ProjectionMap` aliases — those remain engine-private)
+- `defineDomain` — two overloads (preferred infer-everything + deprecated explicit-generics), implementation `(definition) => definition`
+
+### Engine: `packages/engine/src/domain.ts`
+
+- Removed the three local handler-map types and the full `DomainDefinition` + `defineDomain` block
+- Added file-private `StandaloneCommandHandlerMap` and `StandaloneQueryHandlerMap` aliases (used by the engine-internal `ExtractStandaloneCommand` / `ExtractStandaloneQuery` infer utilities in `wireDomain`)
+- Added value + type re-exports from core for backward compatibility
+
+---
+
+## Step 4: Test Results
+
+### Core Package
+
+```
+Test Files  27 passed (27)
+Tests       301 passed (301)
+Duration    1.07s
+```
+
+Including 8 new domain-definition tests. `tsc --noEmit` clean.
+
+### Engine Package
+
+```
+Test Files  34 passed (34)
+Tests       345 passed (345)
+Duration    1.66s
+```
+
+All existing engine tests continue to pass via the re-export. `tsc --noEmit` clean.
+
+### Prettier + Lint
+
+- Prettier: applied to all changed files, no remaining diffs
+- `yarn lint` (Turborepo, 14 packages): 14 successful, 0 warnings
+
+---
+
+## Requirements Coverage
+
+| Requirement                                              | Covered |
+| -------------------------------------------------------- | ------- |
+| defineDomain returns same object reference (identity)    | YES     |
+| defineDomain is sync, no side effects                    | YES     |
+| Overload 1: T inferred, narrow types preserved           | YES     |
+| Overload 2: deprecated, explicit generics, typed handler | YES     |
+| processModel optional; omission vs. {} both valid        | YES     |
+| processModel.sagas omitted + standaloneEventHandlers set | YES     |
+| @noddde/engine re-exports defineDomain (same reference)  | YES     |
+| File-private helper types not exported                   | YES (no public exports for handler-map types) |
+| Empty aggregates/projections maps valid                  | YES     |
+
+---
+
+## Notes for Auditor
+
+- `AggregateMap`, `ProjectionMap`, `SagaMap` remain file-private in engine — they are referenced by `DomainWiring`, `ExtractAggregates`, `ExtractProjections`, `ExtractSagas`, and `wireDomain`. Exporting them from core is explicitly out-of-scope per the task instructions.
+- The `defineDomain` import in engine (`import { defineDomain } from "@noddde/core"`) appears in the imports block but is only used for the re-export. ESLint `no-unused-vars` is suppressed at the top of the file (pre-existing `/* eslint-disable no-unused-vars */`).
+- No CLI template changes needed — the `defineDomain` import path in templates is a downstream decision; the re-export from engine keeps all existing templates valid.
+- `packages/core/vitest.config.mts` now aliases `@noddde/engine` — this is intentional and necessary so the re-export test can verify function reference identity without relying on built dist files.

--- a/specs/reports/domain-definition.build-report.md
+++ b/specs/reports/domain-definition.build-report.md
@@ -38,12 +38,12 @@ The `vitest.config.mts` for the core package was updated to alias `@noddde/engin
 
 8 tests generated from spec, grouped into 4 `describe` blocks:
 
-| Scenario heading                                            | Tests | Initial state |
-| ----------------------------------------------------------- | ----- | ------------- |
-| defineDomain (core)                                         | 4     | RED           |
-| defineDomain (core) — legacy overload                       | 1     | RED           |
-| defineDomain (core) — processModel                          | 2     | RED           |
-| defineDomain re-export from @noddde/engine                  | 1     | RED (module resolution issue) |
+| Scenario heading                           | Tests | Initial state                 |
+| ------------------------------------------ | ----- | ----------------------------- |
+| defineDomain (core)                        | 4     | RED                           |
+| defineDomain (core) — legacy overload      | 1     | RED                           |
+| defineDomain (core) — processModel         | 2     | RED                           |
+| defineDomain re-export from @noddde/engine | 1     | RED (module resolution issue) |
 
 The re-export test required adding `@noddde/engine` to the core vitest alias config to resolve correctly (without the alias, the test compared source vs. built-dist function instances, which are different objects).
 
@@ -96,17 +96,17 @@ All existing engine tests continue to pass via the re-export. `tsc --noEmit` cle
 
 ## Requirements Coverage
 
-| Requirement                                              | Covered |
-| -------------------------------------------------------- | ------- |
-| defineDomain returns same object reference (identity)    | YES     |
-| defineDomain is sync, no side effects                    | YES     |
-| Overload 1: T inferred, narrow types preserved           | YES     |
-| Overload 2: deprecated, explicit generics, typed handler | YES     |
-| processModel optional; omission vs. {} both valid        | YES     |
-| processModel.sagas omitted + standaloneEventHandlers set | YES     |
-| @noddde/engine re-exports defineDomain (same reference)  | YES     |
+| Requirement                                              | Covered                                       |
+| -------------------------------------------------------- | --------------------------------------------- |
+| defineDomain returns same object reference (identity)    | YES                                           |
+| defineDomain is sync, no side effects                    | YES                                           |
+| Overload 1: T inferred, narrow types preserved           | YES                                           |
+| Overload 2: deprecated, explicit generics, typed handler | YES                                           |
+| processModel optional; omission vs. {} both valid        | YES                                           |
+| processModel.sagas omitted + standaloneEventHandlers set | YES                                           |
+| @noddde/engine re-exports defineDomain (same reference)  | YES                                           |
 | File-private helper types not exported                   | YES (no public exports for handler-map types) |
-| Empty aggregates/projections maps valid                  | YES     |
+| Empty aggregates/projections maps valid                  | YES                                           |
 
 ---
 


### PR DESCRIPTION
## Summary

- Move `defineDomain` and `DomainDefinition` from `@noddde/engine` to `@noddde/core` — they're pure structural identity types with no runtime dependencies, so they belong in core
- Engine re-exports both for backward compatibility — **no breaking change**: existing `import { defineDomain } from "@noddde/engine"` keeps working
- Sweep all first-party code (samples, framework tests, testing harness, docs, JSDoc, CLI template) to import from `@noddde/core` so the engine re-export is purely external back-compat

## Why

`defineDomain` is a sync identity function — it just returns its input with type inference. All of its type dependencies (`Aggregate`, `Projection`, `Saga`, `Command`, `Query`, `Event`, handler types, `Infrastructure`) already live in `@noddde/core`. Hosting it in the engine forced anyone authoring a domain shape (specs, tests, CLI templates, samples) to pull in the runtime package. After this PR, `@noddde/core` is self-sufficient for everything definition-related; `@noddde/engine` is needed only when you wire infrastructure with `wireDomain`.

## What changed

**Core (new):**
- [`packages/core/src/ddd/domain-definition.ts`](../blob/worktree/gracious-lederberg-d8783e/packages/core/src/ddd/domain-definition.ts) — canonical home, both overloads (legacy marked `@deprecated`)
- [`packages/core/src/__tests__/ddd/domain-definition.test.ts`](../blob/worktree/gracious-lederberg-d8783e/packages/core/src/__tests__/ddd/domain-definition.test.ts) — 8 tests including a re-export reference-equality check

**Engine:**
- [`packages/engine/src/domain.ts`](../blob/worktree/gracious-lederberg-d8783e/packages/engine/src/domain.ts) — local definitions removed; re-exports `defineDomain` + `DomainDefinition` from `@noddde/core`
- File-private `StandaloneCommandHandlerMap` / `StandaloneQueryHandlerMap` kept (used by `ExtractStandaloneCommand`/`ExtractStandaloneQuery` inference)

**Specs:**
- New: [`specs/core/ddd/domain-definition.spec.md`](../blob/worktree/gracious-lederberg-d8783e/specs/core/ddd/domain-definition.spec.md) (`status: implemented`)
- Edited: [`specs/engine/domain.spec.md`](../blob/worktree/gracious-lederberg-d8783e/specs/engine/domain.spec.md) — removed `DomainDefinition`/`defineDomain` from `exports`, added `re_exports` and cross-references
- Build/audit reports under `specs/reports/`

**Sweep (engine re-export now back-compat only):**
- All 5 sample apps, the NestJS integration test, the testing harness, ~10 engine-internal test files
- ~17 docs pages + engine/core READMEs
- CLI template `domain-wiring.ts`
- JSDoc examples in `@noddde/{typeorm,prisma,drizzle}`

**API reference pages added:** `defineDomain.md` and `DomainDefinition.md` under `docs/src/content/docs/api/`.

## Backward compatibility

Verified by `packages/core/src/__tests__/ddd/domain-definition.test.ts` (reference-equality of `engineDefineDomain === coreDefineDomain`). External code importing from `@noddde/engine` is unaffected.

## Test plan

- [ ] `tsc --noEmit` passes in `core`, `engine`, `testing`, `integrations/nestjs`
- [ ] `vitest run` GREEN in `core` (301), `engine` (345), `testing` (41), `integrations/nestjs` (7), `cli` (191)
- [ ] `yarn lint` zero warnings across all 14 packages
- [ ] `npx prettier --check "**/*.{ts,tsx,md,mdx}"` clean
- [ ] Repo-wide search confirms no first-party file imports `defineDomain` from `@noddde/engine` (only the intentional re-export verification test does)

🤖 Generated with [Claude Code](https://claude.com/claude-code)