### PR TITLE
polish(v1): projection handler init refactor + NestJS README + audit annotation

### DIFF
--- a/.changeset/warm-wolves-beg.md
+++ b/.changeset/warm-wolves-beg.md
@@ -1,0 +1,6 @@
+---
+"@noddde/engine": patch
+"@noddde/nestjs": patch
+---
+
+polish(v1): projection handler init refactor + NestJS README + audit annotation

--- a/packages/engine/src/domain.ts
+++ b/packages/engine/src/domain.ts
@@ -777,25 +777,44 @@ export class Domain<
     for (const [name, projection] of Object.entries(
       definition.readModel.projections,
     )) {
-      resolvedProjections.set(name, projection);
       const wiringViewStore = wiring.projections?.[name];
 
       const factory: ViewStoreFactory | undefined =
         wiringViewStore?.viewStore ??
         (projection.viewStore as ViewStoreFactory | undefined);
+
+      let resolvedProjection: Projection<any> = projection;
+
       if (factory) {
         const baseStore = factory.getForContext(undefined);
         resolvedViewStoreFactories.set(name, factory);
         resolvedViewStores.set(name, baseStore);
-        // Default missing id extractors to event.metadata.aggregateId
+
+        // Build an augmented `on` map without mutating the user-provided
+        // projection. Handlers that already have an `id` extractor are
+        // referenced as-is; handlers missing one are shallow-cloned with a
+        // default extractor that reads `event.metadata.aggregateId`. The
+        // user's `definition.readModel.projections[name]` is never modified.
+        let augmentedAny = false;
+        const augmentedOn: Record<string, unknown> = {};
         for (const [eventName, handler] of Object.entries(projection.on)) {
-          if (handler && !(handler as any).id) {
-            domainLog.warn(
-              `Projection "${String(name)}": handler "${eventName}" has no "id" function. ` +
-                `Defaulting to event.metadata.aggregateId. Provide an explicit "id" ` +
-                `extractor if the view key differs from the aggregate ID.`,
-            );
-            (handler as any).id = (event: Event) => {
+          if (!handler) {
+            augmentedOn[eventName] = handler;
+            continue;
+          }
+          if ((handler as { id?: unknown }).id) {
+            augmentedOn[eventName] = handler;
+            continue;
+          }
+          domainLog.warn(
+            `Projection "${String(name)}": handler "${eventName}" has no "id" function. ` +
+              `Defaulting to event.metadata.aggregateId. Provide an explicit "id" ` +
+              `extractor if the view key differs from the aggregate ID.`,
+          );
+          augmentedAny = true;
+          augmentedOn[eventName] = {
+            ...(handler as object),
+            id: (event: Event) => {
               const id = event.metadata?.aggregateId;
               if (id == null) {
                 throw new Error(
@@ -805,10 +824,18 @@ export class Domain<
                 );
               }
               return id;
-            };
-          }
+            },
+          };
+        }
+        if (augmentedAny) {
+          resolvedProjection = {
+            ...projection,
+            on: augmentedOn as typeof projection.on,
+          };
         }
       }
+
+      resolvedProjections.set(name, resolvedProjection);
     }
 
     // Step 5.8b: Resolve outbox store
@@ -1046,9 +1073,12 @@ export class Domain<
     }
 
     // Step 10: Register event listeners for projections
-    for (const [projectionName, projection] of Object.entries(
-      definition.readModel.projections,
-    )) {
+    //
+    // Iterate over `resolvedProjections` (not `definition.readModel.projections`)
+    // so we read from the augmented `on` map built during Step 5.7 — handlers
+    // missing an explicit `id` extractor have the default `event.metadata.aggregateId`
+    // extractor available without mutating the user-provided definition.
+    for (const [projectionName, projection] of resolvedProjections) {
       // Skip strong-consistency projections — they're handled via onEventsProduced
       if (projection.consistency === "strong") continue;
 

--- a/packages/integrations/nestjs/README.md
+++ b/packages/integrations/nestjs/README.md
@@ -1,0 +1,220 @@
+# @noddde/nestjs
+
+NestJS integration for [noddde](https://noddde.dev) — bridges noddde's functional domain model to NestJS dependency injection and lifecycle.
+
+- Calls `wireDomain()` inside a NestJS dynamic module.
+- Registers the `Domain` as a `@Global()` injectable.
+- Calls `domain.shutdown()` automatically on `OnApplicationShutdown`.
+- Optional `NodddeMetadataInterceptor` for propagating correlation/user IDs from HTTP requests into commands.
+
+> **Full guide:** https://noddde.dev/docs/integrations/nestjs
+
+---
+
+## Install
+
+```bash
+yarn add @noddde/nestjs @noddde/core @noddde/engine
+# or
+npm install @noddde/nestjs @noddde/core @noddde/engine
+```
+
+`@nestjs/common` and `@nestjs/core` (>= 10.0.0) are peer dependencies — they must already be installed in your application.
+
+---
+
+## Quick Start
+
+### Static configuration — `forRoot`
+
+Use when your wiring has no NestJS-injected dependencies (e.g. all in-memory):
+
+```ts
+import { Module } from "@nestjs/common";
+import { NodddeModule } from "@noddde/nestjs";
+import { myDomain } from "./domain";
+
+@Module({
+  imports: [NodddeModule.forRoot({ definition: myDomain })],
+})
+export class AppModule {}
+```
+
+### Async configuration — `forRootAsync`
+
+Use when wiring depends on NestJS-managed providers (`ConfigService`, a `DataSource`, a `PrismaClient`, etc.):
+
+```ts
+import { Module } from "@nestjs/common";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import { NodddeModule } from "@noddde/nestjs";
+import { createDrizzleAdapter } from "@noddde/drizzle";
+import { myDomain } from "./domain";
+
+@Module({
+  imports: [
+    ConfigModule.forRoot(),
+    NodddeModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        definition: myDomain,
+        wiring: {
+          persistenceAdapter: createDrizzleAdapter({
+            client: buildDrizzleClient(config.get("DATABASE_URL")!),
+            dialect: "pg",
+          }),
+        },
+      }),
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+---
+
+## Injecting the Domain
+
+The module is registered `@Global()` — `Domain` is injectable from any module without re-importing.
+
+```ts
+import { Controller, Post, Body } from "@nestjs/common";
+import { InjectDomain } from "@noddde/nestjs";
+import type { InferDomain } from "@noddde/nestjs";
+import type { myDomain } from "./domain";
+
+type AppDomain = InferDomain<typeof myDomain>;
+
+@Controller("orders")
+export class OrdersController {
+  constructor(@InjectDomain() private readonly domain: AppDomain) {}
+
+  @Post()
+  async place(@Body() body: { orderId: string; items: string[] }) {
+    await this.domain.dispatchCommand({
+      name: "PlaceOrder",
+      targetAggregateId: body.orderId,
+      payload: { items: body.items },
+    });
+    return { orderId: body.orderId };
+  }
+}
+```
+
+`InferDomain<typeof myDomain>` gives you fully typed `dispatchCommand` / `dispatchQuery` — command names, payloads, and query results are all narrowed at compile time.
+
+---
+
+## Exposing individual buses
+
+When you only need a single bus (e.g. a controller that just dispatches commands), set `exposeBuses: true`:
+
+```ts
+NodddeModule.forRoot({
+  definition: myDomain,
+  exposeBuses: true,
+});
+```
+
+Then inject the bus you need:
+
+```ts
+import {
+  InjectCommandBus,
+  InjectQueryBus,
+  InjectEventBus,
+} from "@noddde/nestjs";
+import type { CommandBus, QueryBus, EventBus } from "@noddde/core";
+
+@Controller()
+export class FooController {
+  constructor(
+    @InjectCommandBus() private readonly commands: CommandBus,
+    @InjectQueryBus() private readonly queries: QueryBus,
+    @InjectEventBus() private readonly events: EventBus,
+  ) {}
+}
+```
+
+Raw injection tokens are also exported (`NODDDE_DOMAIN`, `NODDDE_COMMAND_BUS`, `NODDDE_QUERY_BUS`, `NODDDE_EVENT_BUS`) for advanced use cases.
+
+---
+
+## Correlation IDs — `NodddeMetadataInterceptor`
+
+Wrap your handlers in `domain.withMetadataContext()` so every command dispatched within a request automatically inherits the request's correlation ID, user ID, and causation metadata.
+
+Provide a `MetadataExtractor` that maps your `ExecutionContext` to a noddde `MetadataContext`:
+
+```ts
+import { APP_INTERCEPTOR } from "@nestjs/core";
+import type { ExecutionContext } from "@nestjs/common";
+import { NodddeModule, NodddeMetadataInterceptor } from "@noddde/nestjs";
+import type { MetadataExtractor } from "@noddde/nestjs";
+import { randomUUID } from "node:crypto";
+
+const extractMetadata: MetadataExtractor = (ctx: ExecutionContext) => {
+  const req = ctx.switchToHttp().getRequest();
+  return {
+    correlationId: req.headers["x-correlation-id"] ?? randomUUID(),
+    userId: req.user?.id,
+  };
+};
+
+@Module({
+  imports: [NodddeModule.forRoot({ definition: myDomain })],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useFactory: (extractor: MetadataExtractor) =>
+        new NodddeMetadataInterceptor(
+          extractor /* domain injected automatically */,
+        ),
+      useValue: extractMetadata,
+    },
+  ],
+})
+export class AppModule {}
+```
+
+Every event emitted as a side-effect of a command dispatched inside an HTTP handler will carry the same `correlationId`, propagating through sagas and projections.
+
+---
+
+## Lifecycle
+
+The module installs a private `OnApplicationShutdown` listener that calls `domain.shutdown()` for you. That drains in-flight commands, flushes the outbox relay, lets active sagas finish, and closes infrastructure implementing `Closeable` (event buses, persistence adapters, etc.). Just make sure your Nest app calls `app.enableShutdownHooks()`:
+
+```ts
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module";
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.enableShutdownHooks();
+  await app.listen(3000);
+}
+bootstrap();
+```
+
+---
+
+## What's exported
+
+| Symbol                                                                        | Kind             | Purpose                                                |
+| ----------------------------------------------------------------------------- | ---------------- | ------------------------------------------------------ |
+| `NodddeModule.forRoot`                                                        | static factory   | Synchronous module setup                               |
+| `NodddeModule.forRootAsync`                                                   | static factory   | Async setup with injected dependencies                 |
+| `NodddeMetadataInterceptor`                                                   | class            | Wraps handlers in `domain.withMetadataContext()`       |
+| `InjectDomain`, `InjectCommandBus`, `InjectQueryBus`, `InjectEventBus`        | decorators       | Typed parameter decorators                             |
+| `NODDDE_DOMAIN`, `NODDDE_COMMAND_BUS`, `NODDDE_QUERY_BUS`, `NODDDE_EVENT_BUS` | symbols          | Raw injection tokens                                   |
+| `NodddeModuleOptions`, `NodddeModuleAsyncOptions`                             | interfaces       | Module configuration shapes                            |
+| `MetadataExtractor`                                                           | type             | `(ctx: ExecutionContext) => MetadataContext`           |
+| `InferDomain`                                                                 | type (re-export) | Derive a typed `Domain` from a `defineDomain()` result |
+
+---
+
+## License
+
+MIT © [Nidhal Dogga](https://github.com/dogganidhal)

--- a/specs/reports/engine-parallel-dispatch.audit-report.md
+++ b/specs/reports/engine-parallel-dispatch.audit-report.md
@@ -3,7 +3,23 @@
 **Date**: 2026-04-10
 **Auditor**: Opus 4.6
 **Cycle**: 1
-**Result**: **FAIL**
+**Result**: **FAIL** _(historical — see Resolution below)_
+
+> **Resolution (2026-06-03, v0.3.8):** This FAIL verdict has been resolved by a
+> deliberate spec change, not a code change. After this audit was written, the
+> `saga-executor` spec was updated: requirement #12 in
+> `specs/engine/executors/saga-executor.spec.md` now mandates **sequential**
+> dispatch (`for (const e of events) { await infrastructure.eventBus.dispatch(e); }`)
+> rather than parallel. The justification, captured in the spec, is that
+> sequential dispatch preserves causal ordering of events emitted from a single
+> saga reaction. `saga-executor.ts:160-162` already matches the current spec.
+>
+> The other two dispatch sites flagged in this report (`command-lifecycle-executor.ts:166`
+> and `domain.ts:1332` inside `withUnitOfWork`) remain parallel via
+> `Promise.all(events.map(...))` and continue to match their respective specs.
+>
+> This report is retained for historical traceability of the design decision.
+> It does **not** represent an open issue against the codebase.
 
 ---
 


### PR DESCRIPTION
## Summary

Three small, independent v1-readiness polish items. All three were follow-ups from an objective audit of the framework's stable-v1 candidacy. They are bundled in one PR because each is small on its own; the commits are split per concern for clean review.

## What changed

### 1. `refactor(engine): stop mutating user-provided projection handlers at init` (`e403f33`)

The init loop in `packages/engine/src/domain.ts` was writing a default `id` extractor onto handler objects living in `definition.readModel.projections` via `(handler as any).id = ...`. That breaks the implicit contract that a `defineProjection()` result is immutable — the framework was rewriting user code at startup.

Replaced the in-place mutation with a clone-and-augment pattern:

- Handlers that already declare `id` are referenced as-is (no allocation).
- Handlers missing `id` get a shallow-cloned wrapper carrying the same default `event.metadata.aggregateId` extractor and the same runtime error if the metadata is missing.
- Only if at least one handler needed augmenting does the projection itself get a shallow clone (`{ ...projection, on: augmentedOn }`).
- The augmented projection lands in `resolvedProjections`; the user's `definition.readModel.projections` is never touched.

Step 10 (event-listener registration) now iterates `resolvedProjections` instead of `definition.readModel.projections` so eventual-consistency dispatch reads the augmented `id` extractors. Strong-consistency dispatch already routed through `resolvedProjections` (via the `strongProjections` filter), and `Domain.rebuildProjection` already reads from `this._resolvedProjections`, so both paths transparently see the augmented handlers without further changes.

**Behavior contract preserved exactly** — same warning message, same runtime error, same default extractor semantics.

### 2. `docs(specs): annotate engine-parallel-dispatch audit as historically resolved` (`a85096f`)

`specs/reports/engine-parallel-dispatch.audit-report.md` carries a **FAIL** verdict dated 2026-04-10 — at the time `saga-executor.ts` used a sequential dispatch loop where the spec required `Promise.all`. Resolution was a deliberate spec change (not a code change): `saga-executor.spec.md` req #12 was updated to mandate sequential dispatch on the grounds that it preserves causal ordering of events from a single saga reaction.

The other two dispatch sites in that report (`command-lifecycle-executor.ts:166`, `domain.ts:1332` in `withUnitOfWork`) remain parallel and match their specs.

Added a resolution header at the top of the report so a fresh reader scanning `specs/reports/` does not mistake this for an open issue. The report is retained for historical traceability.

### 3. `docs(nestjs): add package README` (`904f27f`)

`packages/integrations/nestjs` was the only publishable `@noddde` package without a README, so its npm page rendered blank.

Added a focused README covering: install + peer-dep note, `forRoot` / `forRootAsync` with a real Drizzle example, typed injection via `InjectDomain()` + `InferDomain<typeof myDomain>`, the `exposeBuses: true` shorthand and the four `Inject*Bus()` decorators, the `NodddeMetadataInterceptor` correlation-ID pattern, lifecycle (`app.enableShutdownHooks()`), and a reference table of all exported symbols. Points at `https://noddde.dev/docs/integrations/nestjs` for the longer guide.

## Why

These were the lowest-cost items remaining between the current `v0.3.x` line and a credible `v1.0.0-rc.1` tag: a soft-quality refactor (#1), a documentation cleanup that removes a confusing FAIL signal in the spec archive (#2), and a publishing prerequisite (#3). None of them change the public API or alter externally-observable behavior.

## Test plan

- [x] `tsc --noEmit` in `packages/engine` — clean
- [x] `yarn lint` — 14/14 pass, zero warnings
- [x] `yarn build` — 15/15 pass
- [x] `yarn test` — 379/379 engine tests pass; full repo 21/22 (the one failure is an unrelated pre-existing Windows-only `EBUSY` flake on a Prisma SQLite teardown — CI on Linux is unaffected)
- [ ] Reviewer to confirm: NestJS README code samples render correctly on npm preview
- [ ] Reviewer to confirm: the resolution header on the audit report is the right convention (vs. moving the report into an `archive/` subdirectory)

## Notes for reviewer

- The refactor (#1) introduces no new public types or exports. The change is purely internal to `domain.ts`.
- A net reduction in `as any` usage in `domain.ts`: the loop no longer needs the `(handler as any).id = ...` write; the augmented `on` map cast to `typeof projection.on` is the only added cast (and it's narrower-than-`any`).
- The README example uses `createDrizzleAdapter` (verified exported from `@noddde/drizzle`) and an illustrative `buildDrizzleClient` helper the reader is expected to provide — the README does not document Drizzle setup itself, only how the resulting adapter plugs into `NodddeModule.forRootAsync`.
