### PR TITLE
chore(release): enter rc pre-mode for v1.0.0-rc.0

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,25 @@
+{
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "@noddde/docs": "0.0.0",
+    "@noddde/drizzle": "0.3.9",
+    "@noddde/kafka": "0.3.9",
+    "@noddde/nats": "0.3.9",
+    "@noddde/prisma": "0.3.9",
+    "@noddde/rabbitmq": "0.3.9",
+    "@noddde/typeorm": "0.3.9",
+    "@noddde/cli": "0.3.9",
+    "@noddde/core": "0.3.9",
+    "@noddde/engine": "0.3.9",
+    "@noddde/eslint-config": "0.0.1",
+    "@noddde/nestjs": "0.3.9",
+    "@noddde/testing": "0.3.9",
+    "@noddde/testing-integration": "0.0.0",
+    "@noddde/typescript-config": "0.0.0",
+    "@noddde/sample-auction": "0.0.1",
+    "@noddde/sample-flash-sale": "0.0.1",
+    "@noddde/sample-hotel-booking": "0.0.1"
+  },
+  "changesets": []
+}

--- a/.changeset/v1-0-0-rc.md
+++ b/.changeset/v1-0-0-rc.md
@@ -1,0 +1,25 @@
+---
+"@noddde/core": major
+"@noddde/engine": major
+"@noddde/cli": major
+"@noddde/testing": major
+"@noddde/drizzle": major
+"@noddde/prisma": major
+"@noddde/typeorm": major
+"@noddde/rabbitmq": major
+"@noddde/nats": major
+"@noddde/kafka": major
+"@noddde/nestjs": major
+---
+
+First release candidate for v1.0.0.
+
+This kicks off the pre-release cycle ahead of the stable v1.0.0 release. The public API surface is now considered stable; subsequent `rc` builds will focus on stabilization, documentation, and adapter robustness based on community feedback.
+
+Highlights since 0.3.9:
+
+- **Adapters** — pg/mysql portability fixes across Drizzle/Prisma/TypeORM (timestamp encoding, advisory-lock return shapes, optimistic-concurrency detection on mysql2). NATS push consumers now declare an explicit `deliverTo` inbox (required by NATS Server >= 2.10). Kafka `connect()` waits for `GROUP_JOIN` so producers can't publish into the consumer's not-yet-joined window.
+- **Build output** — all packages now ship dual CJS and ESM bundles.
+- **Type system** — stress-tested across core and engine; results captured in `specs/reports/type-perf.md`.
+- **Docs** — full pre-GA audit pass across the documentation site (API drift, naming, broken links, structure).
+- **Integration testing** — adapter integration test suite with testcontainers + path-filtered CI lane.


### PR DESCRIPTION
## Summary

- Enters changesets pre-release mode with the `rc` tag (`.changeset/pre.json`).
- Adds a major-bump changeset (`.changeset/v1-0-0-rc.md`) across all 11 published packages in the fixed group.

Once merged, the `Release` workflow will open a follow-up **"chore(release): version packages"** PR that bumps every fixed package from `0.3.9` → `1.0.0-rc.0` and updates the per-package `CHANGELOG.md`. Merging that second PR triggers `npm publish --tag rc` with provenance plus per-package git tags (e.g. `@noddde/core@1.0.0-rc.0`).

Verified locally by running `yarn changeset version` on a throwaway state — every published package resolved to `1.0.0-rc.0`.

## Notes on naming

Changesets numbers prereleases starting at `.0`, so the first RC published from this branch will be tagged `1.0.0-rc.0`. If you want the very first published RC to read `1.0.0-rc.1` instead, the simplest path is to ship `rc.0` from this PR and then add a no-op changeset (or land any other fix) to produce `rc.1` next.

## Test plan

- [ ] Merge this PR — `Release` workflow opens the version-packages PR
- [ ] Review the version-packages PR diff — confirm every fixed package goes to `1.0.0-rc.0`
- [ ] Confirm `CHANGELOG.md` entries read sensibly
- [ ] Merge the version-packages PR — confirm publish job succeeds and `npm view @noddde/core dist-tags` shows the `rc` tag pointing at `1.0.0-rc.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)