### PR TITLE
docs(site): code-block file titles + vertical stepper for step-by-step guides

### DIFF
--- a/docs/content/docs/core-concepts/cqrs-and-event-sourcing.mdx
+++ b/docs/content/docs/core-concepts/cqrs-and-event-sourcing.mdx
@@ -38,7 +38,7 @@ The write model is where domain logic lives. Its primary building blocks are **a
 
 In the domain definition, the write model is declared under the `writeModel` key:
 
-```typescript
+```typescript title="domain.ts"
 import { defineDomain } from "@noddde/core";
 import { wireDomain } from "@noddde/engine";
 
@@ -70,7 +70,7 @@ The read model consumes events and builds **projections** -- query-optimized dat
 
 For queries that do not belong to any projection, noddde provides **standalone query handlers**.
 
-```typescript
+```typescript title="domain.ts"
 const bankingDomain = defineDomain({
   // ...
   readModel: {
@@ -106,7 +106,7 @@ For a detailed guide on defining sagas, `on` map entries, and handlers, see [Sag
 
 Communication between the write model, read model, and the outside world flows through three buses. Together they form the `CQRSInfrastructure`:
 
-```typescript
+```typescript title="packages/core/src/cqrs/cqrs-infrastructure.ts"
 interface CQRSInfrastructure {
   commandBus: CommandBus;
   eventBus: EventBus;
@@ -116,7 +116,7 @@ interface CQRSInfrastructure {
 
 **CommandBus** routes commands to the correct handler -- either an aggregate's decide handler or a standalone command handler, based on the command's `name`.
 
-```typescript
+```typescript title="packages/core/src/cqrs/command-bus.ts"
 interface CommandBus {
   dispatch(command: Command): Promise<void>;
 }
@@ -124,7 +124,7 @@ interface CommandBus {
 
 **EventBus** distributes events to all interested subscribers. After an aggregate produces events, the framework dispatches each one through the event bus. Every projection with a matching reducer and every saga with a matching association receives it.
 
-```typescript
+```typescript title="packages/core/src/edd/event-bus.ts"
 interface EventBus {
   dispatch<TEvent extends Event>(event: TEvent): Promise<void>;
 }
@@ -132,7 +132,7 @@ interface EventBus {
 
 **QueryBus** routes queries to the appropriate handler and returns the result. It connects the outside world to the read model.
 
-```typescript
+```typescript title="packages/core/src/cqrs/query-bus.ts"
 interface QueryBus {
   dispatch<TQuery extends Query<any>>(
     query: TQuery,
@@ -142,7 +142,7 @@ interface QueryBus {
 
 noddde ships with in-memory implementations of all three buses for development and testing:
 
-```typescript
+```typescript title="main.ts"
 import {
   InMemoryCommandBus,
   EventEmitterEventBus,
@@ -191,7 +191,7 @@ The event stream is an append-only log. Events are never modified or deleted. Ea
 
 noddde supports event sourcing through the `EventSourcedAggregatePersistence` interface:
 
-```typescript
+```typescript title="packages/core/src/persistence/event-sourced-aggregate-persistence.ts"
 interface EventSourcedAggregatePersistence {
   save(
     aggregateName: string,
@@ -212,7 +212,7 @@ When a command arrives for an aggregate instance, the framework follows this seq
 
 The conceptual replay logic looks like this:
 
-```typescript
+```typescript title="replay-state.ts"
 function replayState<T extends AggregateTypes>(
   aggregate: Aggregate<T>,
   events: Event[],
@@ -230,7 +230,7 @@ This is why the evolve handlers in a noddde aggregate are so important. They are
 
 Not every aggregate needs event sourcing. noddde also supports **state-stored persistence**, where the framework saves and loads the final state directly:
 
-```typescript
+```typescript title="packages/core/src/persistence/state-stored-aggregate-persistence.ts"
 interface StateStoredAggregatePersistence {
   save(aggregateName: string, aggregateId: string, state: any): Promise<void>;
   load(aggregateName: string, aggregateId: string): Promise<any>;
@@ -241,7 +241,7 @@ With state-stored persistence, events are still produced by decide handlers and 
 
 The key design choice: **the aggregate definition does not change** between event-sourced and state-stored persistence. The same `defineAggregate` with the same `decide` and `evolve` handlers works with either strategy. The persistence strategy is a deployment decision, not a domain modeling decision.
 
-```typescript
+```typescript title="bank-account/bank-account.ts"
 // This aggregate works identically with either persistence strategy
 const BankAccount = defineAggregate<BankAccountTypes>({
   initialState: { balance: 0, status: "active" },

--- a/docs/content/docs/core-concepts/decider-pattern.mdx
+++ b/docs/content/docs/core-concepts/decider-pattern.mdx
@@ -32,7 +32,7 @@ The flow works as follows: a command arrives, and `decide` examines the current 
 
 Here is a Decider for a simple counter, expressed as plain TypeScript:
 
-```typescript
+```typescript title="counter.ts"
 // The state
 type CounterState = { value: number };
 
@@ -78,7 +78,7 @@ Most DDD frameworks model aggregates as classes with methods that mutate interna
 
 In a traditional OOP framework, you might write something like this:
 
-```typescript
+```typescript title="bank-account-aggregate.ts"
 // Typical OOP aggregate (NOT noddde)
 class BankAccountAggregate extends AggregateRoot {
   private balance: number = 0;
@@ -117,7 +117,7 @@ This approach has several characteristics:
 
 Here is the same domain expressed as a noddde Decider:
 
-```typescript
+```typescript title="bank-account.ts"
 import { defineAggregate, DefineCommands, DefineEvents } from "@noddde/core";
 
 type BankingCommand = DefineCommands<{
@@ -211,7 +211,7 @@ The differences are significant:
 
 Because `decide` and `evolve` are pure functions, testing them requires no setup:
 
-```typescript
+```typescript title="__tests__/authorize-transaction.test.ts"
 import { describe, it, expect } from "vitest";
 
 describe("AuthorizeTransaction", () => {
@@ -252,7 +252,7 @@ No aggregate instantiation, no event store setup, no mock buses. Just function i
 
 Deciders are plain objects. You can combine them, transform them, or wrap them without inheritance hierarchies. For example, you could write a function that adds logging to any aggregate:
 
-```typescript
+```typescript title="with-logging.ts"
 function withLogging<T extends AggregateTypes>(
   aggregate: Aggregate<T>,
 ): Aggregate<T> {
@@ -291,7 +291,7 @@ noddde's `defineAggregate` function maps directly to the three components of a D
 
 The `defineAggregate` function takes a configuration object and returns it with full type inference. It does not add behavior or register anything — it is an identity function that exists solely to provide type checking:
 
-```typescript
+```typescript title="packages/core/src/ddd/aggregate-root.ts"
 export function defineAggregate<T extends AggregateTypes>(
   config: Aggregate<T>,
 ): Aggregate<T> {
@@ -305,7 +305,7 @@ This means the framework has zero runtime overhead in the aggregate definition. 
 
 Rather than passing five positional generic parameters, noddde uses a single types bundle that names each type in the aggregate's type universe:
 
-```typescript
+```typescript title="bank-account/bank-account.ts"
 type BankAccountTypes = {
   state: BankAccountState; // The aggregate's state shape
   commands: BankingCommand; // The discriminated union of commands

--- a/docs/content/docs/core-concepts/id-types.mdx
+++ b/docs/content/docs/core-concepts/id-types.mdx
@@ -7,7 +7,7 @@ description: How noddde supports string, number, and bigint identifiers througho
 
 noddde defines a single type alias that represents the set of serializable identifier types supported by the framework:
 
-```typescript
+```typescript title="packages/core/src/cqrs/id.ts"
 type ID = string | number | bigint;
 ```
 
@@ -31,7 +31,7 @@ Rather than forcing all domains to use strings (and pay the conversion cost), no
 
 ### Commands
 
-```typescript
+```typescript title="packages/core/src/cqrs/command.ts"
 interface AggregateCommand<TID extends ID = string> extends Command {
   targetAggregateId: TID;
 }
@@ -48,7 +48,7 @@ The default is `string`, so existing code that omits the type parameter is unaff
 
 ### Event Metadata
 
-```typescript
+```typescript title="packages/core/src/edd/event-metadata.ts"
 interface EventMetadata {
   eventId: string;
   timestamp: string;
@@ -65,7 +65,7 @@ interface EventMetadata {
 
 ### Persistence Interfaces
 
-```typescript
+```typescript title="packages/core/src/persistence/event-sourced-aggregate-persistence.ts"
 interface EventSourcedAggregatePersistence {
   save(
     aggregateName: string,
@@ -81,7 +81,7 @@ All persistence interfaces accept `ID` for aggregate and saga identifiers. Custo
 
 ### Sagas
 
-```typescript
+```typescript title="packages/core/src/ddd/saga.ts"
 interface Saga<T extends SagaTypes, TSagaId extends ID = string> {
   /* ... */
 }
@@ -98,7 +98,7 @@ function defineSaga<T extends SagaTypes, TSagaId extends ID = string>(
 
 Branded types extending `string`, `number`, or `bigint` satisfy `ID`:
 
-```typescript
+```typescript title="branded-ids.ts"
 type UserId = string & { __brand: "UserId" };
 type AccountId = number & { __brand: "AccountId" };
 
@@ -113,7 +113,7 @@ This means you can use branded types for domain-specific identifier safety while
 
 All generic `ID` parameters default to `string`:
 
-```typescript
+```typescript title="commands/index.ts"
 // These are equivalent:
 type MyCommands = DefineCommands<{ Create: void }>;
 type MyCommands = DefineCommands<{ Create: void }, string>;
@@ -121,7 +121,7 @@ type MyCommands = DefineCommands<{ Create: void }, string>;
 
 Existing code that uses string identifiers requires no changes. To use a different identifier type, provide the type parameter explicitly:
 
-```typescript
+```typescript title="commands/index.ts"
 type MyCommands = DefineCommands<{ Create: void }, number>;
 // targetAggregateId is now `number`
 ```

--- a/docs/content/docs/core-concepts/messages-and-types.mdx
+++ b/docs/content/docs/core-concepts/messages-and-types.mdx
@@ -31,7 +31,7 @@ Every message in noddde follows the same structural pattern: a **name** field th
 
 ### The Command Interface
 
-```typescript
+```typescript title="packages/core/src/cqrs/command.ts"
 interface Command {
   name: string;
   payload?: any;
@@ -43,7 +43,7 @@ The optional `commandId` field enables [idempotent command processing](/docs/run
 
 Commands that target a specific aggregate instance extend this with `targetAggregateId`, which tells the framework which aggregate instance should handle the command:
 
-```typescript
+```typescript title="packages/core/src/cqrs/command.ts"
 interface AggregateCommand<TID extends ID = string> extends Command {
   targetAggregateId: TID;
 }
@@ -53,7 +53,7 @@ Commands that do not target an aggregate (for example, commands handled by stand
 
 ### The Event Interface
 
-```typescript
+```typescript title="packages/core/src/edd/event.ts"
 interface Event {
   name: string;
   payload: any;
@@ -65,7 +65,7 @@ Events have a required `payload` (unlike commands where it is optional) — ever
 
 ### The Query Interface
 
-```typescript
+```typescript title="packages/core/src/cqrs/query.ts"
 interface Query<TResult> {
   name: string;
   payload?: any;
@@ -84,7 +84,7 @@ The `name` field is the key to type safety in noddde. When you define multiple c
 
 Consider a set of banking events:
 
-```typescript
+```typescript title="event-model/index.ts"
 type BankingEvent =
   | { name: "BankAccountCreated"; payload: { id: string } }
   | {
@@ -96,7 +96,7 @@ type BankingEvent =
 
 TypeScript can narrow the type based on the `name` field. Inside a `switch` statement, each `case` branch knows the exact shape of the payload:
 
-```typescript
+```typescript title="describe-event.ts"
 function describeEvent(event: BankingEvent): string {
   switch (event.name) {
     case "BankAccountCreated":
@@ -126,7 +126,7 @@ The `DefineCommands` and `DefineEvents` utility types are the foundation of nodd
 
 Without these utilities, defining a set of typed commands requires writing each variant of the union by hand:
 
-```typescript
+```typescript title="bank-account/commands/index-manual.ts"
 // Without DefineCommands — verbose and error-prone
 type BankingCommand =
   | { name: "CreateBankAccount"; targetAggregateId: string }
@@ -149,7 +149,7 @@ Every variant repeats `targetAggregateId: string`. Commands without payloads mus
 
 With `DefineCommands`, you express the same type as a simple mapping from command names to payload types:
 
-```typescript
+```typescript title="bank-account/bank-account.ts"
 import { DefineCommands, DefineEvents } from "@noddde/core";
 
 // With DefineCommands — concise and correct by construction
@@ -177,7 +177,7 @@ Let's trace through the type transformation for the banking commands above.
 
 The `DefineCommands` type is defined as:
 
-```typescript
+```typescript title="packages/core/src/cqrs/command.ts"
 type DefineCommands<
   TPayloads extends Record<string, any>,
   TID extends ID = string,
@@ -192,7 +192,7 @@ type DefineCommands<
 
 Applied to our input, this produces an intermediate object type:
 
-```typescript
+```typescript title="define-commands-phase-1.ts"
 {
   CreateBankAccount: {
     name: "CreateBankAccount";
@@ -222,7 +222,7 @@ Applied to our input, this produces an intermediate object type:
 
 **Phase 2: Indexed access to union.** The `[keyof TPayloads & string]` at the end indexes into this object type with all keys at once, producing a union of all value types:
 
-```typescript
+```typescript title="define-commands-phase-2.ts"
 | { name: "CreateBankAccount"; targetAggregateId: string }
 | { name: "AuthorizeTransaction"; targetAggregateId: string; payload: { amount: number; merchant: string } }
 | { name: "DepositFunds"; targetAggregateId: string; payload: { amount: number } }
@@ -235,7 +235,7 @@ This is a proper discriminated union with `name` as the discriminant. TypeScript
 
 `DefineEvents` follows the same pattern, but simpler — events always have a payload (no `void` check) and do not carry `targetAggregateId`:
 
-```typescript
+```typescript title="packages/core/src/edd/event.ts"
 type DefineEvents<TPayloads extends Record<string, any>> = {
   [K in keyof TPayloads & string]: { name: K; payload: TPayloads[K] };
 }[keyof TPayloads & string];
@@ -243,7 +243,7 @@ type DefineEvents<TPayloads extends Record<string, any>> = {
 
 For the banking events payload map defined earlier, the result is:
 
-```typescript
+```typescript title="define-events-expanded.ts"
 | { name: "BankAccountCreated"; payload: { id: string } }
 | { name: "TransactionAuthorized"; payload: { id: string; amount: number; merchant: string } }
 | { name: "TransactionDeclined"; payload: { reason: string } }
@@ -269,7 +269,7 @@ This symmetry is intentional. Commands and events are both messages. They follow
 
 The second type parameter `TID` on `DefineCommands` defaults to `string`, but you can use any type that suits your domain:
 
-```typescript
+```typescript title="bank-account/commands/index.ts"
 // UUID-branded type
 type AccountId = string & { __brand: "AccountId" };
 
@@ -288,7 +288,7 @@ type BankingCommand = DefineCommands<
 
 When a command's payload type is `void`, the resulting type has no `payload` field at all. This is not the same as `payload: undefined` — the field is completely absent from the type, which prevents you from accidentally passing data where none is expected:
 
-```typescript
+```typescript title="void-payload-example.ts"
 type MyCommands = DefineCommands<{
   CreateBankAccount: void;
   AuthorizeTransaction: { amount: number; merchant: string };
@@ -313,7 +313,7 @@ const auth: MyCommands = {
 
 When defining an aggregate, you need to specify several related types: the state shape, the command union, the event union, and the infrastructure type. A naive approach would use positional generics:
 
-```typescript
+```typescript title="positional-generics-hypothetical.ts"
 // Hypothetical positional generics — NOT how noddde works
 defineAggregate<
   BankAccountState,
@@ -332,7 +332,7 @@ This is fragile. Five generic parameters in a specific order are hard to read, e
 
 noddde uses a single named types bundle instead:
 
-```typescript
+```typescript title="packages/core/src/ddd/aggregate.ts"
 type AggregateTypes = {
   state: any;
   events: Event;
@@ -343,7 +343,7 @@ type AggregateTypes = {
 
 You define your aggregate's types bundle as a concrete type:
 
-```typescript
+```typescript title="bank-account/bank-account.ts"
 type BankAccountTypes = {
   state: BankAccountState;
   commands: BankingCommand;
@@ -354,7 +354,7 @@ type BankAccountTypes = {
 
 Then pass it as a single generic parameter:
 
-```typescript
+```typescript title="bank-account/bank-account.ts"
 const BankAccount = defineAggregate<BankAccountTypes>({
   initialState: { balance: 0, status: "active" },
   decide: {
@@ -370,7 +370,7 @@ const BankAccount = defineAggregate<BankAccountTypes>({
 
 The `AggregateTypes` bundle is not just a convenience for the developer — it is the mechanism that powers the framework's type inference. The `Aggregate` interface uses the bundle to generate correctly typed handler maps:
 
-```typescript
+```typescript title="packages/core/src/ddd/aggregate.ts"
 // How the framework uses the bundle internally
 type DecideHandlerMap<T extends AggregateTypes> = {
   [K in T["commands"]["name"]]: DecideHandler<
@@ -398,7 +398,7 @@ This means that when you write a decide handler for `AuthorizeTransaction`, Type
 
 You get this without writing a single type annotation on the handler function:
 
-```typescript
+```typescript title="bank-account/bank-account.ts"
 decide: {
   // TypeScript infers all parameter types from the bundle
   AuthorizeTransaction: (command, state, infrastructure) => {
@@ -421,7 +421,7 @@ decide: {
 
 Similarly, in evolve handlers, the event payload type is narrowed per handler:
 
-```typescript
+```typescript title="bank-account/bank-account.ts"
 evolve: {
   // TypeScript knows: event is { amount: number; merchant: string }
   // (the payload of TransactionAuthorized)
@@ -436,7 +436,7 @@ evolve: {
 
 Compare reading the bundle:
 
-```typescript
+```typescript title="bank-account/bank-account.ts"
 type BankAccountTypes = {
   state: BankAccountState;
   commands: BankingCommand;
@@ -447,7 +447,7 @@ type BankAccountTypes = {
 
 Versus reading positional generics:
 
-```typescript
+```typescript title="positional-generics-comparison.ts"
 defineAggregate<BankAccountState, BankingCommand, BankingEvent, string, MyInfrastructure>({...})
 ```
 
@@ -473,7 +473,7 @@ At every step, TypeScript infers the types from the previous step. You declare t
 
 noddde provides utility types for extracting individual types from an aggregate definition. These are useful when you need to reference an aggregate's types outside of the aggregate definition itself — for example, in tests, in projections, or in utility functions.
 
-```typescript
+```typescript title="packages/core/src/ddd/aggregate.ts"
 type InferAggregateState<T extends Aggregate> =
   T extends Aggregate<infer U> ? U["state"] : never;
 
@@ -496,7 +496,7 @@ Use inference helpers when you have an aggregate value (the result of `defineAgg
 
 **Example: Typing a test helper.**
 
-```typescript
+```typescript title="__tests__/apply-events.ts"
 import { InferAggregateState, InferAggregateEvents } from "@noddde/core";
 
 // Extract types from the aggregate value
@@ -513,7 +513,7 @@ function applyEvents(events: BankEvent[]): BankState {
 
 **Example: Typing a projection's event handler.**
 
-```typescript
+```typescript title="handle-event.ts"
 import { InferAggregateEvents } from "@noddde/core";
 
 type AllBankEvents = InferAggregateEvents<typeof BankAccount>;
@@ -534,7 +534,7 @@ function handleEvent(event: AllBankEvents): void {
 
 If you already have the types bundle (e.g., `BankAccountTypes`), you can access the types directly:
 
-```typescript
+```typescript title="types-direct-access.ts"
 // Direct access — no inference helper needed
 type State = BankAccountTypes["state"];
 type Events = BankAccountTypes["events"];
@@ -549,7 +549,7 @@ The inference helpers are for when you only have the aggregate value (the result
 
 The most common mistake when using noddde's type system is over-annotating. You almost never need to write type annotations on handler parameters:
 
-```typescript
+```typescript title="bank-account/bank-account.ts"
 // Unnecessary — TypeScript already knows these types
 decide: {
   AuthorizeTransaction: (
@@ -569,7 +569,7 @@ decide: {
 
 Always assign the types bundle to a named type alias rather than inlining it:
 
-```typescript
+```typescript title="bank-account/bank-account.ts"
 // Good — readable and reusable
 type BankAccountTypes = {
   state: BankAccountState;
@@ -597,7 +597,7 @@ const BankAccount = defineAggregate<{
 
 When your state includes literal types (like status strings), use `as const` to preserve the literal type:
 
-```typescript
+```typescript title="bank-account/state.ts"
 initialState: {
   balance: 0,
   status: "active" as const,  // Type is "active", not string

--- a/docs/content/docs/design-decisions/why-aggregate-types.mdx
+++ b/docs/content/docs/design-decisions/why-aggregate-types.mdx
@@ -11,7 +11,7 @@ noddde uses a single `AggregateTypes` bundle type instead of multiple positional
 
 Without the bundle, a fully typed aggregate definition would require five positional generics:
 
-```ts
+```ts title="define-aggregate.ts"
 // Hypothetical — NOT how noddde works
 function defineAggregate<
   TState,
@@ -52,7 +52,7 @@ This is:
 
 The `AggregateTypes` bundle uses named members:
 
-```ts
+```ts title="bank-account/bank-account.ts"
 type AggregateTypes = {
   state: any;
   events: Event;
@@ -90,7 +90,7 @@ In practice, the extra type declaration serves as a useful summary of the aggreg
 
 ## Example
 
-```ts
+```ts title="bank-account/bank-account.ts"
 // The bundle declares the aggregate's type universe
 type BankAccountTypes = {
   state: BankAccountState;

--- a/docs/content/docs/design-decisions/why-commands-return-events.mdx
+++ b/docs/content/docs/design-decisions/why-commands-return-events.mdx
@@ -7,7 +7,7 @@ description: Why decide handlers return events instead of calling eventBus.dispa
 
 In noddde, decide handlers return the event(s) they produce as a return value. The framework handles persistence and publishing.
 
-```ts
+```ts title="bank-account/bank-account.ts"
 decide: {
   AuthorizeTransaction: (command, state, infra) => {
     return { name: "TransactionAuthorized", payload: { ... } };
@@ -19,7 +19,7 @@ decide: {
 
 In many frameworks, decide handlers call `this.apply()` or `eventBus.dispatch()` directly:
 
-```ts
+```ts title="bank-account-traditional.ts"
 // Traditional approach (NOT how noddde works)
 class BankAccount {
   authorizeTransaction(command, eventBus) {
@@ -47,7 +47,7 @@ This creates problems:
 
 Returning events makes the handler a pure decision function:
 
-```ts
+```ts title="bank-account/bank-account.ts"
 // The handler only decides WHAT happened
 decide: {
   AuthorizeTransaction: (command, state) => {
@@ -82,7 +82,7 @@ These limitations are intentional — they enforce the Decider pattern where eac
 
 ## Example
 
-```ts
+```ts title="bank-account/bank-account.ts"
 // Handler returns single event
 decide: {
   CreateBankAccount: (command) => ({

--- a/docs/content/docs/design-decisions/why-decider.mdx
+++ b/docs/content/docs/design-decisions/why-decider.mdx
@@ -21,7 +21,7 @@ Traditional DDD frameworks model aggregates as classes that extend a base `Aggre
 
 The Decider pattern treats an aggregate as three pure components:
 
-```ts
+```ts title="bank-account/bank-account.ts"
 const BankAccount = defineAggregate<BankAccountTypes>({
   initialState: { balance: 0, transactions: [] },
   decide: {

--- a/docs/content/docs/design-decisions/why-define-commands-events.mdx
+++ b/docs/content/docs/design-decisions/why-define-commands-events.mdx
@@ -11,7 +11,7 @@ noddde provides `DefineCommands` and `DefineEvents` utility types that build dis
 
 The traditional approach to typed commands/events requires three things for each message:
 
-```ts
+```ts title="event-model-traditional.ts"
 // Step 1: Enum for names
 enum BankAccountEvents {
   BankAccountCreated = "BankAccountCreated",
@@ -51,7 +51,7 @@ This is:
 
 `DefineEvents` collapses all three declarations into one:
 
-```ts
+```ts title="event-model/index.ts"
 type BankAccountEvent = DefineEvents<{
   BankAccountCreated: { id: string };
   TransactionAuthorized: { id: string; amount: number; merchant: string };
@@ -67,7 +67,7 @@ This single declaration:
 
 `DefineCommands` works the same way, with the addition of `targetAggregateId`:
 
-```ts
+```ts title="bank-account/commands/index.ts"
 type BankAccountCommand = DefineCommands<{
   CreateBankAccount: void; // void = no payload
   AuthorizeTransaction: { amount: number; merchant: string };
@@ -78,7 +78,7 @@ type BankAccountCommand = DefineCommands<{
 
 The mapped type transformation step by step:
 
-```ts
+```ts title="define-events-expansion.ts"
 // Input: payload map
 { BankAccountCreated: { id: string }; TransactionAuthorized: { ... }; }
 
@@ -95,7 +95,7 @@ The mapped type transformation step by step:
 
 The result is a proper discriminated union where `name` is the discriminant. TypeScript narrows the type in `switch` statements:
 
-```ts
+```ts title="narrowing-example.ts"
 switch (event.name) {
   case "BankAccountCreated":
     // TypeScript knows event.payload is { id: string }
@@ -114,7 +114,7 @@ switch (event.name) {
 
 ## Example: Before and After
 
-```ts
+```ts title="before-and-after.ts"
 // Before: ~30 lines, 3 declarations, name appears 3 times
 enum Events {
   Created = "Created",

--- a/docs/content/docs/design-decisions/why-extracted-handlers.mdx
+++ b/docs/content/docs/design-decisions/why-extracted-handlers.mdx
@@ -7,8 +7,7 @@ description: Why noddde recommends extracting decide handlers, evolve handlers, 
 
 noddde recommends extracting all handlers -- decide handlers, evolve handlers, saga on-entries, projection event handlers, and query handlers -- into standalone functions in separate files, typed with the `Infer*Handler` utilities.
 
-```ts
-// deciders/decide-place-bid.ts
+```ts title="auction/deciders/decide-place-bid.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { AuctionTypes } from "../auction";
 
@@ -23,8 +22,7 @@ export const decidePlaceBid: InferDecideHandler<AuctionTypes, "PlaceBid"> = (
 
 The aggregate (or saga, or projection) definition becomes a clean wiring file:
 
-```ts
-// auction.ts
+```ts title="auction/auction.ts"
 export const Auction = defineAggregate<AuctionTypes>({
   initialState,
   decide: {
@@ -57,7 +55,7 @@ Inline handlers concentrate all business logic in a single file. As aggregates g
 
 Each handler is a plain function that can be tested in isolation. Pass in a command, a state snapshot, and (for decide handlers) an infrastructure stub -- assert on the returned events or new state. No aggregate wiring needed:
 
-```ts
+```ts title="__tests__/decide-place-bid.test.ts"
 import { decidePlaceBid } from "./deciders/decide-place-bid";
 
 it("should reject bids below the starting price", () => {
@@ -102,7 +100,7 @@ Changes to one handler do not require reading through a large file. Each handler
 
 For aggregates with 1-2 trivial handlers (e.g., a no-op evolve handler or a simple pass-through command), inline is acceptable:
 
-```ts
+```ts title="counter.ts"
 export const Counter = defineAggregate<CounterTypes>({
   initialState: { count: 0 },
   decide: {

--- a/docs/content/docs/design-decisions/why-id-not-in-state.mdx
+++ b/docs/content/docs/design-decisions/why-id-not-in-state.mdx
@@ -7,7 +7,7 @@ description: Why noddde keeps the aggregate identifier on commands rather than i
 
 In noddde, the aggregate identifier lives on the command as `targetAggregateId`, not inside the aggregate's state object.
 
-```ts
+```ts title="bank-account/state.ts"
 // The ID is on the command
 { name: "CreateBankAccount", targetAggregateId: "acc-123" }
 
@@ -23,7 +23,7 @@ interface BankAccountState {
 
 If the ID is part of aggregate state, `initialState` becomes awkward:
 
-```ts
+```ts title="bank-account/state-with-id.ts"
 // Problematic: what goes in the id field?
 initialState: {
   id: ???,         // Empty string? null? placeholder?
@@ -55,7 +55,7 @@ Keeping the ID on commands:
 
 When a decide handler needs the aggregate ID (e.g., to include it in event payloads), it reads it from the command:
 
-```ts
+```ts title="bank-account/bank-account.ts"
 decide: {
   CreateBankAccount: (command) => ({
     name: "BankAccountCreated",
@@ -71,7 +71,7 @@ decide: {
 
 ## Example
 
-```ts
+```ts title="bank-account/bank-account.ts"
 // Commands carry the ID
 await domain.dispatchCommand({
   name: "AuthorizeTransaction",

--- a/docs/content/docs/design-decisions/why-injectable-infrastructure.mdx
+++ b/docs/content/docs/design-decisions/why-injectable-infrastructure.mdx
@@ -7,7 +7,7 @@ description: Why noddde uses function parameter injection instead of dependency 
 
 noddde injects infrastructure into handlers as function parameters. No DI container, no decorators, no service locator, no global state.
 
-```ts
+```ts title="auction/auction.ts"
 decide: {
   PlaceBid: (command, state, { clock }) => {
     const now = clock.now();
@@ -20,7 +20,7 @@ decide: {
 
 Domain logic that directly imports its dependencies is hard to test:
 
-```ts
+```ts title="bank-account-direct-imports.ts"
 // Problematic: direct import
 import { db } from "./database";
 import { logger } from "./logger";
@@ -50,7 +50,7 @@ To test this handler, you need to:
 
 Function parameter injection is the simplest possible dependency injection:
 
-```ts
+```ts title="auction/auction.ts"
 // Infrastructure is declared as a type
 interface AuctionInfrastructure {
   clock: Clock;
@@ -75,7 +75,7 @@ Benefits:
 
 ## Testing Comparison
 
-```ts
+```ts title="__tests__/authorize-transaction.test.ts"
 // With module mocking (complex)
 jest.mock("./database", () => ({ getRate: () => 1.5 }));
 jest.mock("./logger", () => ({ info: jest.fn() }));
@@ -95,7 +95,7 @@ const result = BankAccount.commands.AuthorizeTransaction(command, state, {
 
 Infrastructure is created once in the domain configuration and injected everywhere:
 
-```ts
+```ts title="domain.ts"
 infrastructure: () => ({
   clock: new SystemClock(),        // Production: real clock
   // OR
@@ -115,7 +115,7 @@ These trade-offs are intentional. Explicit wiring is easier to understand, debug
 
 ## Example
 
-```ts
+```ts title="infrastructure/index.ts"
 // Define what you need
 interface BankingInfrastructure {
   logger: Logger;

--- a/docs/content/docs/design-decisions/why-pure-apply-handlers.mdx
+++ b/docs/content/docs/design-decisions/why-pure-apply-handlers.mdx
@@ -7,7 +7,7 @@ description: Why noddde requires evolve handlers to be pure functions with no in
 
 Evolve handlers in noddde are pure functions that receive only the event payload and current state, returning the new state. They have no access to infrastructure, no async capability, and must produce no side effects.
 
-```ts
+```ts title="types.ts"
 type EvolveHandler<TEvent extends Event, TState> = (
   event: TEvent["payload"],
   state: TState,
@@ -18,7 +18,7 @@ type EvolveHandler<TEvent extends Event, TState> = (
 
 If evolve handlers could access infrastructure (databases, APIs, time), event replay becomes non-deterministic:
 
-```ts
+```ts title="bank-account/evolve-impure.ts"
 // Dangerous: evolve handler with side effects (NOT how noddde works)
 evolve: {
   TransactionAuthorized: (event, state, { exchangeRateService }) => {
@@ -54,7 +54,7 @@ This guarantee is foundational to event sourcing:
 
 If your state transition needs external data, capture it in the **event payload** at decision time (in the decide handler), not at replay time (in the evolve handler):
 
-```ts
+```ts title="bank-account/bank-account.ts"
 // Decide handler captures all needed data AT DECISION TIME
 decide: {
   AuthorizeTransaction: (command, state, { exchangeRateService }) => {
@@ -89,7 +89,7 @@ The decide handler is allowed to be impure (it has infrastructure access). The e
 
 ## Example
 
-```ts
+```ts title="bank-account/bank-account.ts"
 // Pure evolve handler — same inputs always produce same outputs
 evolve: {
   TransactionAuthorized: (event, state) => ({

--- a/docs/content/docs/design-decisions/why-sagas-return-commands.mdx
+++ b/docs/content/docs/design-decisions/why-sagas-return-commands.mdx
@@ -7,7 +7,7 @@ description: Why saga event handlers return a SagaReaction instead of dispatchin
 
 Saga event handlers return a `SagaReaction<TState, TCommands>` (state + commands) rather than dispatching commands imperatively through the `CommandBus`.
 
-```ts
+```ts title="order-fulfillment/saga.ts"
 // noddde approach: declarative return
 PaymentCompleted: {
   id: (event) => event.payload.referenceId,
@@ -43,7 +43,7 @@ This consistency makes the framework predictable: **handlers declare outputs, th
 
 With declarative returns, testing is trivial:
 
-```ts
+```ts title="__tests__/order-fulfillment-saga.test.ts"
 const reaction = OrderFulfillmentSaga.on.PaymentCompleted!.handle(
   event,
   state,

--- a/docs/content/docs/design-decisions/why-state-mapper.mdx
+++ b/docs/content/docs/design-decisions/why-state-mapper.mdx
@@ -7,12 +7,20 @@ description: Why noddde uses a bi-directional mapper to bridge aggregate state a
 
 When an aggregate uses a dedicated state table, noddde requires a `mapper` (`DrizzleStateMapper`, `PrismaStateMapper`, or `TypeORMStateMapper`) that defines how aggregate state translates to and from rows. The framework writes the `aggregateId` and `version` columns; the mapper owns everything else.
 
-```ts
+```ts title="order/state-mapper.ts"
 const orderMapper: DrizzleStateMapper<OrderState, typeof orders> = {
   aggregateIdColumn: orders.aggregateId,
   versionColumn: orders.version,
-  toRow: (s) => ({ customerId: s.customerId, total: s.total, status: s.status }),
-  fromRow: (r) => ({ customerId: r.customerId!, total: r.total!, status: r.status! }),
+  toRow: (s) => ({
+    customerId: s.customerId,
+    total: s.total,
+    status: s.status,
+  }),
+  fromRow: (r) => ({
+    customerId: r.customerId!,
+    total: r.total!,
+    status: r.status!,
+  }),
 };
 
 adapter.stateStored(orders, { mapper: orderMapper });

--- a/docs/content/docs/design-decisions/why-two-persistence-strategies.mdx
+++ b/docs/content/docs/design-decisions/why-two-persistence-strategies.mdx
@@ -27,7 +27,7 @@ On the other hand, state-stored-only frameworks cannot provide audit trails, eve
 
 The same aggregate definition works with either strategy:
 
-```ts
+```ts title="bank-account/bank-account.ts"
 // This aggregate works with EITHER persistence strategy
 export const BankAccount = defineAggregate<BankAccountTypes>({
   initialState: { ... },
@@ -38,7 +38,7 @@ export const BankAccount = defineAggregate<BankAccountTypes>({
 
 The choice is made at wiring time:
 
-```ts
+```ts title="main.ts"
 import { wireDomain } from "@noddde/engine";
 
 // Event sourcing — store events, replay on load
@@ -75,7 +75,7 @@ For the per-strategy decision matrix, see [Persistence — Decision Matrix](/doc
 
 ## Example
 
-```ts
+```ts title="main.ts"
 import { defineDomain } from "@noddde/core";
 import { wireDomain } from "@noddde/engine";
 

--- a/docs/content/docs/event-bus/custom-event-bus.mdx
+++ b/docs/content/docs/event-bus/custom-event-bus.mdx
@@ -7,7 +7,7 @@ Implement the `EventBus` interface to integrate any transport that isn't covered
 
 You can implement the `EventBus` interface directly for any message transport. If your bus needs an async connection step, also implement `Connectable` — the Domain will auto-call `connect()` during wiring:
 
-```ts
+```ts title="adapters/redis-event-bus.ts"
 import type {
   EventBus,
   AsyncEventHandler,

--- a/docs/content/docs/event-bus/in-memory.mdx
+++ b/docs/content/docs/event-bus/in-memory.mdx
@@ -7,7 +7,7 @@ The in-memory event bus is the default implementation shipped with `@noddde/engi
 
 The default event bus, included in `@noddde/engine`. No external dependencies required.
 
-```ts
+```ts title="infrastructure/event-bus.ts"
 import { EventEmitterEventBus } from "@noddde/engine";
 
 const eventBus = new EventEmitterEventBus();
@@ -17,7 +17,7 @@ This is the right choice for development, testing, and single-process deployment
 
 ## Configuration
 
-```ts
+```ts title="infrastructure/event-bus.ts"
 import { EventEmitterEventBus } from "@noddde/engine";
 
 const eventBus = new EventEmitterEventBus({

--- a/docs/content/docs/event-bus/kafka.mdx
+++ b/docs/content/docs/event-bus/kafka.mdx
@@ -13,7 +13,7 @@ yarn add @noddde/kafka kafkajs
 
 ## Configuration
 
-```ts
+```ts title="infrastructure/event-bus.ts"
 import { KafkaEventBus } from "@noddde/kafka";
 
 const eventBus = new KafkaEventBus({
@@ -52,7 +52,7 @@ const eventBus = new KafkaEventBus({
 
 ## Wiring with Domain
 
-```ts
+```ts title="main.ts"
 import { wireDomain } from "@noddde/engine";
 import { KafkaEventBus } from "@noddde/kafka";
 

--- a/docs/content/docs/event-bus/nats.mdx
+++ b/docs/content/docs/event-bus/nats.mdx
@@ -13,7 +13,7 @@ yarn add @noddde/nats nats
 
 ## Configuration
 
-```ts
+```ts title="infrastructure/event-bus.ts"
 import { NatsEventBus } from "@noddde/nats";
 
 const eventBus = new NatsEventBus({
@@ -49,7 +49,7 @@ const eventBus = new NatsEventBus({
 
 ## Wiring with Domain
 
-```ts
+```ts title="main.ts"
 import { wireDomain } from "@noddde/engine";
 import { NatsEventBus } from "@noddde/nats";
 

--- a/docs/content/docs/event-bus/rabbitmq.mdx
+++ b/docs/content/docs/event-bus/rabbitmq.mdx
@@ -14,7 +14,7 @@ yarn add -D @types/amqplib
 
 ## Configuration
 
-```ts
+```ts title="infrastructure/event-bus.ts"
 import { RabbitMqEventBus } from "@noddde/rabbitmq";
 
 const eventBus = new RabbitMqEventBus({
@@ -56,7 +56,7 @@ const eventBus = new RabbitMqEventBus({
 
 ## Wiring with Domain
 
-```ts
+```ts title="main.ts"
 import { wireDomain } from "@noddde/engine";
 import { RabbitMqEventBus } from "@noddde/rabbitmq";
 

--- a/docs/content/docs/getting-started/introduction.mdx
+++ b/docs/content/docs/getting-started/introduction.mdx
@@ -13,7 +13,7 @@ Three structural concepts — Aggregate, Projection, Saga — and the two messag
 
 A consistency boundary. Processes commands, enforces invariants, produces events. Defined as `initialState + decide + evolve`:
 
-```ts
+```ts title="bank-account/bank-account.ts"
 const BankAccount = defineAggregate<BankAccountTypes>({
   initialState: { balance: 0 },
   decide: {
@@ -35,7 +35,7 @@ const BankAccount = defineAggregate<BankAccountTypes>({
 
 Imperative. The thing the user is asking the aggregate to do.
 
-```ts
+```ts title="bank-account/commands/index.ts"
 type BankAccountCommand = DefineCommands<{
   CreateBankAccount: void;
   AuthorizeTransaction: { amount: number; merchant: string };
@@ -48,7 +48,7 @@ Carries a `name`, a `targetAggregateId`, and an optional `payload`. → [Message
 
 Past-tense fact. The thing that actually happened.
 
-```ts
+```ts title="event-model/index.ts"
 type BankAccountEvent = DefineEvents<{
   BankAccountCreated: { id: string };
   TransactionAuthorized: { id: string; amount: number; merchant: string };
@@ -61,7 +61,7 @@ Immutable. Persisted. Replayed by `evolve` to rebuild state on load.
 
 The query side of CQRS. Builds read-optimized views from event streams.
 
-```ts
+```ts title="bank-account-projection/bank-account-projection.ts"
 const BankAccountProjection = defineProjection<BankAccountProjectionDef>({
   on: {
     TransactionAuthorized: {
@@ -83,7 +83,7 @@ const BankAccountProjection = defineProjection<BankAccountProjectionDef>({
 
 Process manager. Listens to events, emits commands. The structural inverse of an aggregate.
 
-```ts
+```ts title="order-fulfillment/saga.ts"
 const OrderFulfillmentSaga = defineSaga<OrderFulfillmentSagaDef>({
   initialState: { status: null },
   startedBy: ["OrderPlaced"],
@@ -105,7 +105,7 @@ const OrderFulfillmentSaga = defineSaga<OrderFulfillmentSagaDef>({
 
 `defineDomain` captures the structure; `wireDomain` plugs in infrastructure:
 
-```ts
+```ts title="domain.ts"
 const myDomain = defineDomain({
   writeModel: { aggregates: { BankAccount } },
   readModel: { projections: { BankAccount: BankAccountProjection } },

--- a/docs/content/docs/getting-started/project-structure.mdx
+++ b/docs/content/docs/getting-started/project-structure.mdx
@@ -105,8 +105,7 @@ Each aggregate owns its type unions. The aggregate file imports event payloads f
 
 **Decide handlers** and **evolve handlers** are standalone exported functions typed with `InferDecideHandler` and `InferEvolveHandler`. They are imported into the `defineAggregate` `decide` and `evolve` maps. This keeps each handler individually testable and the aggregate definition concise:
 
-```ts
-// deciders/decide-create-hotel-booking.ts
+```ts title="hotel-booking/deciders/decide-create-hotel-booking.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { HotelBookingTypes } from "../hotel-booking.js";
 
@@ -169,8 +168,7 @@ export const HotelBooking = defineAggregate<HotelBookingTypes>({
 
 Projections follow the same extraction pattern as aggregates. **Query handlers** are typed with `InferProjectionQueryHandler` and **on-entries** are the event reducers that build the view. Both are standalone functions imported into the `defineProjection` `queryHandlers` and `on` maps:
 
-```ts
-// on-entries/on-hotel-booking-created.ts
+```ts title="hotel-booking/on-entries/on-hotel-booking-created.ts"
 import type { InferProjectionEventHandler } from "@noddde/core";
 import type { HotelBookingProjectionDef } from "../hotel-booking.js";
 
@@ -221,8 +219,7 @@ export const HotelBookingProjection =
 
 Sagas follow the same extraction pattern. **On-entries** are standalone `{ id, handle }` objects typed with `InferSagaOnEntry`, imported into the `defineSaga` `on` map. Each on-entry specifies how to extract the saga ID from the event and how to handle the transition:
 
-```ts
-// on-entries/on-order-placed.ts
+```ts title="booking-fulfillment/on-entries/on-order-placed.ts"
 import type { InferSagaOnEntry } from "@noddde/core";
 import type { BookingFulfillmentDef } from "../saga.js";
 
@@ -266,7 +263,7 @@ The `process-model/` directory is created empty when scaffolding a project or do
 
 The `defineDomain` call captures the pure domain structure — aggregates, projections, and sagas — without any infrastructure or runtime concerns:
 
-```ts
+```ts title="domain.ts"
 export const hotelBookingDomain = defineDomain({
   writeModel: { aggregates: { HotelBooking } },
   readModel: { projections: { HotelBooking: HotelBookingProjection } },
@@ -285,7 +282,7 @@ This is a sync identity function. It returns the input with full type inference.
 
 Defines the domain-wide infrastructure interface that gets passed to all handlers:
 
-```ts
+```ts title="infrastructure/index.ts"
 export interface HotelBookingInfrastructure extends Infrastructure {
   // clock, logger, external services, etc.
 }
@@ -299,7 +296,7 @@ export interface HotelBookingInfrastructure extends Infrastructure {
 
 Wires the domain to runtime infrastructure using `wireDomain`:
 
-```ts
+```ts title="main.ts"
 const domain = await wireDomain(hotelBookingDomain, {
   infrastructure: () => ({
     /* implementations */
@@ -325,7 +322,7 @@ noddde new saga BookingFulfillment
 
 Then wire them into `domain.ts`:
 
-```ts
+```ts title="domain.ts"
 import { Room } from "./write-model/aggregates/room/index.js";
 import { RoomAvailabilityProjection } from "./read-model/projections/room-availability/index.js";
 import { BookingFulfillmentSaga } from "./process-model/booking-fulfillment/index.js";

--- a/docs/content/docs/getting-started/quick-start.mdx
+++ b/docs/content/docs/getting-started/quick-start.mdx
@@ -205,11 +205,15 @@ This example uses optimistic concurrency with no retries. For high-contention ag
 
 Now that you have seen the whole file, here is each part on its own.
 
-### 1. Events — `DefineEvents`
+<Steps>
+
+<Step>
+
+### Events — `DefineEvents`
 
 Events are immutable facts. `DefineEvents` turns a name → payload map into a discriminated union:
 
-```ts
+```ts title="account.ts"
 type BankAccountEvent = DefineEvents<{
   BankAccountCreated: { id: string };
   TransactionAuthorized: {
@@ -223,22 +227,30 @@ type BankAccountEvent = DefineEvents<{
 
 Each key becomes the event's `name` discriminant; the value becomes its `payload`.
 
-### 2. Commands — `DefineCommands`
+</Step>
+
+<Step>
+
+### Commands — `DefineCommands`
 
 Commands express intent. `void` means no payload — just a name and a `targetAggregateId`:
 
-```ts
+```ts title="account.ts"
 type BankAccountCommand = DefineCommands<{
   CreateBankAccount: void;
   AuthorizeTransaction: { amount: number; merchant: string };
 }>;
 ```
 
-### 3. State
+</Step>
+
+<Step>
+
+### State
 
 State holds everything `decide` reads to make decisions. The aggregate ID is **not** part of state — it lives on the command as `targetAggregateId`. See [Why ID Not in State](/docs/design-decisions/why-id-not-in-state).
 
-```ts
+```ts title="account.ts"
 interface BankAccountState {
   balance: number;
   availableBalance: number;
@@ -248,11 +260,15 @@ interface BankAccountState {
 }
 ```
 
-### 4. The `Types` bundle
+</Step>
+
+<Step>
+
+### The `Types` bundle
 
 One type that ties state, events, commands, and any custom infrastructure together. This single type replaces five positional generic parameters elsewhere in the framework. See [Why AggregateTypes Bundle](/docs/design-decisions/why-aggregate-types).
 
-```ts
+```ts title="account.ts"
 type BankAccountTypes = {
   state: BankAccountState;
   events: BankAccountEvent;
@@ -261,11 +277,15 @@ type BankAccountTypes = {
 };
 ```
 
-### 5. The aggregate — `defineAggregate`
+</Step>
+
+<Step>
+
+### The aggregate — `defineAggregate`
 
 Three things: `initialState`, a `decide` map (command name → handler returning events), and an `evolve` map (event name → pure state transition).
 
-```ts
+```ts title="account.ts"
 const BankAccount = defineAggregate<BankAccountTypes>({
   initialState: {
     /* ... */
@@ -281,11 +301,15 @@ const BankAccount = defineAggregate<BankAccountTypes>({
 
 `decide` is where business rules live — it can call infrastructure and return one or many events. `evolve` is pure: same event + state always produces the same next state. The two are different because event sourcing replays `evolve` against historical events to rebuild state on load.
 
-### 6. The domain — `defineDomain` + `wireDomain`
+</Step>
+
+<Step>
+
+### The domain — `defineDomain` + `wireDomain`
 
 `defineDomain` captures the static structure (which aggregates, projections, sagas exist). `wireDomain` connects it to infrastructure. With no second argument, you get in-memory defaults for everything:
 
-```ts
+```ts title="account.ts"
 const banking = defineDomain({
   writeModel: { aggregates: { BankAccount } },
   readModel: { projections: {} },
@@ -296,17 +320,25 @@ const domain = await wireDomain(banking);
 
 Swap to a real database with [persistence adapters](/docs/running/persistence-adapters).
 
-### 7. Dispatching commands
+</Step>
+
+<Step>
+
+### Dispatching commands
 
 `dispatchCommand` is fully typed against the domain — `name`, `targetAggregateId`, and `payload` are inferred per command:
 
-```ts
+```ts title="account.ts"
 await domain.dispatchCommand({
   name: "AuthorizeTransaction",
   targetAggregateId: accountId,
   payload: { amount: 100, merchant: "Amazon" },
 });
 ```
+
+</Step>
+
+</Steps>
 
 ## Next steps
 

--- a/docs/content/docs/integrations/nestjs.mdx
+++ b/docs/content/docs/integrations/nestjs.mdx
@@ -19,7 +19,7 @@ yarn add @noddde/nestjs @noddde/core @noddde/engine
 
 Use `forRoot` when your domain wiring has no NestJS-injected dependencies (e.g., all in-memory):
 
-```ts
+```ts title="app.module.ts"
 import { Module } from "@nestjs/common";
 import { NodddeModule } from "@noddde/nestjs";
 import { myDomainDefinition } from "./domain";
@@ -38,7 +38,7 @@ export class AppModule {}
 
 Use `forRootAsync` when your wiring depends on NestJS-managed services like `ConfigService`, database connections, or external clients:
 
-```ts
+```ts title="app.module.ts"
 import { Module } from "@nestjs/common";
 import { ConfigModule, ConfigService } from "@nestjs/config";
 import { NodddeModule } from "@noddde/nestjs";
@@ -90,7 +90,7 @@ export type AppDomain = InferDomain<typeof definition>;
 
 ### Using the convenience decorator
 
-```ts
+```ts title="order.controller.ts"
 import { Controller, Post, Body } from "@nestjs/common";
 import { InjectDomain } from "@noddde/nestjs";
 import type { AppDomain } from "./domain";
@@ -123,7 +123,7 @@ export class OrderController {
 
 ### Using the injection token directly
 
-```ts
+```ts title="order.service.ts"
 import { Inject } from "@nestjs/common";
 import { NODDDE_DOMAIN } from "@noddde/nestjs";
 import type { AppDomain } from "./domain";
@@ -138,7 +138,7 @@ export class OrderService {
 
 By default, only the `Domain` instance is injectable. Set `exposeBuses: true` to also register the `CommandBus`, `QueryBus`, and `EventBus` as individual providers:
 
-```ts
+```ts title="app.module.ts"
 NodddeModule.forRoot({
   definition: myDomainDefinition,
   exposeBuses: true,
@@ -147,8 +147,12 @@ NodddeModule.forRoot({
 
 Then inject them using convenience decorators or tokens:
 
-```ts
-import { InjectCommandBus, InjectQueryBus, InjectEventBus } from "@noddde/nestjs";
+```ts title="order.service.ts"
+import {
+  InjectCommandBus,
+  InjectQueryBus,
+  InjectEventBus,
+} from "@noddde/nestjs";
 import type { CommandBus, QueryBus, EventBus } from "@noddde/core";
 
 @Injectable()
@@ -167,7 +171,7 @@ These are the exact same bus instances used by the `Domain` internally.
 
 `NodddeMetadataInterceptor` wraps handler execution inside `domain.withMetadataContext()`, propagating correlation IDs, user IDs, and causation IDs from the request context into every command dispatched within the handler.
 
-```ts
+```ts title="order.controller.ts"
 import { Controller, UseInterceptors } from "@nestjs/common";
 import { NodddeMetadataInterceptor } from "@noddde/nestjs";
 
@@ -190,7 +194,7 @@ The interceptor accepts a `MetadataExtractor` function — you control how metad
 
 To apply globally:
 
-```ts
+```ts title="app.module.ts"
 import { APP_INTERCEPTOR } from "@nestjs/core";
 
 @Module({
@@ -223,29 +227,29 @@ No manual lifecycle management is needed.
 
 ### NodddeModuleOptions
 
-| Option       | Type                                       | Required | Default | Description                                              |
-| ------------ | ------------------------------------------ | -------- | ------- | -------------------------------------------------------- |
-| `definition` | `DomainDefinition`                         | Yes      | —       | The domain definition from `defineDomain()`              |
-| `wiring`     | `DomainWiring`                             | No       | `{}`    | Infrastructure wiring passed to `wireDomain()`           |
-| `exposeBuses`| `boolean`                                  | No       | `false` | Register CommandBus, QueryBus, EventBus as providers     |
+| Option        | Type               | Required | Default | Description                                          |
+| ------------- | ------------------ | -------- | ------- | ---------------------------------------------------- |
+| `definition`  | `DomainDefinition` | Yes      | —       | The domain definition from `defineDomain()`          |
+| `wiring`      | `DomainWiring`     | No       | `{}`    | Infrastructure wiring passed to `wireDomain()`       |
+| `exposeBuses` | `boolean`          | No       | `false` | Register CommandBus, QueryBus, EventBus as providers |
 
 ### NodddeModuleAsyncOptions
 
-| Option       | Type                                       | Required | Default | Description                                              |
-| ------------ | ------------------------------------------ | -------- | ------- | -------------------------------------------------------- |
-| `imports`    | `ModuleMetadata["imports"]`                | No       | `[]`    | Modules providing tokens for the factory                 |
-| `inject`     | `any[]`                                    | No       | `[]`    | Tokens to inject into `useFactory`                       |
-| `useFactory` | `(...args) => NodddeModuleOptions`         | Yes      | —       | Factory returning module options (can be async)          |
-| `exposeBuses`| `boolean`                                  | No       | `false` | Register CommandBus, QueryBus, EventBus as providers     |
+| Option        | Type                               | Required | Default | Description                                          |
+| ------------- | ---------------------------------- | -------- | ------- | ---------------------------------------------------- |
+| `imports`     | `ModuleMetadata["imports"]`        | No       | `[]`    | Modules providing tokens for the factory             |
+| `inject`      | `any[]`                            | No       | `[]`    | Tokens to inject into `useFactory`                   |
+| `useFactory`  | `(...args) => NodddeModuleOptions` | Yes      | —       | Factory returning module options (can be async)      |
+| `exposeBuses` | `boolean`                          | No       | `false` | Register CommandBus, QueryBus, EventBus as providers |
 
 ### Injection Tokens & Decorators
 
-| Token / Decorator      | Provides                 | Requires            |
-| ---------------------- | ------------------------ | ------------------- |
-| `NODDDE_DOMAIN` / `InjectDomain()`       | `Domain` instance       | `NodddeModule`      |
-| `NODDDE_COMMAND_BUS` / `InjectCommandBus()` | `CommandBus`          | `exposeBuses: true` |
-| `NODDDE_QUERY_BUS` / `InjectQueryBus()`   | `QueryBus`             | `exposeBuses: true` |
-| `NODDDE_EVENT_BUS` / `InjectEventBus()`   | `EventBus`             | `exposeBuses: true` |
+| Token / Decorator                           | Provides          | Requires            |
+| ------------------------------------------- | ----------------- | ------------------- |
+| `NODDDE_DOMAIN` / `InjectDomain()`          | `Domain` instance | `NodddeModule`      |
+| `NODDDE_COMMAND_BUS` / `InjectCommandBus()` | `CommandBus`      | `exposeBuses: true` |
+| `NODDDE_QUERY_BUS` / `InjectQueryBus()`     | `QueryBus`        | `exposeBuses: true` |
+| `NODDDE_EVENT_BUS` / `InjectEventBus()`     | `EventBus`        | `exposeBuses: true` |
 
 ## Compatibility with @nestjs/cqrs
 

--- a/docs/content/docs/modeling/command-handlers.mdx
+++ b/docs/content/docs/modeling/command-handlers.mdx
@@ -7,7 +7,7 @@ description: Writing decide handler logic -- validation, returning events, infra
 
 Every aggregate decide handler has this shape:
 
-```typescript
+```typescript title="decide-handler-signature.ts"
 (command: TCommand, state: TState, infrastructure: TInfrastructure) =>
   TEvents | TEvents[] | Promise<TEvents | TEvents[]>;
 ```
@@ -46,8 +46,7 @@ We recommend extracting each decide handler to its own file typed with `InferDec
 
 The simplest case: the handler returns one event object.
 
-```typescript
-// deciders/decide-create-bank-account.ts
+```typescript title="bank-account/deciders/decide-create-bank-account.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { BankAccountTypes } from "../bank-account";
 
@@ -67,8 +66,7 @@ export const decideCreateBankAccount: InferDecideHandler<
 
 A handler can return different events depending on the current state. This is how you model business rule validation:
 
-```typescript
-// deciders/decide-authorize-transaction.ts
+```typescript title="bank-account/deciders/decide-authorize-transaction.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { BankAccountTypes } from "../bank-account";
 
@@ -110,8 +108,7 @@ Notice that both branches return an event. The handler does not throw an excepti
 
 Return an array when a single command produces multiple events:
 
-```typescript
-// deciders/decide-close-month.ts
+```typescript title="bank-account/deciders/decide-close-month.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { BankAccountTypes } from "../bank-account";
 
@@ -147,8 +144,7 @@ Decide handlers are where business rules live. The `state` parameter contains th
 
 ### Balance Checking
 
-```typescript
-// deciders/decide-authorize-transaction.ts
+```typescript title="bank-account/deciders/decide-authorize-transaction.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { BankAccountTypes } from "../bank-account";
 
@@ -184,8 +180,7 @@ export const decideAuthorizeTransaction: InferDecideHandler<
 
 ### Status Checking
 
-```typescript
-// deciders/decide-place-bid.ts
+```typescript title="auction/deciders/decide-place-bid.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { AuctionTypes } from "../auction";
 
@@ -231,7 +226,7 @@ Each check inspects the current state and returns an appropriate rejection event
 
 noddde encourages modeling business rule violations as **rejection events** rather than thrown exceptions. When a transaction has insufficient funds, the handler returns a `TransactionDeclined` event. When a bid is too low, it returns a `BidRejected` event.
 
-```typescript
+```typescript title="bank-account/deciders/decide-authorize-transaction.ts"
 if (state.availableBalance < amount) {
   return {
     name: "TransactionDeclined",
@@ -258,7 +253,7 @@ Contrast this with throwing an exception: exceptions abort the command processin
 
 Throw exceptions only for truly unexpected situations -- programming errors, infrastructure failures, or invariants that indicate a bug in your code:
 
-```typescript
+```typescript title="bank-account/deciders/decide-authorize-transaction.ts"
 export const decideAuthorizeTransaction: InferDecideHandler<
   BankAccountTypes,
   "AuthorizeTransaction"
@@ -287,8 +282,7 @@ The rule of thumb: if a human user could cause this condition through normal use
 
 The third parameter gives you access to your domain infrastructure. Destructure the services you need directly in the function signature. `InferDecideHandler` automatically types the infrastructure from your `AggregateTypes` bundle:
 
-```typescript
-// deciders/decide-place-bid.ts
+```typescript title="auction/deciders/decide-place-bid.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { AuctionTypes } from "../auction";
 
@@ -315,8 +309,7 @@ In tests, you inject fakes (a fixed clock, a stub fraud service). In production,
 
 When a handler needs several infrastructure services, destructure them all:
 
-```typescript
-// deciders/decide-authorize-transaction.ts
+```typescript title="bank-account/deciders/decide-authorize-transaction.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { BankAccountTypes } from "../bank-account";
 
@@ -357,8 +350,7 @@ export const decideAuthorizeTransaction: InferDecideHandler<
 
 Handlers can be asynchronous when they need to call external infrastructure. Mark the handler with `async` and the framework will `await` it before persisting events:
 
-```typescript
-// deciders/decide-authorize-transaction.ts
+```typescript title="bank-account/deciders/decide-authorize-transaction.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { BankAccountTypes } from "../bank-account";
 

--- a/docs/content/docs/modeling/defining-aggregates.mdx
+++ b/docs/content/docs/modeling/defining-aggregates.mdx
@@ -25,11 +25,15 @@ Reference](/docs/getting-started/cli#noddde-new-aggregate-name) for details.
 
 </Callout>
 
-## Step 1: Define Events
+<Steps>
+
+<Step>
+
+## Define Events
 
 Events represent facts that have already occurred. Define them as a payload map using `DefineEvents`:
 
-```typescript
+```typescript title="event-model/index.ts"
 import { DefineEvents } from "@noddde/core";
 
 type BankAccountEvent = DefineEvents<{
@@ -63,11 +67,15 @@ Each key becomes the event's `name`, and the value becomes its `payload` type. T
 
 For a deeper look at how `DefineEvents` works under the hood, see [Messages & Type System](/docs/core-concepts/messages-and-types).
 
-## Step 2: Define Commands
+</Step>
+
+<Step>
+
+## Define Commands
 
 Commands represent intent -- a request for something to happen. Define them with `DefineCommands`:
 
-```typescript
+```typescript title="bank-account/commands/index.ts"
 import { DefineCommands } from "@noddde/core";
 
 type BankAccountCommand = DefineCommands<{
@@ -84,11 +92,15 @@ Each key becomes the command's `name`, and the value becomes its `payload` type.
 
 For a deeper look at how `DefineCommands` works under the hood, see [Messages & Type System](/docs/core-concepts/messages-and-types).
 
-## Step 3: Define State
+</Step>
+
+<Step>
+
+## Define State
 
 The state interface describes what the aggregate tracks between commands. Design it as a plain TypeScript interface:
 
-```typescript
+```typescript title="bank-account/state.ts"
 interface BankAccountState {
   balance: number;
   availableBalance: number;
@@ -108,11 +120,15 @@ A few design tips:
 - **Prefer flat structures.** Deeply nested state is harder to update immutably in evolve handlers. Keep it as shallow as your domain allows.
 - **The aggregate ID is NOT part of the state.** It lives on the command as `targetAggregateId` and is managed by the framework. See [Why Is the Aggregate ID Not in State?](/docs/design-decisions/why-id-not-in-state) for the rationale.
 
-## Step 4: Bundle Types
+</Step>
+
+<Step>
+
+## Bundle Types
 
 Bundle the state, events, commands, and infrastructure into a single `AggregateTypes` type. This is the single type parameter that `defineAggregate` uses for full type inference across all boundaries:
 
-```typescript
+```typescript title="bank-account/bank-account.ts"
 import { Infrastructure } from "@noddde/core";
 
 type BankAccountTypes = {
@@ -127,7 +143,11 @@ The `infrastructure` field specifies what services your decide handlers can acce
 
 This bundle replaces what would otherwise be five or more positional generic parameters. For the reasoning behind this approach, see [Why AggregateTypes?](/docs/design-decisions/why-aggregate-types).
 
-## Step 5: Extract Handlers
+</Step>
+
+<Step>
+
+## Extract Handlers
 
 The recommended pattern is to define decide handlers and evolve handlers as standalone functions in separate files, typed with `InferDecideHandler` and `InferEvolveHandler`. This keeps each handler focused, independently testable, and makes the aggregate definition itself a clean table of references.
 
@@ -135,8 +155,7 @@ The recommended pattern is to define decide handlers and evolve handlers as stan
 
 Each decide handler lives in its own file and is typed with `InferDecideHandler<TypesBundle, "CommandName">`:
 
-```typescript
-// deciders/decide-create-bank-account.ts
+```typescript title="bank-account/deciders/decide-create-bank-account.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { BankAccountTypes } from "../bank-account";
 
@@ -149,8 +168,7 @@ export const decideCreateBankAccount: InferDecideHandler<
 });
 ```
 
-```typescript
-// deciders/decide-authorize-transaction.ts
+```typescript title="bank-account/deciders/decide-authorize-transaction.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { BankAccountTypes } from "../bank-account";
 
@@ -188,8 +206,7 @@ export const decideAuthorizeTransaction: InferDecideHandler<
 
 Each evolve handler lives in its own file and is typed with `InferEvolveHandler<TypesBundle, "EventName">`:
 
-```typescript
-// evolvers/evolve-bank-account-created.ts
+```typescript title="bank-account/evolvers/evolve-bank-account-created.ts"
 import type { InferEvolveHandler } from "@noddde/core";
 import type { BankAccountTypes } from "../bank-account";
 
@@ -203,8 +220,7 @@ export const evolveBankAccountCreated: InferEvolveHandler<
 });
 ```
 
-```typescript
-// evolvers/evolve-transaction-authorized.ts
+```typescript title="bank-account/evolvers/evolve-transaction-authorized.ts"
 import type { InferEvolveHandler } from "@noddde/core";
 import type { BankAccountTypes } from "../bank-account";
 
@@ -221,14 +237,17 @@ export const evolveTransactionAuthorized: InferEvolveHandler<
 });
 ```
 
-## Step 6: defineAggregate
+</Step>
+
+<Step>
+
+## defineAggregate
 
 `defineAggregate` is an identity function -- it takes your aggregate object and returns it unchanged. Its only purpose is to provide type inference so TypeScript can verify that your decide handlers, evolve handlers, and initial state are all consistent.
 
 With extracted handlers, the aggregate definition becomes a concise wiring file that imports and maps each handler:
 
-```typescript
-// bank-account.ts
+```typescript title="bank-account/bank-account.ts"
 import { defineAggregate } from "@noddde/core";
 import { decideCreateBankAccount } from "./deciders/decide-create-bank-account";
 import { decideAuthorizeTransaction } from "./deciders/decide-authorize-transaction";
@@ -276,14 +295,17 @@ Because `defineAggregate` is an identity function, it adds **zero runtime overhe
 
 Extracting handlers is the recommended pattern in noddde for testability, readability, type safety, and maintainability. See [Why Extract Handlers?](/docs/design-decisions/why-extracted-handlers) for the full rationale.
 
+</Step>
+
+</Steps>
+
 ## Using Infrastructure
 
 When decide handlers need external services -- a clock, a logger, a fraud-check client -- define a custom infrastructure type and include it in the types bundle.
 
 Here is the auction domain, which uses an injected `clock` to validate bid timing. The types are defined first, then the `PlaceBid` handler is extracted to its own file with `InferDecideHandler`:
 
-```typescript
-// types.ts
+```typescript title="auction/auction.ts"
 import { Infrastructure, DefineEvents, DefineCommands } from "@noddde/core";
 
 interface AuctionInfrastructure extends Infrastructure {
@@ -321,8 +343,7 @@ export type AuctionTypes = {
 
 The `PlaceBid` handler destructures `{ clock }` from the infrastructure parameter. `InferDecideHandler` ensures TypeScript knows exactly which services are available:
 
-```typescript
-// deciders/decide-place-bid.ts
+```typescript title="auction/deciders/decide-place-bid.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { AuctionTypes } from "../auction";
 
@@ -365,8 +386,7 @@ export const decidePlaceBid: InferDecideHandler<AuctionTypes, "PlaceBid"> = (
 
 The aggregate definition then wires everything together:
 
-```typescript
-// auction.ts
+```typescript title="auction/auction.ts"
 import { defineAggregate } from "@noddde/core";
 import { decideCreateAuction } from "./deciders/decide-create-auction";
 import { decidePlaceBid } from "./deciders/decide-place-bid";

--- a/docs/content/docs/modeling/event-versioning.mdx
+++ b/docs/content/docs/modeling/event-versioning.mdx
@@ -9,7 +9,7 @@ Event schemas inevitably change as your domain evolves. A field gets added, a ty
 
 Consider a `BankAccountCreated` event that originally had this payload:
 
-```typescript
+```typescript title="event-model/bank-account-created.ts"
 // Version 1 (original)
 {
   id: string;
@@ -19,7 +19,7 @@ Consider a `BankAccountCreated` event that originally had this payload:
 
 Later, you add a `status` field:
 
-```typescript
+```typescript title="event-model/bank-account-created.ts"
 // Version 2 (current)
 {
   id: string;
@@ -34,7 +34,7 @@ Without upcasting, replaying version 1 events through evolve handlers that expec
 
 An upcaster chain declares all historical payload versions as a tuple and provides transform functions between consecutive versions.
 
-```typescript
+```typescript title="bank-account/upcasters.ts"
 import {
   defineEventUpcasterChain,
   defineUpcasters,
@@ -69,7 +69,7 @@ const bankAccountUpcasters = defineUpcasters<BankAccountEvent>({
 
 Events can go through many versions. Each step in the chain transforms from one version to the next:
 
-```typescript
+```typescript title="upcasters.ts"
 type CreatedV1 = { id: string };
 type CreatedV2 = { id: string; status: "active" | "closed" };
 type CreatedV3 = { id: string; status: "active" | "closed"; createdAt: string };
@@ -88,7 +88,7 @@ The version tuple `[V1, V2, V3]` declares all shapes upfront. Step parameters an
 
 Pass the upcaster map to `defineAggregate` via the optional `upcasters` field:
 
-```typescript
+```typescript title="bank-account/bank-account.ts"
 const BankAccount = defineAggregate<BankAccountTypes>({
   initialState: { balance: 0, status: "active" },
   decide: {

--- a/docs/content/docs/modeling/routing-and-dispatch.mdx
+++ b/docs/content/docs/modeling/routing-and-dispatch.mdx
@@ -9,7 +9,7 @@ When you call `domain.dispatchCommand()`, the framework executes a deterministic
 
 The entry point for all command processing is `domain.dispatchCommand()`. You pass a command object with a `name`, a `targetAggregateId`, and optionally a `payload`:
 
-```typescript
+```typescript title="main.ts"
 import { defineDomain } from "@noddde/core";
 import { wireDomain } from "@noddde/engine";
 
@@ -76,11 +76,19 @@ Publish
         --> saga handlers react and may dispatch further commands
 ```
 
-### Step 1: Command Received
+<Steps>
+
+<Step>
+
+### Command Received
 
 `domain.dispatchCommand(command)` receives the command object. The `name` field identifies which aggregate type should process it. The `targetAggregateId` field identifies which instance of that aggregate.
 
-### Step 2: Route to Aggregate
+</Step>
+
+<Step>
+
+### Route to Aggregate
 
 The framework scans the `commands` map of each aggregate in the `writeModel.aggregates` configuration to find one with a handler matching the command's `name`.
 
@@ -89,7 +97,11 @@ The framework scans the `commands` map of each aggregate in the `writeModel.aggr
 
 The `targetAggregateId` tells the framework which instance to load. Two commands with the same `name` but different `targetAggregateId` values operate on completely independent instances with separate event streams and separate state.
 
-### Step 3: Load Current State
+</Step>
+
+<Step>
+
+### Load Current State
 
 For event-sourced persistence, all past events for this aggregate instance are loaded and replayed through the `evolve` handlers to rebuild current state:
 
@@ -103,37 +115,57 @@ For state-stored persistence, the latest state snapshot is loaded directly.
 
 If no prior state exists (the aggregate instance is new), the `initialState` from the aggregate definition is used.
 
-### Step 4: Execute Decide Handler
+</Step>
+
+<Step>
+
+### Execute Decide Handler
 
 The matching handler is called with three arguments:
 
-```typescript
+```typescript title="dispatch-handler-call.ts"
 handler(command, currentState, infrastructure);
 ```
 
 The handler inspects the command and the current state, enforces business invariants, and returns one or more events representing what happened. See [Decide Handlers](/docs/modeling/command-handlers) for patterns on writing handler logic.
 
-### Step 5: Apply Returned Events
+</Step>
+
+<Step>
+
+### Apply Returned Events
 
 Each returned event is passed through the corresponding `evolve` handler to produce a new state:
 
-```typescript
+```typescript title="dispatch-evolve-step.ts"
 newState = evolve[event.name](event.payload, currentState);
 ```
 
 If the decide handler returns multiple events, they are applied sequentially. Each produces a new state that feeds into the next. See [State & Event Application](/docs/modeling/state-and-events) for evolve handler patterns.
 
-### Step 6: Persist
+</Step>
+
+<Step>
+
+### Persist
 
 For event-sourced persistence, the new events are appended to the aggregate's event stream in the event store.
 
 For state-stored persistence, the final state (after all events are applied) is saved as a snapshot, overwriting the previous one.
 
-### Step 7: Publish Events
+</Step>
+
+<Step>
+
+### Publish Events
 
 After successful persistence, each event is dispatched to the `EventBus`. This triggers registered projection reducers (which update read model views) and saga handlers (which may dispatch further commands or trigger side effects).
 
 Events are published **after** persistence, so handlers can assume the event is durably stored.
+
+</Step>
+
+</Steps>
 
 ## Command Routing
 
@@ -143,7 +175,7 @@ Routing answers two questions: **which aggregate type** handles a given command,
 
 The framework matches the command's `name` against the `commands` map of each registered aggregate. The aggregate whose map contains a handler for that name receives the command. This means command names must be globally unique across all aggregate types in a domain.
 
-```typescript
+```typescript title="main.ts"
 // BankAccount handles: CreateBankAccount, AuthorizeTransaction
 // Auction handles: CreateAuction, PlaceBid, CloseAuction
 
@@ -180,7 +212,7 @@ The `targetAggregateId` identifies which instance to load. Each aggregate type h
 
 When you define commands with `DefineCommands`, the `targetAggregateId` field is automatically included on every command in the resulting union:
 
-```typescript
+```typescript title="bank-account/commands/index.ts"
 type BankAccountCommand = DefineCommands<{
   CreateBankAccount: void;
   AuthorizeTransaction: { amount: number; merchant: string };
@@ -197,7 +229,7 @@ The `targetAggregateId` is the caller's responsibility. The framework does not g
 
 The key you use in `writeModel.aggregates` becomes the aggregate's internal name:
 
-```typescript
+```typescript title="domain.ts"
 writeModel: {
   aggregates: {
     BankAccount,        // name: "BankAccount"
@@ -212,7 +244,7 @@ This name is used for persistence namespacing (events stored under `BankAccount:
 
 If two aggregate types define a handler for the same command name, the framework cannot determine which should handle it. This is a configuration error. Keep command names globally unique, typically by prefixing with the aggregate context:
 
-```typescript
+```typescript title="commands.ts"
 // Good: unique names
 type BankAccountCommand = DefineCommands<{
   CreateBankAccount: void;
@@ -233,7 +265,7 @@ type AuctionCommand = DefineCommands<{
 
 By default, `targetAggregateId` is typed as `string`. For stricter type safety, you can use branded types via the second type parameter of `DefineCommands`:
 
-```typescript
+```typescript title="bank-account/commands/index.ts"
 type BankAccountId = string & { __brand: "BankAccountId" };
 
 type BankAccountCommand = DefineCommands<
@@ -249,7 +281,7 @@ type BankAccountCommand = DefineCommands<
 
 With a branded type, TypeScript rejects raw strings where a `BankAccountId` is expected. Create a helper function to construct IDs:
 
-```typescript
+```typescript title="main.ts"
 function bankAccountId(id: string): BankAccountId {
   return id as BankAccountId;
 }
@@ -272,7 +304,7 @@ This prevents accidentally passing an auction ID to a bank account command, catc
 
 The `CommandBus` is the transport interface for commands:
 
-```typescript
+```typescript title="packages/core/src/cqrs/command-bus.ts"
 interface CommandBus {
   dispatch(command: Command): Promise<void>;
 }
@@ -280,7 +312,7 @@ interface CommandBus {
 
 It is part of `CQRSInfrastructure`, which is provided during domain configuration:
 
-```typescript
+```typescript title="packages/core/src/cqrs/cqrs-infrastructure.ts"
 interface CQRSInfrastructure {
   commandBus: CommandBus;
   eventBus: EventBus;
@@ -294,7 +326,7 @@ In most cases, you interact with commands through `domain.dispatchCommand()` rat
 
 noddde ships with `InMemoryCommandBus`, a minimal in-process implementation suitable for development and testing:
 
-```typescript
+```typescript title="main.ts"
 import {
   InMemoryCommandBus,
   EventEmitterEventBus,
@@ -316,7 +348,7 @@ For production systems, you may need a command bus that adds logging, retry logi
 
 The `EventBus` is the transport mechanism that delivers events from aggregates to projections and sagas after persistence:
 
-```typescript
+```typescript title="packages/core/src/edd/event-bus.ts"
 interface EventBus extends Closeable {
   /** Publishes a single domain event to all subscribers. */
   dispatch<TEvent extends Event>(event: TEvent): Promise<void>;
@@ -331,7 +363,7 @@ Like the `CommandBus`, it is part of `CQRSInfrastructure`.
 
 The built-in `EventEmitterEventBus` is an in-process implementation that tracks handlers internally and awaits them sequentially during dispatch:
 
-```typescript
+```typescript title="main.ts"
 import { EventEmitterEventBus } from "@noddde/engine";
 
 buses: () => ({

--- a/docs/content/docs/modeling/state-and-events.mdx
+++ b/docs/content/docs/modeling/state-and-events.mdx
@@ -11,7 +11,7 @@ Evolve handlers are the functions that update aggregate state when an event occu
 
 The `EvolveHandler` type signature:
 
-```typescript
+```typescript title="packages/core/src/ddd/handlers.ts"
 type EvolveHandler<TEvent extends Event, TState> = (
   event: TEvent["payload"],
   state: TState,
@@ -41,7 +41,7 @@ For a deeper discussion of why evolve handlers are pure, see [Why Are Evolve Han
 
 Every aggregate declares an `initialState` -- the state a brand-new instance starts with before any events have been applied. When the framework loads an aggregate for the first time (or when there are no stored events), this is what the decide handler receives as `state`.
 
-```typescript
+```typescript title="bank-account/bank-account.ts"
 export const BankAccount = defineAggregate<BankAccountTypes>({
   initialState: {
     balance: 0,
@@ -61,7 +61,7 @@ Guidelines for a good initial state:
 - Use **`null`** for optional reference-type fields that genuinely have no value yet.
 - Use **`as const`** for status fields when TypeScript needs help narrowing a literal type.
 
-```typescript
+```typescript title="auction/auction.ts"
 initialState: {
   status: "pending" as const,
   highestBid: null as { bidderId: string; amount: number } | null,
@@ -81,8 +81,7 @@ Evolve handlers must return a **new state object**. Never mutate the existing st
 
 Override specific fields while preserving the rest:
 
-```typescript
-// evolvers/evolve-transaction-authorized.ts
+```typescript title="bank-account/evolvers/evolve-transaction-authorized.ts"
 import type { InferEvolveHandler } from "@noddde/core";
 import type { BankAccountTypes } from "../bank-account";
 
@@ -111,8 +110,7 @@ This creates a new object with all existing state fields, but with `availableBal
 
 When updating a specific item inside a collection, use `map` to produce a new array and spread to produce a new item:
 
-```typescript
-// evolvers/evolve-transaction-processed.ts
+```typescript title="bank-account/evolvers/evolve-transaction-processed.ts"
 import type { InferEvolveHandler } from "@noddde/core";
 import type { BankAccountTypes } from "../bank-account";
 
@@ -136,7 +134,7 @@ Here `map` creates a new array, and only the matching transaction is replaced wi
 
 Use spread to append to an array rather than `push`:
 
-```typescript
+```typescript title="bank-account/evolvers/evolve-transaction-authorized.ts"
 transactions: [
   ...state.transactions,
   { ...event, status: "pending" as const },
@@ -147,7 +145,7 @@ transactions: [
 
 Use `map` to transform a specific item rather than direct index assignment:
 
-```typescript
+```typescript title="bank-account/evolvers/evolve-transaction-processed.ts"
 transactions: state.transactions.map((t) =>
   t.id === event.id ? { ...t, status: "processed" as const } : t,
 ),
@@ -157,7 +155,7 @@ transactions: state.transactions.map((t) =>
 
 Never mutate state in place:
 
-```typescript
+```typescript title="anti-pattern-mutation.ts"
 // WRONG: mutates state directly
 TransactionAuthorized: (event, state) => {
   state.availableBalance -= event.amount;
@@ -174,8 +172,7 @@ Some events do not change the aggregate state. For example, a `TransactionDeclin
 
 These handlers simply return the existing state:
 
-```typescript
-// evolvers/evolve-bid-rejected.ts
+```typescript title="auction/evolvers/evolve-bid-rejected.ts"
 import type { InferEvolveHandler } from "@noddde/core";
 import type { AuctionTypes } from "../auction";
 
@@ -199,8 +196,7 @@ The most important thing to understand about evolve handlers is how state accumu
 
 ### Event 1: BankAccountCreated
 
-```typescript
-// evolvers/evolve-bank-account-created.ts
+```typescript title="bank-account/evolvers/evolve-bank-account-created.ts"
 export const evolveBankAccountCreated: InferEvolveHandler<
   BankAccountTypes,
   "BankAccountCreated"
@@ -221,8 +217,7 @@ This handler ignores both the event and prior state, returning a clean initial s
 
 ### Event 2: TransactionAuthorized (amount: 50)
 
-```typescript
-// evolvers/evolve-transaction-authorized.ts
+```typescript title="bank-account/evolvers/evolve-transaction-authorized.ts"
 export const evolveTransactionAuthorized: InferEvolveHandler<
   BankAccountTypes,
   "TransactionAuthorized"
@@ -275,8 +270,7 @@ The same handler runs again with a new event. Both transactions are now pending.
 
 ### Event 4: TransactionProcessed (id: "tx-1", amount: 50)
 
-```typescript
-// evolvers/evolve-transaction-processed.ts
+```typescript title="bank-account/evolvers/evolve-transaction-processed.ts"
 export const evolveTransactionProcessed: InferEvolveHandler<
   BankAccountTypes,
   "TransactionProcessed"
@@ -321,7 +315,7 @@ The rule: **"Does a decide handler need this field to make a decision?"**
 
 Both `balance` and `availableBalance` are stored because they are needed for authorization:
 
-```typescript
+```typescript title="bank-account/deciders/decide-authorize-transaction.ts"
 export const decideAuthorizeTransaction: InferDecideHandler<
   BankAccountTypes,
   "AuthorizeTransaction"
@@ -344,7 +338,7 @@ Even though `availableBalance` could theoretically be computed from the transact
 
 If a value is only needed for read models or queries, compute it in a projection rather than bloating aggregate state:
 
-```typescript
+```typescript title="bank-account/state.ts"
 // Don't store display-only data in aggregate state
 interface BankAccountState {
   balance: number;
@@ -367,7 +361,7 @@ The aggregate ID (`targetAggregateId`) is deliberately excluded from aggregate s
 
 The ID is always available in the command object:
 
-```typescript
+```typescript title="bank-account/deciders/decide-create-bank-account.ts"
 export const decideCreateBankAccount: InferDecideHandler<
   BankAccountTypes,
   "CreateBankAccount"
@@ -389,7 +383,7 @@ Quick reference for the most frequent evolve handler shapes, shown as extracted 
 
 ### Appending to an Array
 
-```typescript
+```typescript title="bank-account/evolvers/evolve-transaction-authorized.ts"
 export const evolveTransactionAuthorized: InferEvolveHandler<
   BankAccountTypes,
   "TransactionAuthorized"
@@ -404,7 +398,7 @@ export const evolveTransactionAuthorized: InferEvolveHandler<
 
 ### Updating an Item in an Array
 
-```typescript
+```typescript title="bank-account/evolvers/evolve-transaction-processed.ts"
 export const evolveTransactionProcessed: InferEvolveHandler<
   BankAccountTypes,
   "TransactionProcessed"
@@ -418,7 +412,7 @@ export const evolveTransactionProcessed: InferEvolveHandler<
 
 ### Incrementing a Counter
 
-```typescript
+```typescript title="auction/evolvers/evolve-bid-placed.ts"
 export const evolveBidPlaced: InferEvolveHandler<AuctionTypes, "BidPlaced"> = (
   event,
   state,
@@ -433,7 +427,7 @@ export const evolveBidPlaced: InferEvolveHandler<AuctionTypes, "BidPlaced"> = (
 
 For creation events that set the entire state from the event payload:
 
-```typescript
+```typescript title="bank-account/evolvers/evolve-bank-account-created.ts"
 export const evolveBankAccountCreated: InferEvolveHandler<
   BankAccountTypes,
   "BankAccountCreated"

--- a/docs/content/docs/modeling/type-inference.mdx
+++ b/docs/content/docs/modeling/type-inference.mdx
@@ -9,7 +9,7 @@ noddde provides five type-level helpers that extract specific types from an aggr
 
 All five helpers are exported from `@noddde/core`:
 
-```typescript
+```typescript title="usage.ts"
 import {
   InferAggregateID,
   InferAggregateState,
@@ -23,14 +23,14 @@ import {
 
 Extracts the state type from an `Aggregate` instance.
 
-```typescript
+```typescript title="packages/core/src/ddd/infer-aggregate.ts"
 type InferAggregateState<T extends Aggregate> =
   T extends Aggregate<infer U> ? U["state"] : never;
 ```
 
 ### Usage
 
-```typescript
+```typescript title="usage.ts"
 import { InferAggregateState } from "@noddde/core";
 import { BankAccount } from "./bank-account";
 
@@ -54,7 +54,7 @@ type BankAccountState = InferAggregateState<typeof BankAccount>;
 - **Projections**: Type your read model transformations against the source aggregate state
 - **API responses**: Derive response types from aggregate state without duplicating the interface
 
-```typescript
+```typescript title="__tests__/bank-account.test.ts"
 // In a test file
 import { InferAggregateState } from "@noddde/core";
 import { BankAccount } from "./bank-account";
@@ -70,14 +70,14 @@ function assertState(actual: State, expected: Partial<State>) {
 
 Extracts the event union type from an `Aggregate` instance.
 
-```typescript
+```typescript title="packages/core/src/ddd/infer-aggregate.ts"
 type InferAggregateEvents<T extends Aggregate> =
   T extends Aggregate<infer U> ? U["events"] : never;
 ```
 
 ### Usage
 
-```typescript
+```typescript title="usage.ts"
 import { InferAggregateEvents } from "@noddde/core";
 import { BankAccount } from "./bank-account";
 
@@ -94,7 +94,7 @@ type BankAccountEvent = InferAggregateEvents<typeof BankAccount>;
 - **Event bus subscribers**: Ensure subscribers handle the correct event shapes
 - **Narrowing**: Use discriminated union narrowing on the `name` field
 
-```typescript
+```typescript title="handle-event.ts"
 type BankEvent = InferAggregateEvents<typeof BankAccount>;
 
 function handleEvent(event: BankEvent) {
@@ -115,14 +115,14 @@ function handleEvent(event: BankEvent) {
 
 Extracts the command union type from an `Aggregate` instance.
 
-```typescript
+```typescript title="packages/core/src/ddd/infer-aggregate.ts"
 type InferAggregateCommands<T extends Aggregate> =
   T extends Aggregate<infer U> ? U["commands"] : never;
 ```
 
 ### Usage
 
-```typescript
+```typescript title="usage.ts"
 import { InferAggregateCommands } from "@noddde/core";
 import { BankAccount } from "./bank-account";
 
@@ -138,7 +138,7 @@ type BankAccountCommand = InferAggregateCommands<typeof BankAccount>;
 - **Command factories**: Build helper functions that construct valid commands
 - **Validation**: Ensure incoming requests match the expected command structure
 
-```typescript
+```typescript title="command-factory.ts"
 type BankCommand = InferAggregateCommands<typeof BankAccount>;
 
 // A typed command factory
@@ -159,14 +159,14 @@ function authorizeTransaction(
 
 Extracts the type of `targetAggregateId` from the aggregate's command types. This operates on the `AggregateTypes` bundle rather than the `Aggregate` instance.
 
-```typescript
+```typescript title="packages/core/src/ddd/infer-aggregate.ts"
 type InferAggregateID<T extends AggregateTypes> =
   T["commands"]["targetAggregateId"];
 ```
 
 ### Usage
 
-```typescript
+```typescript title="usage.ts"
 import { InferAggregateID } from "@noddde/core";
 
 // Using the AggregateTypes bundle directly
@@ -197,7 +197,7 @@ type AuctionId = InferAggregateID<AuctionTypes>;
 - **URL parameters**: Ensure route handlers parse the correct ID type
 - **Cross-aggregate references**: Type references between aggregates
 
-```typescript
+```typescript title="bank-account-repository.ts"
 type AccountId = InferAggregateID<BankAccountTypes>;
 
 interface BankAccountRepository {
@@ -212,14 +212,14 @@ Note that `InferAggregateID` takes an `AggregateTypes` bundle (the type you pass
 
 Extracts the infrastructure type from an `Aggregate` instance.
 
-```typescript
+```typescript title="packages/core/src/ddd/infer-aggregate.ts"
 type InferAggregateInfrastructure<T extends Aggregate> =
   T extends Aggregate<infer U> ? U["infrastructure"] : never;
 ```
 
 ### Usage
 
-```typescript
+```typescript title="usage.ts"
 import { InferAggregateInfrastructure } from "@noddde/core";
 import { Auction } from "./auction";
 
@@ -232,7 +232,7 @@ type AuctionInfra = InferAggregateInfrastructure<typeof Auction>;
 - **Test setup**: Know exactly which infrastructure services to mock
 - **Infrastructure factories**: Type helper functions that build the infrastructure object for a specific aggregate
 
-```typescript
+```typescript title="__tests__/test-infrastructure.ts"
 type AuctionInfra = InferAggregateInfrastructure<typeof Auction>;
 
 function createTestInfrastructure(): AuctionInfra {
@@ -252,7 +252,7 @@ When you extract decide handlers, evolve handlers, saga handlers, or projection 
 
 Types an extracted aggregate decide handler:
 
-```typescript
+```typescript title="booking/deciders/decide-confirm-booking.ts"
 import type { InferDecideHandler } from "@noddde/core";
 
 type BookingTypes = {
@@ -284,7 +284,7 @@ export const decideConfirmBooking: InferDecideHandler<
 
 Types an extracted aggregate evolve handler (event reducer):
 
-```typescript
+```typescript title="booking/evolvers/evolve-booking-confirmed.ts"
 import type { InferEvolveHandler } from "@noddde/core";
 
 export const evolveBookingConfirmed: InferEvolveHandler<
@@ -301,7 +301,7 @@ export const evolveBookingConfirmed: InferEvolveHandler<
 
 Type extracted saga handlers. `InferSagaEventHandler` types just the handler function; `InferSagaOnEntry` types the full `{ id, handle }` bundle:
 
-```typescript
+```typescript title="order-fulfillment/on-entries/on-order-placed.ts"
 import type { InferSagaOnEntry } from "@noddde/core";
 
 export const onOrderPlaced: InferSagaOnEntry<FulfillmentDef, "OrderPlaced"> = {
@@ -317,7 +317,7 @@ export const onOrderPlaced: InferSagaOnEntry<FulfillmentDef, "OrderPlaced"> = {
 
 Type extracted projection handlers:
 
-```typescript
+```typescript title="revenue/projection-handlers.ts"
 import type {
   InferProjectionEventHandler,
   InferProjectionQueryHandler,
@@ -346,7 +346,7 @@ export const queryDailyRevenue: InferProjectionQueryHandler<
 
 Computes the full infrastructure type for a projection's query handlers, conditionally including `{ views }`:
 
-```typescript
+```typescript title="usage.ts"
 import type { InferProjectionQueryInfrastructure } from "@noddde/core";
 
 type Infra = InferProjectionQueryInfrastructure<RevenueDef>;
@@ -375,7 +375,7 @@ type Infra = InferProjectionQueryInfrastructure<RevenueDef>;
 
 These are used internally by `wireDomain` to compute the typed dispatch constraints. You can also use them directly:
 
-```ts
+```ts title="usage.ts"
 import type {
   InferAggregateMapCommands,
   InferProjectionMapQueries,
@@ -408,7 +408,7 @@ Definition-level helpers work with `typeof YourAggregate` (the value returned by
 
 You can combine these helpers to build comprehensive utility types:
 
-```typescript
+```typescript title="bank-account-types.ts"
 import {
   InferAggregateState,
   InferAggregateEvents,

--- a/docs/content/docs/patterns/auction-domain.mdx
+++ b/docs/content/docs/patterns/auction-domain.mdx
@@ -21,7 +21,7 @@ The auction domain models a simple auction that supports:
 
 ## Events
 
-```ts
+```ts title="event-model/index.ts"
 import { DefineEvents } from "@noddde/core";
 
 export type AuctionEvent = DefineEvents<{
@@ -36,7 +36,7 @@ Note `BidRejected` — this is a rejection event, not an exception. The domain e
 
 ## Commands
 
-```ts
+```ts title="auction/commands/index.ts"
 import { DefineCommands } from "@noddde/core";
 
 export type AuctionCommand = DefineCommands<{
@@ -48,7 +48,7 @@ export type AuctionCommand = DefineCommands<{
 
 ## State
 
-```ts
+```ts title="auction/state.ts"
 export interface AuctionState {
   item: string;
   startingPrice: number;
@@ -65,7 +65,7 @@ export interface AuctionState {
 
 The auction needs to check the current time. Instead of calling `new Date()` directly (which would be non-deterministic), we inject a `Clock`:
 
-```ts
+```ts title="infrastructure/index.ts"
 export interface Clock {
   now(): Date;
 }
@@ -91,8 +91,7 @@ The recommended pattern extracts decide handlers and evolve handlers into separa
 
 Each decide handler is a standalone, independently testable function. The type is inferred from the aggregate's type bundle (`AuctionTypes`) and the command name.
 
-```ts
-// deciders/decide-create-auction.ts
+```ts title="auction/deciders/decide-create-auction.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { AuctionTypes } from "../auction";
 
@@ -105,8 +104,7 @@ export const decideCreateAuction: InferDecideHandler<
 });
 ```
 
-```ts
-// deciders/decide-place-bid.ts
+```ts title="auction/deciders/decide-place-bid.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { AuctionTypes } from "../auction";
 
@@ -157,8 +155,7 @@ The `CloseAuction` handler follows the same pattern. Each file imports only `Inf
 
 Evolve handlers are also extracted. They are pure functions — no infrastructure access, no async.
 
-```ts
-// evolvers/evolve-auction-created.ts
+```ts title="auction/evolvers/evolve-auction-created.ts"
 import type { InferEvolveHandler } from "@noddde/core";
 import type { AuctionTypes } from "../auction";
 
@@ -175,8 +172,7 @@ export const evolveAuctionCreated: InferEvolveHandler<
 });
 ```
 
-```ts
-// evolvers/evolve-bid-placed.ts
+```ts title="auction/evolvers/evolve-bid-placed.ts"
 import type { InferEvolveHandler } from "@noddde/core";
 import type { AuctionTypes } from "../auction";
 
@@ -190,8 +186,7 @@ export const evolveBidPlaced: InferEvolveHandler<AuctionTypes, "BidPlaced"> = (
 });
 ```
 
-```ts
-// evolvers/evolve-bid-rejected.ts
+```ts title="auction/evolvers/evolve-bid-rejected.ts"
 import type { InferEvolveHandler } from "@noddde/core";
 import type { AuctionTypes } from "../auction";
 
@@ -207,8 +202,7 @@ The `AuctionClosed` evolve handler follows the same pattern.
 
 The aggregate definition imports all handlers and wires them together. This file is thin — it contains no business logic, only composition.
 
-```ts
-// auction.ts
+```ts title="auction/auction.ts"
 import { defineAggregate } from "@noddde/core";
 
 type AuctionTypes = {
@@ -254,7 +248,7 @@ Instead of throwing `new Error("Auction is closed")`, the handler returns a `Bid
 
 `BidRejected` does not change state:
 
-```ts
+```ts title="auction/evolvers/evolve-bid-rejected.ts"
 BidRejected: (_event, state) => state,
 ```
 
@@ -266,7 +260,7 @@ The aggregate records that the bid happened (as an event) but the state remains 
 
 ## Running the Example
 
-```ts
+```ts title="main.ts"
 import { defineDomain } from "@noddde/core";
 import { wireDomain } from "@noddde/engine";
 

--- a/docs/content/docs/patterns/clock-pattern.mdx
+++ b/docs/content/docs/patterns/clock-pattern.mdx
@@ -9,7 +9,7 @@ The Clock pattern is the canonical example of infrastructure injection in noddde
 
 Consider an auction system where bids are rejected if the auction has ended:
 
-```ts
+```ts title="auction/auction.ts"
 // Problematic: direct Date call
 decide: {
   PlaceBid: (command, state) => {
@@ -32,7 +32,7 @@ This handler is non-deterministic. It produces different results depending on wh
 
 Define a `Clock` interface and inject it through infrastructure:
 
-```ts
+```ts title="infrastructure/clock.ts"
 // Interface — the capability your domain needs
 interface Clock {
   now(): Date;
@@ -56,7 +56,7 @@ class FixedClock implements Clock {
 
 Add it to your infrastructure type:
 
-```ts
+```ts title="infrastructure/index.ts"
 interface AuctionInfrastructure {
   clock: Clock;
 }
@@ -64,7 +64,7 @@ interface AuctionInfrastructure {
 
 Use it in the decide handler:
 
-```ts
+```ts title="auction/auction.ts"
 decide: {
   PlaceBid: (command, state, { clock }) => {
     const now = clock.now(); // Deterministic!
@@ -87,7 +87,7 @@ decide: {
 
 Now tests are deterministic and clear:
 
-```ts
+```ts title="__tests__/auction-place-bid.test.ts"
 describe("PlaceBid", () => {
   const auctionEndsAt = new Date("2024-06-01T00:00:00Z");
   const openAuctionState: AuctionState = {
@@ -139,7 +139,7 @@ describe("PlaceBid", () => {
 
 In production, provide `SystemClock` via the `infrastructure` field in `wireDomain`:
 
-```ts
+```ts title="main.ts"
 import { defineDomain } from "@noddde/core";
 import { wireDomain } from "@noddde/engine";
 

--- a/docs/content/docs/patterns/flash-sale.mdx
+++ b/docs/content/docs/patterns/flash-sale.mdx
@@ -21,8 +21,7 @@ The aggregate uses extracted handlers — each decide handler and evolve handler
 
 ### Decide handlers (extracted)
 
-```ts
-// deciders/decide-create-flash-sale.ts
+```ts title="flash-sale-item/deciders/decide-create-flash-sale.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { FlashSaleItemTypes } from "../flash-sale-item";
 
@@ -38,8 +37,7 @@ export const decideCreateFlashSale: InferDecideHandler<
 });
 ```
 
-```ts
-// deciders/decide-purchase-item.ts
+```ts title="flash-sale-item/deciders/decide-purchase-item.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { FlashSaleItemTypes } from "../flash-sale-item";
 
@@ -67,8 +65,7 @@ The `PurchaseItem` handler either produces `ItemPurchased` (decrements stock) or
 
 ### Evolve handlers (extracted)
 
-```ts
-// evolvers/evolve-flash-sale-created.ts
+```ts title="flash-sale-item/evolvers/evolve-flash-sale-created.ts"
 import type { InferEvolveHandler } from "@noddde/core";
 import type { FlashSaleItemTypes } from "../flash-sale-item";
 
@@ -82,8 +79,7 @@ export const evolveFlashSaleCreated: InferEvolveHandler<
 });
 ```
 
-```ts
-// evolvers/evolve-item-purchased.ts
+```ts title="flash-sale-item/evolvers/evolve-item-purchased.ts"
 import type { InferEvolveHandler } from "@noddde/core";
 import type { FlashSaleItemTypes } from "../flash-sale-item";
 
@@ -101,8 +97,7 @@ The `PurchaseRejected` evolve handler follows the same pattern — it returns `s
 
 ### Aggregate definition (wiring)
 
-```ts
-// flash-sale-item.ts
+```ts title="flash-sale-item/flash-sale-item.ts"
 import { defineAggregate } from "@noddde/core";
 import type { AggregateTypes, Infrastructure } from "@noddde/core";
 
@@ -129,7 +124,7 @@ export const FlashSaleItem = defineAggregate<FlashSaleItemTypes>({
 
 ## Domain Configuration
 
-```ts
+```ts title="main.ts"
 import { defineDomain } from "@noddde/core";
 import {
   wireDomain,

--- a/docs/content/docs/patterns/hotel-booking.mdx
+++ b/docs/content/docs/patterns/hotel-booking.mdx
@@ -53,8 +53,7 @@ The `Booking` aggregate is the most instructive of the three. Its status field i
 
 #### Decide handlers (extracted)
 
-```ts
-// deciders/decide-request-payment.ts
+```ts title="booking/deciders/decide-request-payment.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { BookingTypes } from "../booking";
 
@@ -78,8 +77,7 @@ export const decideRequestPayment: InferDecideHandler<
 };
 ```
 
-```ts
-// deciders/decide-complete-payment.ts
+```ts title="booking/deciders/decide-complete-payment.ts"
 import type { InferDecideHandler } from "@noddde/core";
 import type { BookingTypes } from "../booking";
 
@@ -108,8 +106,7 @@ The remaining decide handlers (`FailPayment`, `RefundPayment`, `CreateBooking`, 
 
 #### Evolve handlers (extracted)
 
-```ts
-// evolvers/evolve-payment-requested.ts
+```ts title="booking/evolvers/evolve-payment-requested.ts"
 import type { InferEvolveHandler } from "@noddde/core";
 import type { BookingTypes } from "../booking";
 
@@ -123,8 +120,7 @@ export const evolvePaymentRequested: InferEvolveHandler<
 });
 ```
 
-```ts
-// evolvers/evolve-payment-failed.ts
+```ts title="booking/evolvers/evolve-payment-failed.ts"
 import type { InferEvolveHandler } from "@noddde/core";
 import type { BookingTypes } from "../booking";
 
@@ -144,8 +140,7 @@ Notice that `PaymentFailed` resets status back to `"pending"` rather than `"canc
 
 The aggregate definition imports all handlers and wires them. This file contains no business logic — only composition.
 
-```ts
-// booking.ts
+```ts title="booking/booking.ts"
 import { defineAggregate } from "@noddde/core";
 
 type BookingTypes = {
@@ -198,8 +193,7 @@ This saga orchestrates the top-level booking flow. It starts on `BookingCreated`
 
 #### Transition handlers (extracted)
 
-```ts
-// on-entries/on-booking-created.ts
+```ts title="booking-fulfillment/on-entries/on-booking-created.ts"
 import { randomUUID } from "crypto";
 import type { BookingFulfillmentState } from "../state";
 
@@ -236,8 +230,7 @@ export const onBookingCreated = (event: {
 };
 ```
 
-```ts
-// on-entries/on-payment-completed.ts
+```ts title="booking-fulfillment/on-entries/on-payment-completed.ts"
 import type { BookingFulfillmentState } from "../state";
 
 export const onPaymentCompleted = async (
@@ -286,8 +279,7 @@ export const onPaymentCompleted = async (
 };
 ```
 
-```ts
-// on-entries/on-booking-cancelled.ts
+```ts title="booking-fulfillment/on-entries/on-booking-cancelled.ts"
 import type { BookingFulfillmentState } from "../state";
 
 export const onBookingCancelled = (
@@ -312,8 +304,7 @@ The `PaymentFailed`, `BookingConfirmed`, `BookingModified`, `PaymentRequested`, 
 
 #### Saga definition (wiring)
 
-```ts
-// saga.ts
+```ts title="booking-fulfillment/saga.ts"
 import { defineSaga } from "@noddde/core";
 import {
   onBookingCancelled,
@@ -361,8 +352,7 @@ This saga bridges the `RequestPayment` command (dispatched by `BookingFulfillmen
 
 #### Transition handlers (extracted)
 
-```ts
-// on-entries/on-payment-requested.ts
+```ts title="payment-processing/on-entries/on-payment-requested.ts"
 import type { PaymentProcessingState } from "../state";
 
 export const onPaymentRequested = async (
@@ -436,8 +426,7 @@ The `PaymentCompleted` and `PaymentFailed` handlers observe terminal states for 
 
 #### Saga definition (wiring)
 
-```ts
-// saga.ts
+```ts title="payment-processing/saga.ts"
 import { defineSaga } from "@noddde/core";
 import {
   onPaymentRequested,
@@ -471,8 +460,7 @@ The third saga is simpler: it starts on `GuestCheckedIn`, sends a welcome SMS vi
 
 The `RoomAvailabilityViewStore` extends the built-in `ViewStore` interface with a domain-specific `findAvailable` method. This pushes filtering to the database rather than loading all views into memory.
 
-```ts
-// domain/read-model/queries.ts
+```ts title="read-model/queries.ts"
 export interface RoomAvailabilityViewStore
   extends ViewStore<RoomAvailabilityView> {
   /** Finds available rooms, optionally filtered by room type. */
@@ -488,8 +476,7 @@ Projections follow the same extracted pattern. Each event handler is in its own 
 
 #### Event handlers (extracted)
 
-```ts
-// on-entries/on-room-created.ts
+```ts title="room-availability/on-entries/on-room-created.ts"
 import type { InferProjectionEventHandler } from "@noddde/core";
 import type { RoomAvailabilityProjectionDef } from "../room-availability";
 
@@ -510,8 +497,7 @@ export const onRoomCreated: InferProjectionEventHandler<
 };
 ```
 
-```ts
-// on-entries/on-room-reserved.ts
+```ts title="room-availability/on-entries/on-room-reserved.ts"
 import type { InferProjectionEventHandler } from "@noddde/core";
 import type { RoomAvailabilityProjectionDef } from "../room-availability";
 
@@ -532,8 +518,7 @@ The `RoomMadeAvailable`, `GuestCheckedIn`, `GuestCheckedOut`, and `RoomUnderMain
 
 #### Projection definition (wiring)
 
-```ts
-// room-availability.ts
+```ts title="room-availability/room-availability.ts"
 import { defineProjection } from "@noddde/core";
 import {
   onRoomCreated,
@@ -590,8 +575,7 @@ The sample shows both consistency modes side by side:
 
 `SearchAvailableRoomsHandler` is registered as a standalone query handler rather than a projection-backed query. It reads directly from `roomAvailabilityViewStore` via infrastructure injection:
 
-```ts
-// domain/read-model/query-handlers.ts
+```ts title="read-model/query-handlers.ts"
 export const SearchAvailableRoomsHandler: QueryHandler<
   HotelInfrastructure,
   Extract<SearchQuery, { name: "SearchAvailableRooms" }>
@@ -607,8 +591,7 @@ See [Queries](/docs/read-model/queries) for the full standalone query handler pa
 
 The domain configuration uses `defineDomain` to capture the pure domain structure, then `wireDomain` to connect infrastructure.
 
-```ts
-// src/main.ts
+```ts title="main.ts"
 import { DrizzleAdapter } from "@noddde/drizzle";
 import { defineDomain } from "@noddde/core";
 import {
@@ -695,8 +678,7 @@ The event bus uses `@noddde/rabbitmq` (`RabbitMqEventBus`) backed by a RabbitMQ 
 
 The group booking endpoint demonstrates `domain.withUnitOfWork()`. All commands dispatched inside the callback share a single database transaction — either all commit or all roll back.
 
-```ts
-// infrastructure/http/routes/bookings.ts
+```ts title="infrastructure/http/routes/bookings.ts"
 fastify.post("/bookings/group", async (request, reply) => {
   const { guestId, rooms } = request.body;
   const bookingIds: string[] = [];

--- a/docs/content/docs/persistence/custom-adapters.mdx
+++ b/docs/content/docs/persistence/custom-adapters.mdx
@@ -7,7 +7,7 @@ You can implement your own adapter for any database driver -- no ORM required. A
 
 ## The `PersistenceAdapter` Interface
 
-```ts
+```ts title="packages/core/src/persistence/persistence-adapter.ts"
 import type {
   PersistenceAdapter,
   EventSourcedAggregatePersistence,
@@ -47,7 +47,7 @@ These are the interfaces your adapter needs to implement depending on which feat
 
 ### `UnitOfWorkFactory` (required)
 
-```ts
+```ts title="packages/core/src/persistence/unit-of-work.ts"
 type UnitOfWorkFactory = () => UnitOfWork;
 ```
 
@@ -55,7 +55,7 @@ A `UnitOfWorkFactory` returns a fresh `UnitOfWork` per command dispatch -- your 
 
 ### `EventSourcedAggregatePersistence`
 
-```ts
+```ts title="packages/core/src/persistence/event-sourced-aggregate-persistence.ts"
 interface EventSourcedAggregatePersistence {
   save(
     aggregateName: string,
@@ -71,7 +71,7 @@ Appends events to an aggregate stream. `save()` must enforce optimistic concurre
 
 ### `StateStoredAggregatePersistence`
 
-```ts
+```ts title="packages/core/src/persistence/state-stored-aggregate-persistence.ts"
 interface StateStoredAggregatePersistence {
   save(
     aggregateName: string,
@@ -90,7 +90,7 @@ Stores the latest aggregate state as a JSON snapshot. `save()` must enforce opti
 
 ### `SagaPersistence`
 
-```ts
+```ts title="packages/core/src/persistence/saga-persistence.ts"
 interface SagaPersistence {
   save(sagaName: string, sagaId: string, state: any): Promise<void>;
   load(sagaName: string, sagaId: string): Promise<any | undefined | null>;
@@ -101,7 +101,7 @@ Simple key-value persistence for saga workflow state. No concurrency control req
 
 ### `SnapshotStore` (optional)
 
-```ts
+```ts title="packages/core/src/persistence/snapshot-store.ts"
 interface SnapshotStore {
   load(aggregateName: string, aggregateId: string): Promise<Snapshot | null>;
   save(
@@ -117,7 +117,7 @@ Caches aggregate state at a point in time so event replay can start from the sna
 
 ### `OutboxStore` (optional)
 
-```ts
+```ts title="packages/core/src/edd/outbox-store.ts"
 interface OutboxStore {
   save(entries: OutboxEntry[]): Promise<void>;
   loadUnpublished(batchSize?: number): Promise<OutboxEntry[]>;
@@ -131,7 +131,7 @@ Transactional outbox for guaranteed at-least-once event delivery. `save()` is ca
 
 ### `AggregateLocker` (optional)
 
-```ts
+```ts title="packages/core/src/persistence/aggregate-locker.ts"
 interface AggregateLocker {
   acquire(
     aggregateName: string,
@@ -154,13 +154,17 @@ This walkthrough builds a custom adapter using the MongoDB native driver (`mongo
   image pre-configured as a single-node replica set.
 </Callout>
 
-### Step 1: Create the UnitOfWork
+<Steps>
+
+<Step>
+
+### Create the UnitOfWork
 
 The UoW is the only required piece. It wraps all enlisted operations in a database transaction so that aggregate persistence, outbox writes, and any other enlisted operations commit or fail atomically.
 
 In MongoDB, this maps to a `ClientSession` with an active transaction:
 
-```ts
+```ts title="adapters/mongo-persistence.ts"
 import { MongoClient, type ClientSession } from "mongodb";
 import type { UnitOfWork, UnitOfWorkFactory, Event } from "@noddde/core";
 
@@ -227,11 +231,15 @@ class MongoUnitOfWork implements UnitOfWork {
 
 The key pattern: a **session store** holds a mutable reference to the active MongoDB session. All persistence classes read from it so their operations participate in the same transaction.
 
-### Step 2: Implement Persistence Classes
+</Step>
+
+<Step>
+
+### Implement Persistence Classes
 
 Each persistence class reads `sessionStore.current` to pass the active session to MongoDB operations. When no UoW is active (e.g., read-only `load()` calls), it falls back to a sessionless call.
 
-```ts
+```ts title="adapters/mongo-persistence.ts"
 import type { Db, Collection } from "mongodb";
 import { ConcurrencyError } from "@noddde/core";
 import type { EventSourcedAggregatePersistence, Event } from "@noddde/core";
@@ -312,7 +320,7 @@ class MongoEventSourcedPersistence implements EventSourcedAggregatePersistence {
 
 For optimistic concurrency in `StateStoredAggregatePersistence`, use a `findOneAndUpdate` with a version filter:
 
-```ts
+```ts title="adapters/mongo-persistence.ts"
 import type { StateStoredAggregatePersistence } from "@noddde/core";
 
 class MongoStateStoredPersistence implements StateStoredAggregatePersistence {
@@ -378,11 +386,15 @@ class MongoStateStoredPersistence implements StateStoredAggregatePersistence {
 }
 ```
 
-### Step 3: Assemble the Adapter
+</Step>
+
+<Step>
+
+### Assemble the Adapter
 
 All persistence classes share a single `sessionStore` so they participate in the same transaction:
 
-```ts
+```ts title="adapters/mongo-persistence.ts"
 import type { PersistenceAdapter } from "@noddde/core";
 import { MongoClient, type Db } from "mongodb";
 
@@ -434,9 +446,13 @@ class MongoAdapter implements PersistenceAdapter {
 }
 ```
 
-### Step 4: Wire It Up
+</Step>
 
-```ts
+<Step>
+
+### Wire It Up
+
+```ts title="main.ts"
 import { defineDomain } from "@noddde/core";
 import { wireDomain } from "@noddde/engine";
 import { MongoClient } from "mongodb";
@@ -455,6 +471,10 @@ const domain = await wireDomain(
   { persistenceAdapter: adapter },
 );
 ```
+
+</Step>
+
+</Steps>
 
 ## Key Implementation Rules
 

--- a/docs/content/docs/persistence/drizzle.mdx
+++ b/docs/content/docs/persistence/drizzle.mdx
@@ -17,7 +17,7 @@ yarn add better-sqlite3  # or: pg, mysql2
 
 The package exports convenience table definitions for each Drizzle dialect. Import from the sub-path matching your database:
 
-```ts
+```ts title="db/schema.ts"
 // SQLite
 import {
   events,
@@ -50,7 +50,7 @@ You can also define your own tables matching the expected column structure -- th
 
 ## Configuration
 
-```ts
+```ts title="main.ts"
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { DrizzleAdapter } from "@noddde/drizzle";
@@ -89,7 +89,7 @@ The persistence classes and `UnitOfWork` share a transaction store. When a trans
 
 For custom table overrides, pass a config object as the second argument:
 
-```ts
+```ts title="main.ts"
 import { DrizzleAdapter } from "@noddde/drizzle";
 import { myEvents, mySagas } from "./schema"; // your own Drizzle tables
 
@@ -111,7 +111,7 @@ The `stateStored()` helper takes a Drizzle table and a required `DrizzleStateMap
 
 Define a `DrizzleStateMapper` with one column per state field, then wire it via `stateStored()`:
 
-```ts
+```ts title="main.ts"
 import type { DrizzleStateMapper } from "@noddde/drizzle";
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 
@@ -149,7 +149,9 @@ const adapter = new DrizzleAdapter(db);
 const domain = await wireDomain(definition, {
   persistenceAdapter: adapter,
   aggregates: {
-    Order: { persistence: adapter.stateStored(orders, { mapper: orderMapper }) },
+    Order: {
+      persistence: adapter.stateStored(orders, { mapper: orderMapper }),
+    },
   },
 });
 ```
@@ -160,7 +162,7 @@ The mapper's `toRow` / `fromRow` are pure and lossless: `fromRow(toRow(state))` 
 
 When you want a dedicated table without per-field columns — for instance, to share a schema with another service — use `jsonStateMapper(table)`:
 
-```ts
+```ts title="main.ts"
 import { jsonStateMapper } from "@noddde/drizzle";
 
 const orders = sqliteTable("orders", {
@@ -174,7 +176,7 @@ adapter.stateStored(orders, { mapper: jsonStateMapper(orders) });
 
 `jsonStateMapper` resolves columns by JS-key convention (`aggregateId`, `state`, `version`). For non-conventional names, pass overrides:
 
-```ts
+```ts title="main.ts"
 adapter.stateStored(customOrders, {
   mapper: jsonStateMapper(customOrders, {
     aggregateIdColumn: customOrders.id,

--- a/docs/content/docs/persistence/prisma.mdx
+++ b/docs/content/docs/persistence/prisma.mdx
@@ -77,7 +77,7 @@ Then run `prisma generate` and your preferred migration command.
 
 ## Configuration
 
-```ts
+```ts title="main.ts"
 import { PrismaClient } from "@prisma/client";
 import { PrismaAdapter } from "@noddde/prisma";
 import { everyNEvents } from "@noddde/core";
@@ -115,7 +115,7 @@ Pass the camelCase Prisma model delegate name and a `PrismaStateMapper`. The fra
 
 ### Typed columns (recommended)
 
-```ts
+```ts title="main.ts"
 import type { PrismaStateMapper } from "@noddde/prisma";
 import type { Prisma } from "@prisma/client";
 
@@ -148,7 +148,9 @@ const adapter = new PrismaAdapter(prisma);
 const domain = await wireDomain(definition, {
   persistenceAdapter: adapter,
   aggregates: {
-    Order: { persistence: adapter.stateStored("order", { mapper: orderMapper }) },
+    Order: {
+      persistence: adapter.stateStored("order", { mapper: orderMapper }),
+    },
   },
 });
 ```
@@ -157,7 +159,7 @@ The Prisma adapter validates that the model exists at creation time and throws a
 
 ### Opaque JSON via `jsonStateMapper`
 
-```ts
+```ts title="main.ts"
 import { jsonStateMapper } from "@noddde/prisma";
 
 adapter.stateStored("order", { mapper: jsonStateMapper() });
@@ -174,7 +176,7 @@ adapter.stateStored("customOrder", {
 
 For pessimistic concurrency, pass the `dialect` option since PrismaClient does not expose the database provider at runtime:
 
-```ts
+```ts title="main.ts"
 const adapter = new PrismaAdapter(prisma, { dialect: "postgresql" });
 ```
 

--- a/docs/content/docs/persistence/schema-reference.mdx
+++ b/docs/content/docs/persistence/schema-reference.mdx
@@ -257,7 +257,7 @@ CREATE TABLE IF NOT EXISTS orders (
 
 Each adapter accepts its own table reference format (Drizzle table object, Prisma model name, TypeORM entity class) plus a `mapper` option:
 
-```ts
+```ts title="main.ts"
 // Drizzle
 adapter.stateStored(orders, { mapper: orderMapper });
 
@@ -282,7 +282,7 @@ CREATE TABLE IF NOT EXISTS orders (
 );
 ```
 
-```ts
+```ts title="main.ts"
 // Drizzle
 adapter.stateStored(orders, { mapper: jsonStateMapper(orders) });
 

--- a/docs/content/docs/persistence/typeorm.mdx
+++ b/docs/content/docs/persistence/typeorm.mdx
@@ -17,7 +17,7 @@ yarn add pg
 
 The package exports TypeORM entity classes decorated with `@Entity`, `@Column`, etc. Register them in your `DataSource` configuration:
 
-```ts
+```ts title="main.ts"
 import {
   NodddeEventEntity,
   NodddeAggregateStateEntity,
@@ -45,7 +45,7 @@ For production, use TypeORM migrations instead of `synchronize: true`.
 
 ## Configuration
 
-```ts
+```ts title="main.ts"
 import { TypeORMAdapter } from "@noddde/typeorm";
 import { everyNEvents } from "@noddde/core";
 import { defineDomain } from "@noddde/core";
@@ -81,7 +81,7 @@ Pass the TypeORM entity class and a `TypeORMStateMapper`. The framework writes t
 
 ### Typed columns (recommended)
 
-```ts
+```ts title="main.ts"
 import type { TypeORMStateMapper } from "@noddde/typeorm";
 import { OrderTypedEntity } from "./entities"; // your own TypeORM entity
 
@@ -112,7 +112,9 @@ const domain = await wireDomain(definition, {
   persistenceAdapter: adapter,
   aggregates: {
     Order: {
-      persistence: adapter.stateStored(OrderTypedEntity, { mapper: orderMapper }),
+      persistence: adapter.stateStored(OrderTypedEntity, {
+        mapper: orderMapper,
+      }),
     },
   },
 });
@@ -120,7 +122,7 @@ const domain = await wireDomain(definition, {
 
 ### Opaque JSON via `jsonStateMapper`
 
-```ts
+```ts title="main.ts"
 import { jsonStateMapper } from "@noddde/typeorm";
 
 adapter.stateStored(OrderEntity, { mapper: jsonStateMapper<OrderEntity>() });

--- a/docs/content/docs/process-managers/sagas.mdx
+++ b/docs/content/docs/process-managers/sagas.mdx
@@ -56,7 +56,7 @@ Use a saga when a business process:
 
 Like aggregates and projections, a saga starts with a **types bundle** that declares its type universe:
 
-```ts
+```ts title="saga.ts"
 import { SagaTypes } from "@noddde/core";
 
 type OrderFulfillmentSagaDef = {
@@ -80,7 +80,7 @@ Note that `events` and `commands` can span multiple aggregates -- this is the wh
 
 The saga state tracks where the workflow currently stands. Design it around the workflow steps, not domain state:
 
-```ts
+```ts title="state.ts"
 type FulfillmentStatus =
   | "awaiting_payment"
   | "payment_failed"
@@ -107,7 +107,7 @@ The `initialState` should use null/empty zero-values, just like aggregate state.
 
 Every saga event handler returns a `SagaReaction` -- the new state plus commands to dispatch:
 
-```ts
+```ts title="packages/core/src/ddd/saga.ts"
 type SagaReaction<TState, TCommands extends Command> = {
   state: TState;
   commands?: TCommands | TCommands[];
@@ -118,7 +118,7 @@ This is the key design: handlers **return** commands declaratively rather than d
 
 ### Return patterns
 
-```ts
+```ts title="on-entries/return-patterns.ts"
 // Single command
 return {
   state: { ...state, status: "awaiting_payment" },
@@ -290,7 +290,7 @@ The **`on` map** solves this: each entry bundles an `id` function that extracts 
 
 The `on` field is a map keyed by event name. Each entry has an `id` function that receives the narrowed event type and returns the saga instance ID, and a `handle` function that receives the event, current state, and infrastructure. Whether the entry is inline or extracted, the shape is the same:
 
-```ts
+```ts title="saga.ts"
 on: {
   // Extracted entries -- each typed with InferSagaOnEntry in its own file
   OrderPlaced: onOrderPlaced,
@@ -315,7 +315,7 @@ This is exactly why `id` functions are per-event rather than a single shared ext
 
 The `startedBy` field declares which events can create a new saga instance:
 
-```ts
+```ts title="saga.ts"
 startedBy: ["OrderPlaced"],
 ```
 
@@ -334,7 +334,7 @@ The `startedBy` type is a non-empty tuple `[T, ...T[]]`, enforcing at least one 
 
 A saga may be started by multiple events:
 
-```ts
+```ts title="saga.ts"
 startedBy: ["OrderPlaced", "ImportedOrderReceived"],
 ```
 
@@ -342,7 +342,7 @@ startedBy: ["OrderPlaced", "ImportedOrderReceived"],
 
 By default, saga IDs are `string`. You can use a custom type via the second generic parameter:
 
-```ts
+```ts title="saga.ts"
 // UUID branded type
 type OrderSagaId = string & { __brand: "OrderSagaId" };
 
@@ -388,12 +388,9 @@ The full saga runtime lifecycle proceeds as follows:
 
 Sagas are registered in the `processModel` section of `defineDomain` -- a dedicated top-level key separate from `writeModel` and `readModel`:
 
-```ts
+```ts title="main.ts"
 import { defineDomain } from "@noddde/core";
-import {
-  wireDomain,
-  InMemorySagaPersistence,
-} from "@noddde/engine";
+import { wireDomain, InMemorySagaPersistence } from "@noddde/engine";
 
 const ecommerceDomain = defineDomain({
   writeModel: {
@@ -431,7 +428,7 @@ The `processModel` section is separate because sagas are neither pure write-mode
 
 Like aggregates and projections, sagas have `Infer*` helpers. The most commonly used is `InferSagaOnEntry`, which types an extracted on-entry in its own file:
 
-```ts
+```ts title="usage.ts"
 import type { InferSagaOnEntry } from "@noddde/core";
 
 // Types the full { id, handle } object for a specific event
@@ -440,7 +437,7 @@ type Entry = InferSagaOnEntry<OrderFulfillmentSagaDef, "OrderPlaced">;
 
 Definition-level helpers extract types from the built saga:
 
-```ts
+```ts title="usage.ts"
 import {
   InferSagaState,
   InferSagaEvents,

--- a/docs/content/docs/process-managers/standalone-commands.mdx
+++ b/docs/content/docs/process-managers/standalone-commands.mdx
@@ -15,7 +15,7 @@ For stateful, multi-step workflows that need to track progress and handle compen
 
 `StandaloneCommand` is an alias for the base `Command` interface:
 
-```typescript
+```typescript title="packages/core/src/cqrs/standalone-command.ts"
 type StandaloneCommand = Command;
 
 // Which is:
@@ -31,7 +31,7 @@ The naming distinction exists to make intent clear in your codebase. When you se
 
 Standalone command handlers have a different signature from aggregate decide handlers. Instead of receiving aggregate state, they receive the full [CQRS](/docs/core-concepts/cqrs-and-event-sourcing) infrastructure:
 
-```typescript
+```typescript title="packages/core/src/cqrs/standalone-command-handler.ts"
 type StandaloneCommandHandler<
   TInfrastructure extends Infrastructure,
   TCommand extends StandaloneCommand,
@@ -43,9 +43,9 @@ type StandaloneCommandHandler<
 ) => void | Promise<void>;
 ```
 
-| Parameter        | Description                                                                                                                       |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `command`        | The incoming standalone command                                                                                                   |
+| Parameter        | Description                                                                                                                           |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `command`        | The incoming standalone command                                                                                                       |
 | `infrastructure` | Your domain infrastructure merged with `CQRSInfrastructure` (commandBus, eventBus, queryBus) and `FrameworkInfrastructure` (`logger`) |
 
 Key differences from aggregate decide handlers:
@@ -58,7 +58,7 @@ Key differences from aggregate decide handlers:
 
 Standalone command handlers are registered in the `writeModel.standaloneCommandHandlers` map of your domain configuration:
 
-```typescript
+```typescript title="domain.ts"
 import { defineDomain } from "@noddde/core";
 import { wireDomain } from "@noddde/engine";
 
@@ -103,7 +103,7 @@ const domain = await wireDomain(bankingDomain, {
 
 Standalone commands work for stateless, fire-and-forget orchestration:
 
-```typescript
+```typescript title="command-handlers/handle-transfer-funds.ts"
 standaloneCommandHandlers: {
   TransferFunds: async (command, { commandBus }) => {
     const { fromAccountId, toAccountId, amount } = command.payload;
@@ -135,7 +135,7 @@ standaloneCommandHandlers: {
 
 Use standalone handlers to bridge your domain with external systems:
 
-```typescript
+```typescript title="command-handlers/handle-sync-with-external-crm.ts"
 standaloneCommandHandlers: {
   SyncWithExternalCRM: async (command, infrastructure) => {
     const { customerId, data } = command.payload;
@@ -156,7 +156,7 @@ standaloneCommandHandlers: {
 
 Standalone handlers can coordinate notifications that pull data from multiple sources:
 
-```typescript
+```typescript title="command-handlers/handle-send-order-confirmation.ts"
 standaloneCommandHandlers: {
   SendOrderConfirmation: async (command, infrastructure) => {
     const { orderId, customerId } = command.payload;

--- a/docs/content/docs/process-managers/standalone-events.mdx
+++ b/docs/content/docs/process-managers/standalone-events.mdx
@@ -15,7 +15,7 @@ For stateful workflows that need to track progress, dispatch commands, or handle
 
 Standalone event handlers use the `EventHandler` type from `@noddde/core`:
 
-```typescript
+```typescript title="packages/core/src/edd/handlers.ts"
 type EventHandler<
   TEvent extends Event,
   TInfrastructure extends Infrastructure,
@@ -25,9 +25,9 @@ type EventHandler<
 ) => void | Promise<void>;
 ```
 
-| Parameter        | Description                                                                                          |
-| ---------------- | ---------------------------------------------------------------------------------------------------- |
-| `event`          | The full event object (name, payload, and optional metadata)                                         |
+| Parameter        | Description                                                                                                |
+| ---------------- | ---------------------------------------------------------------------------------------------------------- |
+| `event`          | The full event object (name, payload, and optional metadata)                                               |
 | `infrastructure` | Your domain infrastructure merged with `FrameworkInfrastructure` (`logger`) — repositories, services, etc. |
 
 Key characteristics:
@@ -42,7 +42,7 @@ Key characteristics:
 
 Standalone event handlers are registered in the `processModel.standaloneEventHandlers` map of your domain configuration:
 
-```typescript
+```typescript title="domain.ts"
 import { defineDomain } from "@noddde/core";
 
 const definition = defineDomain({
@@ -81,7 +81,7 @@ Each key is an event name, and each value is an `EventHandler` function. The han
 
 You can use `standaloneEventHandlers` without defining any sagas. The `sagas` field in `processModel` is optional:
 
-```typescript
+```typescript title="domain.ts"
 processModel: {
   standaloneEventHandlers: {
     OrderShipped: (event, infrastructure) => {

--- a/docs/content/docs/read-model/projection-rebuild.mdx
+++ b/docs/content/docs/read-model/projection-rebuild.mdx
@@ -21,7 +21,7 @@ Do **not** rebuild for a hot-path issue that needs a live fix — rebuild is an 
 
 ## The API
 
-```ts
+```ts title="packages/engine/src/domain.ts"
 class Domain<...> {
   rebuildProjection<TName extends keyof TProjections & string>(
     name: TName,
@@ -53,7 +53,7 @@ console.log(result);
 
 ### ProjectionRebuildOptions
 
-```ts
+```ts title="packages/engine/src/projection-rebuild.ts"
 interface ProjectionRebuildOptions {
   logger?: Logger;
   progressInterval?: number;
@@ -78,7 +78,7 @@ await domain.rebuildProjection("OrderSummary", {
 
 ### ProjectionRebuildResult
 
-```ts
+```ts title="packages/engine/src/projection-rebuild.ts"
 interface ProjectionRebuildResult {
   projectionName: string;
   eventsRead: number; // total events the EventReader yielded
@@ -185,7 +185,7 @@ Rebuild reads from an `EventReader` — a read-only, append-order capability for
 2. **Structural fallback** on the resolved event-sourced persistence — any persistence object with a callable `read()` method is treated as an `EventReader`. The in-memory `InMemoryEventSourcedAggregatePersistence` ships this out of the box, so rebuild works in development and tests with no extra wiring.
 3. If neither is found, `EventReaderUnavailableError`.
 
-```ts
+```ts title="packages/core/src/persistence/event-reader.ts"
 interface EventReader {
   read(options?: EventReadOptions): AsyncIterable<Event>;
 }
@@ -261,7 +261,7 @@ To make your adapter participate in rebuild, implement two capabilities:
 
 Add a `truncate()` method to your `ViewStore` implementation:
 
-```ts
+```ts title="view-store-truncate.ts"
 async truncate(): Promise<void> {
   // Clear every view managed by this store. Must be atomic enough that
   // the store reaches an empty state — typically a single DELETE FROM

--- a/docs/content/docs/read-model/projections.mdx
+++ b/docs/content/docs/read-model/projections.mdx
@@ -44,7 +44,7 @@ Command --> Aggregate --> Events --> EventBus --> Projection on Handlers --> Vie
 
 Every projection is parameterized by a `ProjectionTypes` bundle -- a single named type that captures the projection's type universe:
 
-```ts
+```ts title="types.ts"
 type MyProjectionDef = {
   events: MyEvent; // The event union this projection handles
   queries: MyQuery; // The query union this projection answers
@@ -268,7 +268,7 @@ Query handlers are optional. A projection may handle events (updating a view) wi
 
 noddde provides `Infer*` helpers at two levels. The handler-level helpers are the most commonly used -- they type extracted event handlers and query handlers in separate files:
 
-```ts
+```ts title="usage.ts"
 import type {
   InferProjectionEventHandler,
   InferProjectionQueryHandler,
@@ -289,7 +289,7 @@ type QHandler = InferProjectionQueryHandler<
 
 Definition-level helpers extract types from the built projection:
 
-```ts
+```ts title="usage.ts"
 import type {
   InferProjectionView,
   InferProjectionEvents,
@@ -348,7 +348,7 @@ Both projections consume the same `TransactionProcessed` event but build entirel
 
 A projection is not limited to events from a single aggregate. A single projection can consume events from multiple aggregate types by using a union in the `events` field:
 
-```ts
+```ts title="activity-feed/types.ts"
 type CrossDomainProjectionDef = {
   events: BankAccountEvent | AuditEvent;
   queries: ActivityQuery;
@@ -363,7 +363,7 @@ This is useful for building views that span multiple domain concepts, such as an
 
 Projections are registered in the `readModel.projections` map of the domain definition, and their view stores are wired separately in `wireDomain`'s `projections` field:
 
-```ts
+```ts title="main.ts"
 import { defineDomain } from "@noddde/core";
 import { wireDomain, InMemoryViewStoreFactory } from "@noddde/engine";
 
@@ -417,7 +417,7 @@ The `EventBus` implementation determines delivery guarantees:
 
 Because reducers are pure functions, testing them is straightforward -- call the function with inputs and assert the output. With extracted handlers, you can import and test each handler independently:
 
-```ts
+```ts title="__tests__/bank-account-projection.test.ts"
 import { describe, it, expect } from "vitest";
 import { onBankAccountCreated } from "./on-entries/on-bank-account-created";
 import { onTransactionProcessed } from "./on-entries/on-transaction-processed";
@@ -465,7 +465,7 @@ noddde provides **view stores** — typed persistence interfaces for per-entity 
 
 A `ViewStore<TView>` provides `save(viewId, view)` and `load(viewId)` methods. You can extend it with custom query methods for advanced filtering:
 
-```ts
+```ts title="bank-account/types.ts"
 import type { ViewStore } from "@noddde/core";
 
 interface BankAccountViewStore extends ViewStore<BankAccountView> {
@@ -477,7 +477,7 @@ interface BankAccountViewStore extends ViewStore<BankAccountView> {
 
 To enable automatic view persistence, provide an `id` function inside each relevant `on` entry. The `id` function extracts the view instance ID from the event so the engine knows which view to load and update:
 
-```ts
+```ts title="bank-account/projection.ts"
 on: {
   BankAccountCreated: {
     id: (event) => event.payload.id,  // view instance ID
@@ -530,7 +530,7 @@ Projections support two consistency modes via the `consistency` field:
 - **`"eventual"`** (default): Views are updated asynchronously after the command's unit of work is committed and events are dispatched via the event bus.
 - **`"strong"`**: View updates are enlisted in the same unit of work as the originating command. If the command fails, view updates are rolled back atomically.
 
-```ts
+```ts title="projection.ts"
 const projection = defineProjection<Def>({
   // ...
   consistency: "strong",
@@ -543,7 +543,7 @@ For more details, see [View Persistence](/docs/read-model/view-persistence).
 
 A projection is a function of the event log. When you fix a reducer bug, add a field, or migrate the view schema, the views drift from the log — `Domain.rebuildProjection("<name>")` truncates the view store and replays every persisted event through the projection's `on` map handlers, restoring the views to a state derived solely from the event log.
 
-```ts
+```ts title="ops/rebuild.ts"
 const result = await domain.rebuildProjection("AccountBalance");
 // { eventsRead, eventsApplied, viewsDeleted, durationMs, projectionName }
 ```

--- a/docs/content/docs/read-model/queries.mdx
+++ b/docs/content/docs/read-model/queries.mdx
@@ -20,7 +20,7 @@ Reference](/docs/getting-started/cli#noddde-add-query-name) for details.
 
 A query is defined by extending `Query<TResult>`:
 
-```ts
+```ts title="bank-account/queries/get-bank-account-by-id.ts"
 import { Query } from "@noddde/core";
 
 interface GetBankAccountByIdQuery extends Query<BankAccountView> {
@@ -31,7 +31,7 @@ interface GetBankAccountByIdQuery extends Query<BankAccountView> {
 
 The `Query` interface has two type parameters:
 
-```ts
+```ts title="packages/core/src/cqrs/query.ts"
 interface Query<TResult, TQueryNames extends string | symbol = string> {
   name: TQueryNames;
   payload?: any;
@@ -47,7 +47,7 @@ interface Query<TResult, TQueryNames extends string | symbol = string> {
 
 The recommended way to define queries is the `DefineQueries` utility type. It creates a discriminated union from a definition map, consistent with how events and commands are defined (see [Defining Aggregates](/docs/modeling/defining-aggregates)):
 
-```ts
+```ts title="bank-account/types.ts"
 import { DefineQueries } from "@noddde/core";
 
 type BankAccountQuery = DefineQueries<{
@@ -70,7 +70,7 @@ Each key becomes a query `name`. Each value specifies:
 
 Omit the `payload` field for parameterless queries:
 
-```ts
+```ts title="stats/types.ts"
 type StatsQuery = DefineQueries<{
   GetSystemStats: { result: SystemStats };
 }>;
@@ -82,7 +82,7 @@ type StatsQuery = DefineQueries<{
 
 `QueryResult<TQuery>` extracts the result type from a query definition:
 
-```ts
+```ts title="usage.ts"
 import { QueryResult } from "@noddde/core";
 
 type Result = QueryResult<GetBankAccountByIdQuery>;
@@ -91,7 +91,7 @@ type Result = QueryResult<GetBankAccountByIdQuery>;
 
 Use `QueryResult` when you need the result type without importing the view type directly. If the query's result type changes, all consumers update automatically:
 
-```ts
+```ts title="http/handle-get-account.ts"
 async function handleGetAccount(
   req: Request,
 ): Promise<QueryResult<GetBankAccountByIdQuery>> {
@@ -116,7 +116,7 @@ async function handleGetAccount(
 
 A `QueryHandler` receives a query payload and infrastructure, then returns the result:
 
-```ts
+```ts title="packages/core/src/cqrs/query-handler.ts"
 type QueryHandler<
   TInfrastructure extends Infrastructure,
   TQuery extends Query<any>,
@@ -134,7 +134,7 @@ type QueryHandler<
 
 ### Basic Handler
 
-```ts
+```ts title="bank-account/query-handlers/handle-get-bank-account-by-id.ts"
 const getBankAccountByIdHandler: QueryHandler<
   BankingInfrastructure,
   GetBankAccountByIdQuery
@@ -147,7 +147,7 @@ The handler receives `query` as the payload (`{ id: string }` in this case), des
 
 ### Handler with Filtering and Pagination
 
-```ts
+```ts title="bank-account/query-handlers/handle-list-bank-account-transactions.ts"
 const listTransactionsHandler: QueryHandler<
   BankingInfrastructure,
   ListBankAccountTransactionsQuery
@@ -167,7 +167,7 @@ Default values for optional parameters are typically applied inside the handler.
 
 Query handlers do not have to be async. If the data source is in-memory, return the result directly:
 
-```ts
+```ts title="stats/query-handlers/handle-get-system-stats.ts"
 const getSystemStatsHandler: QueryHandler<
   AppInfrastructure,
   GetSystemStatsQuery
@@ -221,7 +221,7 @@ export const BankAccountProjection = defineProjection<BankAccountProjectionDef>(
 
 Some queries do not need a prebuilt read model. They compute results on-the-fly from raw data or external services:
 
-```ts
+```ts title="query-handlers/handle-calculate-interest.ts"
 const calculateInterestHandler: QueryHandler<
   BankingInfrastructure,
   CalculateInterestQuery
@@ -245,7 +245,7 @@ Standalone handlers are useful for computed or derived data that does not justif
 
 Standalone handlers are registered separately in the domain configuration under `readModel.standaloneQueryHandlers`:
 
-```ts
+```ts title="domain.ts"
 const myDomain = defineDomain({
   writeModel: { aggregates: { BankAccount } },
   readModel: {
@@ -267,7 +267,7 @@ const domain = await wireDomain(myDomain, {
 
 The `QueryBus` is the dispatch mechanism for queries. It provides a single `dispatch` method that routes a query to its registered handler and returns the typed result:
 
-```ts
+```ts title="packages/core/src/cqrs/query-bus.ts"
 interface QueryBus {
   dispatch<TQuery extends Query<any>>(
     query: TQuery,
@@ -279,7 +279,7 @@ interface QueryBus {
 
 The return type is automatically derived from the query type argument:
 
-```ts
+```ts title="usage.ts"
 async function example(queryBus: QueryBus) {
   // result is typed as BankAccountView
   const account = await queryBus.dispatch<GetBankAccountByIdQuery>({
@@ -302,7 +302,7 @@ The explicit type argument on `dispatch<GetBankAccountByIdQuery>(...)` serves tw
 
 noddde ships with `InMemoryQueryBus`, an in-process implementation:
 
-```ts
+```ts title="main.ts"
 import { InMemoryQueryBus } from "@noddde/engine";
 
 const queryBus = new InMemoryQueryBus();
@@ -314,7 +314,7 @@ const queryBus = new InMemoryQueryBus();
 
 The `Domain` class provides `dispatchQuery`, giving you a symmetric API alongside `dispatchCommand`:
 
-```ts
+```ts title="usage.ts"
 // In an HTTP handler, GraphQL resolver, or service layer
 const account = await domain.dispatchQuery({
   name: "GetBankAccountById",
@@ -324,7 +324,7 @@ const account = await domain.dispatchQuery({
 
 ### Dispatching from an Express Route
 
-```ts
+```ts title="http/routes.ts"
 app.get("/accounts/:id", async (req, res) => {
   try {
     const account = await domain.dispatchQuery({
@@ -342,7 +342,7 @@ app.get("/accounts/:id", async (req, res) => {
 
 For production, you may need a query bus with caching, middleware, or distributed routing. A custom implementation must satisfy the `QueryBus` interface:
 
-```ts
+```ts title="infrastructure/production-query-bus.ts"
 class ProductionQueryBus<TInfrastructure extends Infrastructure>
   implements QueryBus
 {
@@ -375,7 +375,7 @@ When building a production query bus, consider error handling for unregistered q
 
 Query handlers can throw errors for invalid queries or missing data. The error propagates through the query bus to the caller:
 
-```ts
+```ts title="bank-account/query-handlers/handle-get-bank-account-by-id.ts"
 const getBankAccountByIdHandler: QueryHandler<
   BankingInfrastructure,
   GetBankAccountByIdQuery

--- a/docs/content/docs/read-model/view-persistence.mdx
+++ b/docs/content/docs/read-model/view-persistence.mdx
@@ -9,7 +9,7 @@ View persistence enables projections to automatically store and retrieve per-ent
 
 `ViewStore<TView>` is the base persistence interface for projection views:
 
-```ts
+```ts title="packages/core/src/ddd/view-store.ts"
 import type { ID } from "@noddde/core";
 
 interface ViewStore<TView = any> {
@@ -28,7 +28,7 @@ interface ViewStore<TView = any> {
 
 The base interface provides `save`, `load`, and `delete`. For advanced filtering, extend it:
 
-```ts
+```ts title="bank-account/types.ts"
 interface BankAccountViewStore extends ViewStore<BankAccountView> {
   findByBalanceRange(min: number, max: number): Promise<BankAccountView[]>;
   findByOwner(ownerId: string): Promise<BankAccountView[]>;
@@ -41,7 +41,7 @@ Custom methods are available in query handlers via the `{ views }` injection. Ex
 
 Any class or object that satisfies the three-method contract is a valid view store. A minimal stub:
 
-```ts
+```ts title="infrastructure/my-view-store.ts"
 import type { ID, ViewStore } from "@noddde/core";
 
 class MyViewStore<TView> implements ViewStore<TView> {
@@ -61,7 +61,7 @@ class MyViewStore<TView> implements ViewStore<TView> {
 
 The engine provides `InMemoryViewStore<TView>` for development and testing:
 
-```ts
+```ts title="usage.ts"
 import { InMemoryViewStore } from "@noddde/engine";
 
 const store = new InMemoryViewStore<BankAccountView>();
@@ -223,7 +223,7 @@ Sometimes a projection should remove a view in response to an event — a user i
 
 noddde exports a unique-symbol sentinel `DeleteView` for exactly this purpose. Returning it from a reducer instructs the engine to call `viewStore.delete(viewId)` instead of `viewStore.save(viewId, ...)` for that event.
 
-```ts
+```ts title="user/projection.ts"
 import { DeleteView, defineProjection } from "@noddde/core";
 
 const UserProjection = defineProjection<UserProjectionDef>({
@@ -254,7 +254,7 @@ When an event arrives for a projection with auto-persistence configured:
 
 The check is on the awaited value, so async reducers are supported. Because TypeScript widens a unique-symbol return from an async arrow to plain `symbol` when the contextual type is a union, give the async arrow an explicit return type:
 
-```ts
+```ts title="user/on-entries/on-user-deleted.ts"
 // Annotate the return type so TypeScript preserves `typeof DeleteView`.
 reduce: async (): Promise<typeof DeleteView> => DeleteView;
 ```
@@ -265,7 +265,7 @@ Sync arrows infer correctly without the annotation (`reduce: () => DeleteView`).
 
 Because the reducer's return type is a union, a single reducer can decide between updating the view and deleting it based on event content:
 
-```ts
+```ts title="item/projection.ts"
 const ItemProjection = defineProjection<ItemProjectionDef>({
   on: {
     ItemDeactivated: {
@@ -290,7 +290,7 @@ Deleting a view that does not exist is a no-op. The `ViewStore` contract require
 
 For projections with `consistency: "strong"`, view deletion is enlisted in the same unit of work as the originating command. If the command fails, the deletion is rolled back atomically:
 
-```ts
+```ts title="user/projection.ts"
 const UserProjection = defineProjection<UserProjectionDef>({
   on: {
     UserDeleted: {
@@ -346,7 +346,7 @@ Unlike the old exhaustive `identity` map, only events the projection cares about
 
 When `load()` returns `undefined` (new entity), the reducer receives `undefined` as the current view. To provide a default starting state, use `initialView`:
 
-```ts
+```ts title="account/projection.ts"
 const projection = defineProjection<Def>({
   on: {
     AccountCreated: {
@@ -363,7 +363,7 @@ const projection = defineProjection<Def>({
 
 The `viewStore` value lives in the domain configuration, under `projections`. It must be a `ViewStoreFactory` — a singleton with a `getForContext(ctx?)` method:
 
-```ts
+```ts title="main.ts"
 projections: {
   // Class-based factory (typical for ORM-backed stores).
   Account: { viewStore: new PrismaAccountViewStoreFactory(prisma) },
@@ -382,7 +382,7 @@ projections: {
 
 Implementing one is small:
 
-```ts
+```ts title="infrastructure/prisma-account-view-store-factory.ts"
 import type { Prisma, PrismaClient } from "@prisma/client";
 import type { ID, ViewStore, ViewStoreFactory } from "@noddde/core";
 
@@ -421,7 +421,7 @@ export class PrismaAccountViewStoreFactory
 
 For simple cases, use the `createViewStoreFactory` helper:
 
-```ts
+```ts title="infrastructure/account-view-store-factory.ts"
 import { createViewStoreFactory } from "@noddde/core";
 
 const factory = createViewStoreFactory<AccountView>(
@@ -436,7 +436,7 @@ const factory = createViewStoreFactory<AccountView>(
 
 When you already have a store instance in scope (typical in tests or lightweight setups), wrap it in a factory inline:
 
-```ts
+```ts title="main.ts"
 import { createViewStoreFactory } from "@noddde/core";
 
 const sharedStore = new InMemoryViewStore<AccountView>();
@@ -480,7 +480,7 @@ Command -> Aggregate -> Events -> [load + reduce + save/delete inside UoW commit
 
 Enable it with `consistency: "strong"`:
 
-```ts
+```ts title="projection.ts"
 const projection = defineProjection<Def>({
   on: {
     Created: onCreated, // extracted handler with InferProjectionEventHandler

--- a/docs/content/docs/running/domain-configuration.mdx
+++ b/docs/content/docs/running/domain-configuration.mdx
@@ -22,7 +22,7 @@ This separation allows domain definitions to be shared, tested, and analyzed ind
 
 `defineDomain` is a sync identity function -- it returns the input unchanged with full type inference. Consistent with `defineAggregate`, `defineProjection`, `defineSaga`. It lives in `@noddde/core` (and is re-exported from `@noddde/engine` for backward compatibility).
 
-```ts
+```ts title="domain.ts"
 import { defineDomain } from "@noddde/core";
 
 const bankingDomain = defineDomain({
@@ -61,7 +61,7 @@ The `TInfrastructure` generic is a type parameter only -- it flows through handl
 
 `wireDomain` accepts a `DomainDefinition` and an **optional** `DomainWiring`, resolves all factories, creates a `Domain` instance, and returns it. The wiring parameter can be omitted entirely for a zero-config hello world:
 
-```ts
+```ts title="main.ts"
 import { wireDomain } from "@noddde/engine";
 
 // Hello world -- everything defaults to in-memory
@@ -70,7 +70,7 @@ const domain = await wireDomain(bankingDomain);
 
 When you're ready for production, provide explicit wiring:
 
-```ts
+```ts title="main.ts"
 const domain = await wireDomain(bankingDomain, {
   // User-provided services (what handlers receive as `infrastructure`)
   infrastructure: () => ({
@@ -144,7 +144,7 @@ All fields are optional. Both `wireDomain(definition)` and `wireDomain(definitio
 
 The `persistenceAdapter` field accepts a `PersistenceAdapter` instance. When provided, the engine resolves aggregate persistence, saga persistence, unit-of-work, snapshots, outbox, idempotency, and locking from the adapter when not explicitly wired. Explicit wiring always takes precedence over adapter defaults.
 
-```ts
+```ts title="main.ts"
 import { DrizzleAdapter } from "@noddde/drizzle";
 
 const adapter = new DrizzleAdapter(db);
@@ -186,7 +186,7 @@ See [Logging](/docs/running/logging) for full details on output formats, log lev
 
 The `aggregates` field accepts either a global config (applies to all aggregates) or a per-aggregate record:
 
-```ts
+```ts title="main.ts"
 // Global: all aggregates share the same config
 aggregates: {
   persistence: () => adapter.eventSourcedPersistence,
@@ -237,7 +237,7 @@ The `concurrency` field accepts string shorthands or object form:
 
 View stores are configured per-projection in the wiring, separating runtime concerns from the projection definition. Each `viewStore` is a `ViewStoreFactory` — either an instance of a class implementing the interface, or a plain object built with `createViewStoreFactory`:
 
-```ts
+```ts title="main.ts"
 import { createViewStoreFactory } from "@noddde/core";
 import { InMemoryViewStoreFactory } from "@noddde/engine";
 
@@ -267,7 +267,7 @@ The `writeModel` section defines how your application processes commands.
 
 The `aggregates` map associates names with [aggregate definitions](/docs/modeling/defining-aggregates):
 
-```ts
+```ts title="domain.ts"
 import { BankAccount } from "./aggregate";
 
 writeModel: {
@@ -285,7 +285,7 @@ A domain can register any number of aggregate types. Each aggregate type handles
 
 Some commands do not target a specific aggregate instance. These are handled by standalone command handlers:
 
-```ts
+```ts title="standalone-command-handlers/process-settlements.ts"
 import { StandaloneCommandHandler } from "@noddde/core";
 
 const processSettlements: StandaloneCommandHandler<
@@ -305,7 +305,7 @@ const processSettlements: StandaloneCommandHandler<
 
 Register them in `standaloneCommandHandlers`:
 
-```ts
+```ts title="domain.ts"
 writeModel: {
   aggregates: { BankAccount },
   standaloneCommandHandlers: {
@@ -322,7 +322,7 @@ The `readModel` section defines how your application builds views and serves que
 
 ### Registering Projections
 
-```ts
+```ts title="domain.ts"
 import { BankAccountProjection } from "./projection";
 import { TransactionHistoryProjection } from "./transaction-history";
 
@@ -342,7 +342,7 @@ Each [projection](/docs/read-model/projections) receives events from the `EventB
 
 For queries that do not belong to any specific projection, register them as standalone query handlers:
 
-```ts
+```ts title="domain.ts"
 import { QueryHandler } from "@noddde/core";
 
 const getSystemStatus: QueryHandler<
@@ -369,7 +369,7 @@ Standalone query handlers are useful for cross-projection queries, system health
 
 The `processModel` section registers [sagas](/docs/process-managers/sagas) and standalone event handlers for event-driven workflows and side effects:
 
-```ts
+```ts title="domain.ts"
 import { BookingFulfillmentSaga } from "./process-model/booking-fulfillment";
 
 processModel: {
@@ -390,7 +390,7 @@ Both `sagas` and `standaloneEventHandlers` are optional — include only what yo
 
 Standalone event handlers are lightweight, stateless functions that react to domain events with simple side effects — sending emails, logging audit trails, notifying external systems. Unlike sagas, they don't maintain state, don't dispatch commands, and don't need persistence.
 
-```ts
+```ts title="domain.ts"
 standaloneEventHandlers: {
   OrderPlaced: async (event, infrastructure) => {
     await infrastructure.analytics.track("order_placed", event.payload);
@@ -411,7 +411,7 @@ The `Domain` class returned by `wireDomain` exposes the main capabilities of you
 
 ### Dispatching Commands
 
-```ts
+```ts title="main.ts"
 const aggregateId = await domain.dispatchCommand({
   name: "CreateBankAccount",
   targetAggregateId: "acc-123",
@@ -422,7 +422,7 @@ const aggregateId = await domain.dispatchCommand({
 
 ### Dispatching Queries
 
-```ts
+```ts title="main.ts"
 const account = await domain.dispatchQuery({
   name: "GetBankAccountById",
   payload: { id: "acc-123" },
@@ -433,7 +433,7 @@ const account = await domain.dispatchQuery({
 
 ### Accessing Infrastructure
 
-```ts
+```ts title="main.ts"
 const { commandBus, eventBus, queryBus } = domain.infrastructure;
 ```
 
@@ -443,7 +443,7 @@ The `infrastructure` getter returns the merged custom infrastructure and CQRS in
 
 Projection views are persisted via `ViewStore`. To read a projection's view, query through the query bus or access the view store directly from your infrastructure:
 
-```ts
+```ts title="main.ts"
 // Via query bus
 const view = await domain.infrastructure.queryBus.dispatch({
   name: "GetOrderSummary",
@@ -462,7 +462,7 @@ Every event dispatched through the domain is automatically enriched with an `Eve
 
 ### What Metadata Contains
 
-```ts
+```ts title="packages/core/src/edd/event-metadata.ts"
 interface EventMetadata {
   eventId: string; // UUID v7 (time-ordered)
   timestamp: string; // ISO 8601
@@ -479,7 +479,7 @@ interface EventMetadata {
 
 The `metadataProvider` is a function called on every command dispatch. Use it to inject per-request context (e.g., the authenticated user ID or a trace ID from HTTP middleware):
 
-```ts
+```ts title="main.ts"
 const domain = await wireDomain(bankingDomain, {
   // ...other wiring
   metadataProvider: () => ({
@@ -495,7 +495,7 @@ Values from the provider are merged into every event's metadata. Fields you omit
 
 For one-off overrides (admin actions, migration scripts, manual fixes), use `withMetadataContext` as an escape hatch:
 
-```ts
+```ts title="main.ts"
 await domain.withMetadataContext(
   { userId: "admin", correlationId: "manual-fix-123" },
   () => domain.dispatchCommand(fixCommand),
@@ -512,7 +512,7 @@ When a saga dispatches commands in response to an event, the engine automaticall
 
 Here is a full domain configuration for a banking application using `defineDomain` + `wireDomain`:
 
-```ts
+```ts title="main.ts"
 import { defineDomain } from "@noddde/core";
 import {
   wireDomain,
@@ -587,7 +587,7 @@ const account = await domain.dispatchQuery({
 
 When your application needs to stop — whether for a deployment, scaling event, or process signal — call `domain.shutdown()` to safely wind down the domain:
 
-```ts
+```ts title="main.ts"
 const domain = await wireDomain(bankingDomain, {
   /* wiring */
 });
@@ -609,7 +609,7 @@ Shutdown proceeds through four sequential phases:
 
 You can set a maximum duration for the drain phases:
 
-```ts
+```ts title="main.ts"
 await domain.shutdown({ timeoutMs: 10_000 }); // 10 seconds
 ```
 
@@ -619,7 +619,7 @@ The default timeout is 30 seconds. If in-flight operations do not complete withi
 
 Commands and queries dispatched after shutdown has started receive a `DomainShutdownError`:
 
-```ts
+```ts title="main.ts"
 import { DomainShutdownError } from "@noddde/engine";
 
 try {
@@ -639,7 +639,7 @@ Calling `shutdown()` multiple times returns the same promise. The shutdown seque
 
 If your custom infrastructure holds resources (database connections, file handles, network sockets), implement the `Closeable` interface so the domain releases them automatically:
 
-```ts
+```ts title="infrastructure/database-pool.ts"
 import type { Closeable } from "@noddde/core";
 
 class MyDatabasePool implements Closeable {

--- a/docs/content/docs/running/event-bus-adapters.mdx
+++ b/docs/content/docs/running/event-bus-adapters.mdx
@@ -26,7 +26,7 @@ noddde ships with an in-memory `EventEmitterEventBus` for single-process develop
 
 Every adapter implements this interface:
 
-```ts
+```ts title="packages/core/src/edd/event-bus.ts"
 import type { Closeable } from "@noddde/core";
 
 type AsyncEventHandler = (event: Event) => void | Promise<void>;

--- a/docs/content/docs/running/idempotent-commands.mdx
+++ b/docs/content/docs/running/idempotent-commands.mdx
@@ -7,7 +7,7 @@ In distributed systems, commands may be delivered more than once — network ret
 
 ## Quick Example
 
-```ts
+```ts title="main.ts"
 // First dispatch — processes normally, events persisted and published
 await domain.dispatchCommand({
   name: "Transfer",
@@ -52,7 +52,7 @@ After successful execution, the `commandId` is recorded in the same [unit of wor
 
 The `commandId` is an optional field on the base `Command` interface:
 
-```ts
+```ts title="packages/core/src/cqrs/command.ts"
 interface Command {
   name: string;
   payload?: any;
@@ -64,7 +64,7 @@ Since `AggregateCommand` extends `Command`, the field is available on all aggreg
 
 When using `DefineCommands` to build command unions, the `commandId` field is not part of the generated types (it is a framework concern, not a domain modeling concern). Pass it at dispatch time:
 
-```ts
+```ts title="main.ts"
 // Inline — TypeScript infers the full type including commandId
 await domain.dispatchCommand({
   name: "CreateAccount",
@@ -81,7 +81,7 @@ await domain.dispatchCommand({ ...cmd, commandId: requestId });
 
 Add an `idempotency` factory to your [domain wiring](/docs/running/domain-configuration):
 
-```ts
+```ts title="main.ts"
 import { wireDomain, InMemoryIdempotencyStore } from "@noddde/engine";
 
 const domain = await wireDomain(bankingDomain, {
@@ -96,14 +96,14 @@ Without `idempotency` configured, the `commandId` field is ignored and all comma
 
 The `InMemoryIdempotencyStore` accepts an optional `ttlMs` parameter. When set, `exists()` performs lazy cleanup: if a record has expired, it is deleted and the command is treated as new.
 
-```ts
+```ts title="main.ts"
 // Records auto-expire after 24 hours on exists() checks
 const store = new InMemoryIdempotencyStore(24 * 60 * 60 * 1000);
 ```
 
 For explicit batch cleanup (e.g., on a timer), call `removeExpired()`:
 
-```ts
+```ts title="main.ts"
 // Remove all records older than 1 hour
 await store.removeExpired(60 * 60 * 1000);
 ```
@@ -112,7 +112,7 @@ Without a `ttlMs`, records persist indefinitely until explicitly removed.
 
 ## The IdempotencyStore Interface
 
-```ts
+```ts title="packages/core/src/cqrs/idempotency-store.ts"
 interface IdempotencyRecord {
   commandId: ID;
   aggregateName: string;

--- a/docs/content/docs/running/infrastructure.mdx
+++ b/docs/content/docs/running/infrastructure.mdx
@@ -13,7 +13,7 @@ A decide handler that decides whether a transaction is authorized should not kno
 
 noddde enforces this by injecting infrastructure as a function parameter, never as a direct import:
 
-```ts
+```ts title="bank-account/bank-account.ts"
 decide: {
   AuthorizeTransaction: (command, state, { logger }) => {
     logger.info(`Processing transaction for ${command.payload.merchant}`);
@@ -28,13 +28,13 @@ The handler depends on the `Logger` interface, not a concrete `SystemClock`. Thi
 
 The base `Infrastructure` type is deliberately empty:
 
-```ts
+```ts title="packages/core/src/infrastructure/infrastructure.ts"
 type Infrastructure = {};
 ```
 
 You extend it with whatever your domain needs:
 
-```ts
+```ts title="infrastructure/index.ts"
 interface BankingInfrastructure {
   logger: Logger;
   bankAccountViewRepository: BankAccountViewRepository;
@@ -48,7 +48,7 @@ This type becomes the `infrastructure` member of your [AggregateTypes](/docs/mod
 
 The recommended pattern is to declare a **narrow infrastructure interface per component** rather than a single god-interface for the entire domain:
 
-```ts
+```ts title="infrastructure/index.ts"
 // Auction aggregate only needs a clock
 interface AuctionInfrastructure {
   clock: Clock;
@@ -68,7 +68,7 @@ interface PaymentInfrastructure {
 
 When you wire the domain, `wireDomain` computes the intersection of all these types. The `infrastructure` factory must return an object satisfying all of them:
 
-```ts
+```ts title="main.ts"
 const domain = await wireDomain(definition, {
   // Compiler requires: { clock: Clock, emailService: EmailService, paymentGateway: PaymentGateway }
   infrastructure: () => ({
@@ -87,7 +87,7 @@ Components that share the same dependency (like `clock` above) simply declare it
 
 Each member of your infrastructure type should be an interface with concrete implementations:
 
-```ts
+```ts title="infrastructure/clock.ts"
 interface Clock {
   now(): Date;
 }
@@ -128,7 +128,7 @@ Infrastructure appears as a parameter in three handler types:
 
 In addition to your custom infrastructure, noddde provides a built-in `CQRSInfrastructure` type:
 
-```ts
+```ts title="packages/core/src/cqrs/cqrs-infrastructure.ts"
 interface CQRSInfrastructure {
   commandBus: CommandBus;
   eventBus: EventBus;
@@ -152,7 +152,7 @@ With `wireDomain`, infrastructure is provided via the `DomainWiring` object. The
 
 The `infrastructure` factory provides your custom domain services -- repositories, clients, clocks:
 
-```ts
+```ts title="main.ts"
 const domain = await wireDomain(bankingDomain, {
   infrastructure: () => ({
     clock: new SystemClock(),
@@ -169,7 +169,7 @@ The infrastructure type is **inferred automatically** from your aggregates, proj
 
 The `buses` factory provides the three CQRS buses. It receives the resolved user infrastructure as a parameter:
 
-```ts
+```ts title="main.ts"
 buses: (customInfra) => ({
   commandBus: new InMemoryCommandBus(),
   eventBus: new EventEmitterEventBus(),
@@ -181,7 +181,7 @@ buses: (customInfra) => ({
 
 The `aggregates` field provides persistence, concurrency, and snapshots -- either globally or per-aggregate:
 
-```ts
+```ts title="main.ts"
 // Global: all aggregates share the same config
 aggregates: {
   persistence: () => new InMemoryEventSourcedAggregatePersistence(),
@@ -207,7 +207,7 @@ See [Persistence](/docs/running/persistence) for details on persistence strategi
 
 View stores are provided per-projection, separating runtime concerns from projection definitions:
 
-```ts
+```ts title="main.ts"
 import { InMemoryViewStoreFactory } from "@noddde/engine";
 
 projections: {
@@ -218,7 +218,7 @@ projections: {
 
 ### Other Wiring Fields
 
-```ts
+```ts title="main.ts"
 unitOfWork: () => () => new PostgresUnitOfWork(pool),
 idempotency: () => new InMemoryIdempotencyStore(),
 sagas: { persistence: () => new InMemorySagaPersistence() },
@@ -232,7 +232,7 @@ All providers are factory functions (not raw values). This is intentional:
 - **Async setup** -- Database connections, service discovery, config loading
 - **Clean isolation** -- Each test can create fresh infrastructure
 
-```ts
+```ts title="main.ts"
 infrastructure: async () => {
   const dbConnection = await connectToDatabase();
   return {
@@ -268,7 +268,7 @@ The built-in buses (`InMemoryCommandBus`, `EventEmitterEventBus`, `InMemoryQuery
 
 A common pattern is to wrap a bus with logging:
 
-```ts
+```ts title="infrastructure/logging-command-bus.ts"
 class LoggingCommandBus implements CommandBus {
   constructor(
     private readonly inner: CommandBus,
@@ -296,7 +296,7 @@ Notice how `buses` receives the custom infrastructure as a parameter. This allow
 
 The `defineDomain` + `wireDomain` split makes it especially easy to swap infrastructure for testing -- the domain definition is shared, only the wiring differs:
 
-```ts
+```ts title="main.ts"
 // Shared domain definition
 const bankingDomain = defineDomain({
   writeModel: { aggregates: { BankAccount } },
@@ -335,7 +335,7 @@ Same domain definition, different wiring. The domain logic does not change -- on
 
 After configuration, buses are available on `domain.infrastructure`:
 
-```ts
+```ts title="main.ts"
 const domain = await wireDomain(bankingDomain, {
   /* ... */
 });
@@ -347,7 +347,7 @@ const { commandBus, eventBus, queryBus } = domain.infrastructure;
 
 If your custom infrastructure holds resources that need cleanup on shutdown (database pools, file handles, network connections), implement the `Closeable` interface:
 
-```ts
+```ts title="infrastructure/postgres-bank-account-repository.ts"
 import type { Closeable } from "@noddde/core";
 
 class PostgresBankAccountRepository

--- a/docs/content/docs/running/logging.mdx
+++ b/docs/content/docs/running/logging.mdx
@@ -59,7 +59,7 @@ Everything else gets JSON. No environment variables to set, no config flags to t
 
 The default level is `'warn'` -- only warnings and errors are visible. To see more detail, pass a `NodddeLogger` with a lower level:
 
-```ts
+```ts title="main.ts"
 import { wireDomain, NodddeLogger } from "@noddde/engine";
 
 const domain = await wireDomain(bankingDomain, {
@@ -81,7 +81,7 @@ A message is emitted only when its severity is **>=** the configured level.
 
 To suppress all framework logging:
 
-```ts
+```ts title="main.ts"
 import { NoopLogger } from "@noddde/engine";
 
 const domain = await wireDomain(bankingDomain, {
@@ -95,7 +95,7 @@ The framework logger is automatically available as `infrastructure.logger` in **
 
 ### In Aggregate Decide Handlers
 
-```ts
+```ts title="bank-account/bank-account.ts"
 const BankAccount = defineAggregate<BankAccountTypes>({
   initialState: { balance: 0 },
   decide: {
@@ -118,7 +118,7 @@ const BankAccount = defineAggregate<BankAccountTypes>({
 
 ### In Saga Handlers
 
-```ts
+```ts title="order-fulfillment/saga.ts"
 const OrderFulfillment = defineSaga<OrderFulfillmentTypes>({
   initialState: { status: "pending" },
   startedBy: ["OrderPlaced"],
@@ -144,7 +144,7 @@ const OrderFulfillment = defineSaga<OrderFulfillmentTypes>({
 
 ### In Query Handlers
 
-```ts
+```ts title="bank-account/query-handlers/handle-get-account-by-id.ts"
 const getAccountById: QueryHandler<BankingInfrastructure, GetAccountQuery> = (
   query,
   infrastructure,
@@ -158,7 +158,7 @@ const getAccountById: QueryHandler<BankingInfrastructure, GetAccountQuery> = (
 
 Use `child()` to create loggers with a more specific namespace:
 
-```ts
+```ts title="bank-account/bank-account.ts"
 Deposit: (command, state, infrastructure) => {
   const log = infrastructure.logger.child("deposit");
   log.info("Processing"); // logs as [noddde:deposit]
@@ -172,7 +172,7 @@ The framework itself uses child loggers with namespaces like `domain`, `command`
 
 The `infrastructure` factory in `DomainWiring` receives the framework logger as its first argument. Use it to inject logging into your custom services at construction time:
 
-```ts
+```ts title="main.ts"
 const domain = await wireDomain(bankingDomain, {
   infrastructure: (logger) => ({
     paymentGateway: new StripeGateway(logger.child("stripe")),
@@ -192,7 +192,7 @@ This gives your services properly-scoped child loggers that share the same level
 
 You can replace the built-in logger entirely by implementing the `Logger` interface from `@noddde/core`:
 
-```ts
+```ts title="infrastructure/pino-logger.ts"
 import type { Logger } from "@noddde/core";
 
 function createPinoLogger(pino: PinoInstance, ns: string): Logger {
@@ -213,7 +213,7 @@ const domain = await wireDomain(bankingDomain, {
 
 The `Logger` interface is minimal:
 
-```ts
+```ts title="packages/core/src/infrastructure/logger.ts"
 interface Logger {
   debug(message: string, data?: Record<string, unknown>): void;
   info(message: string, data?: Record<string, unknown>): void;

--- a/docs/content/docs/running/observability.mdx
+++ b/docs/content/docs/running/observability.mdx
@@ -17,17 +17,25 @@ This means:
 
 ## Setup
 
-### 1. Install the OTel API and an SDK
+<Steps>
+
+<Step>
+
+### Install the OTel API and an SDK
 
 ```bash
 npm install @opentelemetry/api @opentelemetry/sdk-trace-node @opentelemetry/auto-instrumentations-node
 ```
 
-### 2. Register a tracer provider
+</Step>
+
+<Step>
+
+### Register a tracer provider
 
 Configure OTel before calling `wireDomain()`. A typical setup:
 
-```ts
+```ts title="infrastructure/tracing.ts"
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
@@ -44,9 +52,13 @@ const provider = new NodeTracerProvider({
 provider.register();
 ```
 
-### 3. Wire your domain as usual
+</Step>
 
-```ts
+<Step>
+
+### Wire your domain as usual
+
+```ts title="main.ts"
 import { wireDomain } from "@noddde/engine";
 
 const domain = await wireDomain(myDomainDefinition, {
@@ -55,6 +67,10 @@ const domain = await wireDomain(myDomainDefinition, {
 ```
 
 The engine logs `"OpenTelemetry detected. Tracing enabled."` at info level when OTel is found. If not found, it logs `"OpenTelemetry not detected. Tracing disabled."` at debug level.
+
+</Step>
+
+</Steps>
 
 ## What Gets Traced
 

--- a/docs/content/docs/running/outbox-pattern.mdx
+++ b/docs/content/docs/running/outbox-pattern.mdx
@@ -9,7 +9,7 @@ The **transactional outbox pattern** solves this by writing events to an outbox 
 
 ## Quick Example
 
-```ts
+```ts title="main.ts"
 import { wireDomain, InMemoryOutboxStore } from "@noddde/engine";
 
 const domain = await wireDomain(orderDomain, {
@@ -61,7 +61,7 @@ Best-effort: outboxStore.markPublishedByEventIds()  <-- cleanup
 
 Add the `outbox` field as a top-level field in your `wireDomain` configuration:
 
-```ts
+```ts title="main.ts"
 outbox: {
   // Factory for the outbox store (called once during init)
   store: () => new InMemoryOutboxStore(),
@@ -75,7 +75,7 @@ outbox: {
 
 For production, all three [persistence adapter packages](/docs/running/persistence-adapters) (`@noddde/drizzle`, `@noddde/prisma`, `@noddde/typeorm`) include a database-backed `OutboxStore` via the adapter's `outboxStore` field. When you wire the domain with a `persistenceAdapter`, the outbox is resolved from the adapter automatically:
 
-```ts
+```ts title="main.ts"
 // Drizzle: the adapter exposes outboxStore directly
 import { DrizzleAdapter } from "@noddde/drizzle";
 const adapter = new DrizzleAdapter(db);
@@ -96,7 +96,7 @@ const typeormAdapter = new TypeORMAdapter(dataSource);
 
 The outbox relay is **not started automatically** during `domain.init()`. You control its lifecycle explicitly:
 
-```ts
+```ts title="main.ts"
 // Start polling
 domain.startOutboxRelay();
 
@@ -111,7 +111,7 @@ Both `startOutboxRelay()` and `stopOutboxRelay()` are idempotent — calling the
 
 ## The OutboxStore Interface
 
-```ts
+```ts title="packages/core/src/edd/outbox-store.ts"
 interface OutboxEntry {
   id: string; // UUID v7 (time-ordered)
   event: Event; // Fully enriched domain event
@@ -140,7 +140,7 @@ interface OutboxStore {
 
 Use `processOutboxOnce()` instead of starting the relay in tests:
 
-```ts
+```ts title="__tests__/outbox.test.ts"
 import { InMemoryOutboxStore } from "@noddde/engine";
 
 const outboxStore = new InMemoryOutboxStore();

--- a/docs/content/docs/running/persistence-adapters.mdx
+++ b/docs/content/docs/running/persistence-adapters.mdx
@@ -37,7 +37,7 @@ For SQLite or any dialect without advisory lock support, use `InMemoryAggregateL
 
 Each package exports a class-based adapter that implements the `PersistenceAdapter` interface from `@noddde/core`. Pass it to `wireDomain` via the `persistenceAdapter` property and the engine resolves all persistence concerns automatically:
 
-```ts
+```ts title="main.ts"
 import { DrizzleAdapter } from "@noddde/drizzle";
 import { wireDomain } from "@noddde/engine";
 

--- a/docs/content/docs/running/persistence.mdx
+++ b/docs/content/docs/running/persistence.mdx
@@ -13,7 +13,7 @@ For the conceptual foundation of event sourcing and CQRS, see [CQRS and Event So
 
 With event sourcing, events are the source of truth. State is ephemeral -- derived on every load by replaying the complete event history through the aggregate's evolve handlers.
 
-```ts
+```ts title="packages/core/src/persistence/event-sourced-aggregate-persistence.ts"
 interface EventSourcedAggregatePersistence {
   save(
     aggregateName: string,
@@ -34,7 +34,7 @@ Each aggregate instance has its own event stream, identified by the combination 
 
 With state storage, the current state is saved directly. No event replay is needed -- the loaded state is used as-is.
 
-```ts
+```ts title="packages/core/src/persistence/state-stored-aggregate-persistence.ts"
 interface StateStoredAggregatePersistence {
   save(
     aggregateName: string,
@@ -60,7 +60,7 @@ For long-lived aggregates with large event streams, replaying every event on eac
 
 Snapshots are not the source of truth — the event stream is. Deleting all snapshots is safe; the engine falls back to full replay.
 
-```ts
+```ts title="packages/core/src/persistence/snapshot-store.ts"
 interface Snapshot {
   state: any;
   version: number; // event stream version at snapshot time
@@ -83,7 +83,7 @@ interface SnapshotStore {
 
 A `SnapshotStrategy` is a pure function that decides whether to take a snapshot after each command. The built-in `everyNEvents` factory covers the common case:
 
-```ts
+```ts title="main.ts"
 import { everyNEvents } from "@noddde/core";
 
 // Snapshot every 100 events
@@ -92,7 +92,7 @@ const strategy = everyNEvents(100);
 
 You can also write custom strategies:
 
-```ts
+```ts title="infrastructure/snapshot-strategy.ts"
 import type { SnapshotStrategy } from "@noddde/core";
 
 const customStrategy: SnapshotStrategy = ({ version, eventsSinceSnapshot }) => {
@@ -105,7 +105,7 @@ const customStrategy: SnapshotStrategy = ({ version, eventsSinceSnapshot }) => {
 
 With `wireDomain`, snapshots are configured as part of the aggregate wiring -- either globally or per-aggregate:
 
-```ts
+```ts title="main.ts"
 import {
   wireDomain,
   InMemoryEventSourcedAggregatePersistence,
@@ -148,7 +148,7 @@ Both `store` and `strategy` must be present in the `snapshots` object for snapsh
 
 When a snapshot exists, the engine only needs events that occurred after it. If the persistence implementation also implements `PartialEventLoad`, the engine uses `loadAfterVersion()` to avoid loading the full event stream:
 
-```ts
+```ts title="packages/core/src/persistence/partial-event-load.ts"
 interface PartialEventLoad {
   loadAfterVersion(
     aggregateName: string,
@@ -168,7 +168,7 @@ Snapshots are saved **after** the unit of work commits, as a best-effort operati
 
 Sagas are always state-stored. The `SagaPersistence` interface mirrors the state-stored aggregate interface:
 
-```ts
+```ts title="packages/core/src/persistence/saga-persistence.ts"
 interface SagaPersistence {
   save(sagaName: string, sagaId: ID, state: any): Promise<void>;
   load(sagaName: string, sagaId: ID): Promise<any>;
@@ -183,7 +183,7 @@ Required when using sagas (`processModel`) in your [domain configuration](/docs/
 
 Provide persistence via the `aggregates` field in `wireDomain`:
 
-```ts
+```ts title="main.ts"
 import {
   wireDomain,
   InMemoryEventSourcedAggregatePersistence,
@@ -202,7 +202,7 @@ const domain = await wireDomain(bankingDomain, {
 
 For per-aggregate persistence, provide each aggregate name mapped to its own wiring. All registered aggregates must have an entry:
 
-```ts
+```ts title="main.ts"
 const domain = await wireDomain(myDomain, {
   aggregates: {
     Order: {
@@ -227,7 +227,7 @@ When `concurrency` is omitted, no retry logic or locking is applied. The version
 
 This is appropriate for low-contention scenarios and works with every database dialect supported by your ORM adapter.
 
-```ts
+```ts title="main.ts"
 const domain = await wireDomain(myDomain, {
   aggregates: {
     persistence: () => new InMemoryEventSourcedAggregatePersistence(),
@@ -240,7 +240,7 @@ const domain = await wireDomain(myDomain, {
 
 Opt into automatic retries by setting `maxRetries`. On `ConcurrencyError`, the domain re-executes the full load->execute->save cycle against the latest state, up to `maxRetries` times. If all retries are exhausted, `ConcurrencyError` propagates.
 
-```ts
+```ts title="main.ts"
 const domain = await wireDomain(myDomain, {
   aggregates: {
     persistence: () => new InMemoryEventSourcedAggregatePersistence(),
@@ -257,7 +257,7 @@ Decide handlers may be called multiple times during retry and should be side-eff
 
 For high-contention aggregates where retries waste work, pessimistic locking serializes access by acquiring an exclusive lock before loading the aggregate.
 
-```ts
+```ts title="main.ts"
 import { InMemoryAggregateLocker } from "@noddde/engine";
 
 const domain = await wireDomain(myDomain, {
@@ -276,7 +276,7 @@ const domain = await wireDomain(myDomain, {
 
 Different aggregates can use different concurrency strategies:
 
-```ts
+```ts title="main.ts"
 const domain = await wireDomain(myDomain, {
   aggregates: {
     // High-contention: pessimistic locking
@@ -327,7 +327,7 @@ The `@noddde/engine` package includes in-memory implementations that require no 
 
 ### InMemoryEventSourcedAggregatePersistence
 
-```ts
+```ts title="main.ts"
 import { InMemoryEventSourcedAggregatePersistence } from "@noddde/engine";
 
 const persistence = new InMemoryEventSourcedAggregatePersistence();
@@ -337,7 +337,7 @@ Stores event streams in memory, keyed by `(aggregateName, aggregateId)`. Also im
 
 ### InMemorySnapshotStore
 
-```ts
+```ts title="main.ts"
 import { InMemorySnapshotStore } from "@noddde/engine";
 
 const snapshotStore = new InMemorySnapshotStore();
@@ -347,7 +347,7 @@ Stores aggregate state snapshots in memory, keyed by `(aggregateName, aggregateI
 
 ### InMemoryStateStoredAggregatePersistence
 
-```ts
+```ts title="main.ts"
 import { InMemoryStateStoredAggregatePersistence } from "@noddde/engine";
 
 const persistence = new InMemoryStateStoredAggregatePersistence();
@@ -357,7 +357,7 @@ Stores aggregate state snapshots in memory, keyed by `(aggregateName, aggregateI
 
 ### InMemoryIdempotencyStore
 
-```ts
+```ts title="main.ts"
 import { InMemoryIdempotencyStore } from "@noddde/engine";
 
 const store = new InMemoryIdempotencyStore(); // no TTL
@@ -368,7 +368,7 @@ Stores processed command records in memory, keyed by `commandId`. When `ttlMs` i
 
 ### InMemorySagaPersistence
 
-```ts
+```ts title="main.ts"
 import { InMemorySagaPersistence } from "@noddde/engine";
 
 const persistence = new InMemorySagaPersistence();
@@ -420,7 +420,7 @@ The strategy is a configuration choice, not a modeling choice.
 
 The persistence interfaces are deliberately minimal -- `save` and `load` are the only two operations. This makes it straightforward to implement for any storage backend:
 
-```ts
+```ts title="adapters/postgres-event-store.ts"
 import {
   Event,
   EventSourcedAggregatePersistence,
@@ -524,7 +524,7 @@ If persistence fails, no events are published. This prevents inconsistencies bet
 
 Every `dispatchCommand` call is automatically wrapped in its own unit of work. No configuration needed:
 
-```ts
+```ts title="main.ts"
 // This is already wrapped in a unit of work
 await domain.dispatchCommand({
   name: "CreateBankAccount",
@@ -537,7 +537,7 @@ await domain.dispatchCommand({
 
 Use `domain.withUnitOfWork()` to group multiple commands into a single atomic boundary:
 
-```ts
+```ts title="main.ts"
 await domain.withUnitOfWork(async () => {
   await domain.dispatchCommand({
     name: "DebitAccount",
@@ -558,7 +558,7 @@ If any command within the unit of work throws, all buffered persistence operatio
 
 `withUnitOfWork()` returns the value from its callback:
 
-```ts
+```ts title="main.ts"
 const accountId = await domain.withUnitOfWork(async () => {
   const id = await domain.dispatchCommand(createAccountCommand);
   await domain.dispatchCommand(initialDepositCommand);
@@ -584,7 +584,7 @@ This ensures that saga state transitions and the commands they trigger are alway
 
 ### The UnitOfWork Interface
 
-```ts
+```ts title="packages/core/src/persistence/unit-of-work.ts"
 interface UnitOfWork {
   enlist(operation: () => Promise<void>): void;
   deferPublish(...events: Event[]): void;
@@ -604,7 +604,7 @@ A UnitOfWork is single-use: after `commit()` or `rollback()`, further calls thro
 
 By default, the domain uses `InMemoryUnitOfWork`. For production use with a database, provide a custom `unitOfWork` factory in [domain wiring](/docs/running/domain-configuration):
 
-```ts
+```ts title="main.ts"
 const domain = await wireDomain(bankingDomain, {
   aggregates: {
     persistence: () => new PostgresEventStore(),

--- a/docs/content/docs/testing/overview.mdx
+++ b/docs/content/docs/testing/overview.mdx
@@ -21,7 +21,7 @@ yarn add --dev @noddde/testing
 
 Test individual handlers without booting a domain. The harnesses replay events, call handlers, and return structured results.
 
-```ts
+```ts title="__tests__/bank-account.test.ts"
 import { testAggregate } from "@noddde/testing";
 
 const result = await testAggregate(BankAccount)
@@ -53,7 +53,7 @@ Available unit harnesses:
 
 Test multiple components together with zero infrastructure boilerplate. `testDomain` automatically wires in-memory buses, persistence, and installs spies.
 
-```ts
+```ts title="__tests__/domain.test.ts"
 import { testDomain } from "@noddde/testing";
 
 const { domain, spy } = await testDomain({
@@ -95,7 +95,7 @@ For sagas, this pattern is inverted: events come in, commands go out.
 
 All unit harnesses capture errors in the result instead of throwing. This makes testing rejection cases straightforward:
 
-```ts
+```ts title="__tests__/bank-account-errors.test.ts"
 const result = await testAggregate(BankAccount)
   .when({
     name: "AuthorizeTransaction",
@@ -113,7 +113,7 @@ expect(result.events).toEqual([]);
 
 Since all handlers are extracted to standalone functions, you can import and test them directly without any harness:
 
-```ts
+```ts title="__tests__/direct-handler.test.ts"
 // Decide handler — import the extracted function
 import { decideAuthorizeTransaction } from "./deciders/decide-authorize-transaction";
 
@@ -140,7 +140,7 @@ The most common pattern is the **Clock**: inject a `Clock` interface instead of 
 
 For infrastructure with multiple members, create a reusable mock factory:
 
-```ts
+```ts title="__tests__/helpers/mock-infrastructure.ts"
 function createMockBankingInfrastructure() {
   return {
     logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
@@ -163,7 +163,7 @@ When events flow through the `Domain`, they are automatically enriched with an [
 
 Most tests care about _what_ happened (event name + payload), not _when_ or _by whom_. Use `stripMetadata` to remove the metadata envelope:
 
-```ts
+```ts title="__tests__/metadata-stripping.test.ts"
 import { stripMetadata } from "@noddde/testing";
 
 const { spy } = await testDomain({ aggregates: { BankAccount } });
@@ -182,7 +182,7 @@ expect(stripMetadata(spy.publishedEvents)).toContainEqual({
 
 Use `expectValidMetadata` to verify that an event carries a well-formed metadata envelope with all required fields:
 
-```ts
+```ts title="__tests__/metadata-validation.test.ts"
 import { expectValidMetadata } from "@noddde/testing";
 
 // Asserts: eventId is UUID v7, timestamp is valid ISO 8601,
@@ -194,7 +194,7 @@ expectValidMetadata(spy.publishedEvents[0]!);
 
 Two helpers verify that events form a proper tracing chain:
 
-```ts
+```ts title="__tests__/correlation.test.ts"
 import { expectSameCorrelation, expectCausationChain } from "@noddde/testing";
 
 // All events share the same correlationId (same causal chain)
@@ -210,7 +210,7 @@ These are particularly useful when testing [saga workflows](/docs/process-manage
 
 For tests that need exact equality (snapshot tests, deterministic replay), use `createTestMetadataFactory` to produce predictable metadata:
 
-```ts
+```ts title="__tests__/metadata-factory.test.ts"
 import { createTestMetadataFactory } from "@noddde/testing";
 
 const metadataFactory = createTestMetadataFactory({

--- a/docs/content/docs/testing/testing-aggregates-and-projections.mdx
+++ b/docs/content/docs/testing/testing-aggregates-and-projections.mdx
@@ -9,7 +9,7 @@ Aggregates and projections share a similar testing shape: replay events, then as
 
 The primary harness for testing decide handlers. It replays given events through `evolve` handlers to build state, executes the decide handler, and returns the produced events and resulting state.
 
-```ts
+```ts title="__tests__/bank-account.test.ts"
 import { testAggregate } from "@noddde/testing";
 
 const result = await testAggregate(BankAccount)
@@ -35,16 +35,16 @@ expect(result.state.availableBalance).toBe(500);
 
 ### Builder API
 
-| Method                       | Purpose                                                                                           |
-| ---------------------------- | ------------------------------------------------------------------------------------------------- |
+| Method                       | Purpose                                                                                            |
+| ---------------------------- | -------------------------------------------------------------------------------------------------- |
 | `.given(...events)`          | Prior events to replay through `evolve` handlers. Can be called multiple times; events accumulate. |
-| `.when(command)`             | The command to execute. Required before `.execute()`.                                             |
-| `.withInfrastructure(infra)` | Custom infrastructure for the handler. Defaults to `{}`.                                          |
-| `.execute()`                 | Runs the test and returns the result. Always async.                                               |
+| `.when(command)`             | The command to execute. Required before `.execute()`.                                              |
+| `.withInfrastructure(infra)` | Custom infrastructure for the handler. Defaults to `{}`.                                           |
+| `.execute()`                 | Runs the test and returns the result. Always async.                                                |
 
 ### Result Shape
 
-```ts
+```ts title="aggregate-test-result.ts"
 type AggregateTestResult<TState, TEvents> = {
   events: TEvents[]; // Events produced by the decide handler
   state: TState; // State after applying produced events
@@ -58,7 +58,7 @@ The harness **never throws** -- errors are always captured in `result.error`.
 
 When no `.given()` is called, the command runs against `aggregate.initialState`:
 
-```ts
+```ts title="__tests__/bank-account-create.test.ts"
 const result = await testAggregate(BankAccount)
   .when({
     name: "CreateBankAccount",
@@ -73,7 +73,7 @@ expect(result.events[0].name).toBe("BankAccountCreated");
 
 When a decide handler throws (e.g., validation failure), the error is captured:
 
-```ts
+```ts title="__tests__/bank-account-rejection.test.ts"
 const result = await testAggregate(BankAccount)
   .given({ name: "AccountCreated", payload: { id: "acc-1" } })
   .when({
@@ -92,7 +92,7 @@ expect(result.events).toEqual([]);
 
 Pass infrastructure via `.withInfrastructure()`. This is how you inject clocks, loggers, or any domain-specific dependency:
 
-```ts
+```ts title="__tests__/bank-account-with-infrastructure.test.ts"
 const result = await testAggregate(BankAccount)
   .given({ name: "AccountCreated", payload: { id: "acc-1" } })
   .when({
@@ -109,7 +109,7 @@ const result = await testAggregate(BankAccount)
 
 For infrastructure with multiple members, create a reusable mock factory to keep tests concise:
 
-```ts
+```ts title="__tests__/helpers/mock-infrastructure.ts"
 function createMockBankingInfrastructure() {
   return {
     logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
@@ -131,7 +131,7 @@ const result = await testAggregate(BankAccount)
 
 When a decide handler returns an array of events, all are captured and applied:
 
-```ts
+```ts title="__tests__/bank-account-batch.test.ts"
 const result = await testAggregate(BankAccount)
   .given(
     { name: "AccountCreated", payload: { id: "acc-1" } },
@@ -153,7 +153,7 @@ expect(result.events).toHaveLength(3);
 
 A standalone pure function for replaying events through evolve handlers. Useful when you need to reconstruct state without executing a command:
 
-```ts
+```ts title="__tests__/bank-account-evolve.test.ts"
 import { evolveAggregate } from "@noddde/testing";
 
 const state = evolveAggregate(BankAccount, [
@@ -173,7 +173,7 @@ expect(state.balance).toBe(300);
 
 You can also pass a custom starting state:
 
-```ts
+```ts title="__tests__/bank-account-evolve-custom-start.test.ts"
 const state = evolveAggregate(
   BankAccount,
   [{ name: "DepositMade", payload: { amount: 50 } }],
@@ -187,7 +187,7 @@ expect(state.balance).toBe(150);
 
 Since handlers are extracted to standalone functions, you can import and call them directly without going through the aggregate object:
 
-```ts
+```ts title="__tests__/direct-handler.test.ts"
 // Decide handler — import the extracted function
 import { decideAuthorizeTransaction } from "./deciders/decide-authorize-transaction";
 
@@ -207,7 +207,7 @@ The harness is recommended for most tests because it manages state reconstructio
 
 Projections build read models from event streams. The `testProjection` harness replays events through the projection's reducers and returns the final view.
 
-```ts
+```ts title="__tests__/bank-account-projection.test.ts"
 import { testProjection } from "@noddde/testing";
 
 const result = await testProjection(BankAccountProjection)
@@ -238,7 +238,7 @@ expect(result.view.transactions).toHaveLength(2);
 
 ### Result Shape
 
-```ts
+```ts title="projection-test-result.ts"
 type ProjectionTestResult<TView> = {
   view: TView; // Final view after all events
   error?: Error; // Captured error (if a reducer threw)
@@ -249,7 +249,7 @@ type ProjectionTestResult<TView> = {
 
 Control the starting state of the projection. This is useful when testing incremental updates rather than building from scratch:
 
-```ts
+```ts title="__tests__/bank-account-projection-initial-view.test.ts"
 const result = await testProjection(BankAccountProjection)
   .initialView({
     id: "acc-1",
@@ -269,8 +269,7 @@ expect(result.view.balance).toBe(800);
 
 When `.initialView()` is not called, the first reducer invocation receives `undefined` as the view. This matches real projection behavior when the first event arrives. Design your reducers to handle this:
 
-```ts
-// on-entries/on-account-created.ts
+```ts title="bank-account/on-entries/on-account-created.ts"
 export const onAccountCreated: InferProjectionEventHandler<
   Def,
   "AccountCreated"
@@ -295,7 +294,7 @@ export const onDepositMade: InferProjectionEventHandler<Def, "DepositMade"> = {
 
 Build a complete view from scratch by providing all events in order:
 
-```ts
+```ts title="__tests__/bank-account-projection-full-stream.test.ts"
 const result = await testProjection(BankAccountProjection)
   .given(
     { name: "BankAccountCreated", payload: { id: "acc-1" } },
@@ -319,8 +318,7 @@ expect(result.view.transactions).toHaveLength(1);
 
 Projection reducers receive the **full event object** (`{ name, payload }`), not just the payload. The event type is narrowed by name:
 
-```ts
-// on-entries/on-account-created.ts
+```ts title="bank-account/on-entries/on-account-created.ts"
 export const onAccountCreated: InferProjectionEventHandler<
   Def,
   "AccountCreated"
@@ -338,7 +336,7 @@ This is consistent with the runtime behavior in `@noddde/engine` and different f
 
 Reducers can be async. The harness awaits each one sequentially:
 
-```ts
+```ts title="__tests__/async-projection.test.ts"
 const result = await testProjection(AsyncProjection)
   .given({ name: "DataFetched", payload: { url: "https://example.com" } })
   .execute();
@@ -350,7 +348,7 @@ expect(result.view.fetched).toBe(true);
 
 If a reducer throws, the error is captured in the result:
 
-```ts
+```ts title="__tests__/strict-projection.test.ts"
 const result = await testProjection(StrictProjection)
   .given({ name: "InvalidEvent", payload: { bad: true } })
   .execute();
@@ -363,7 +361,7 @@ expect(result.error!.message).toContain("invalid");
 
 Since projection event handlers are extracted to standalone functions, import and call them directly:
 
-```ts
+```ts title="__tests__/direct-reducer.test.ts"
 import { onTransactionProcessed } from "./on-entries/on-transaction-processed";
 
 const newView = onTransactionProcessed.reduce(

--- a/docs/content/docs/testing/testing-domains.mdx
+++ b/docs/content/docs/testing/testing-domains.mdx
@@ -7,7 +7,7 @@ The `testDomain` harness from `@noddde/testing` creates a fully wired domain wit
 
 ## testDomain
 
-```ts
+```ts title="__tests__/domain.test.ts"
 import { testDomain } from "@noddde/testing";
 
 const { domain, spy } = await testDomain({
@@ -38,7 +38,7 @@ expect(view?.balance).toBe(-100);
 
 ### Configuration
 
-```ts
+```ts title="test-domain-config.ts"
 type TestDomainConfig<TInfrastructure extends Infrastructure = Infrastructure> =
   {
     /** Aggregate definitions keyed by name. */
@@ -66,7 +66,7 @@ Only specify what you are testing. Everything else is wired automatically:
 
 ### Result Shape
 
-```ts
+```ts title="test-domain-result.ts"
 type TestDomainResult = {
   domain: Domain; // The fully initialized domain
   spy: DomainSpy; // Spy accessors
@@ -82,7 +82,7 @@ type DomainSpy = {
 
 `spy.publishedEvents` records every event published on the event bus, in order. This captures events from aggregate decide handlers after persistence:
 
-```ts
+```ts title="__tests__/published-events.test.ts"
 const { domain, spy } = await testDomain({
   aggregates: { BankAccount },
 });
@@ -108,7 +108,7 @@ expect(spy.publishedEvents).toEqual([
 
 `spy.dispatchedCommands` records commands dispatched through the command bus. This is most useful for verifying saga behavior -- sagas dispatch commands as reactions to events:
 
-```ts
+```ts title="__tests__/dispatched-commands.test.ts"
 const { domain, spy } = await testDomain({
   aggregates: {},
   sagas: { OrderFulfillment },
@@ -133,7 +133,7 @@ Commands dispatched by sagas that have no registered handler are captured by the
 
 After dispatching commands, check the projection view directly:
 
-```ts
+```ts title="__tests__/projection-views.test.ts"
 const { domain } = await testDomain({
   aggregates: { BankAccount },
   projections: { BankAccountView },
@@ -158,7 +158,7 @@ expect(view?.balance).toBe(1000);
 
 Pass domain-specific dependencies that handlers need:
 
-```ts
+```ts title="__tests__/custom-infrastructure.test.ts"
 const mockLogger = { info: vi.fn(), error: vi.fn() };
 
 const { domain } = await testDomain<BankingInfrastructure>({
@@ -181,7 +181,7 @@ expect(mockLogger.info).toHaveBeenCalled();
 
 Testing the complete order fulfillment flow -- aggregate, projection, and saga together:
 
-```ts
+```ts title="__tests__/order-fulfillment-slice.test.ts"
 const { domain, spy } = await testDomain({
   aggregates: { Order, Payment },
   projections: { OrderSummary },
@@ -218,10 +218,10 @@ expect(summary?.status).toBe("confirmed");
 
 ## When to Use testDomain vs. defineDomain + wireDomain
 
-| Scenario                             | Use                                                 |
-| ------------------------------------ | --------------------------------------------------- |
-| Testing handler logic in isolation   | `testAggregate`, `testProjection`, `testSaga`       |
-| Testing multiple components together | `testDomain`                                        |
+| Scenario                             | Use                                                                     |
+| ------------------------------------ | ----------------------------------------------------------------------- |
+| Testing handler logic in isolation   | `testAggregate`, `testProjection`, `testSaga`                           |
+| Testing multiple components together | `testDomain`                                                            |
 | Custom persistence strategies        | `defineDomain` from `@noddde/core` + `wireDomain` from `@noddde/engine` |
 | Custom bus implementations           | `defineDomain` from `@noddde/core` + `wireDomain` from `@noddde/engine` |
 | Production-like environment tests    | `defineDomain` from `@noddde/core` + `wireDomain` from `@noddde/engine` |

--- a/docs/content/docs/testing/testing-sagas.mdx
+++ b/docs/content/docs/testing/testing-sagas.mdx
@@ -7,7 +7,7 @@ Sagas orchestrate workflows across aggregates by reacting to events and dispatch
 
 ## testSaga
 
-```ts
+```ts title="__tests__/order-fulfillment-saga.test.ts"
 import { testSaga } from "@noddde/testing";
 
 const result = await testSaga(OrderFulfillmentSaga)
@@ -42,7 +42,7 @@ expect(result.commands).toEqual([
 
 ### Result Shape
 
-```ts
+```ts title="saga-test-result.ts"
 type SagaTestResult<TState, TCommands> = {
   state: TState; // New saga state
   commands: TCommands[]; // Commands to dispatch (always an array, empty if none)
@@ -56,7 +56,7 @@ Commands are always normalized to an array, even when the handler returns a sing
 
 When no `.givenState()` is called, the handler receives `saga.initialState`:
 
-```ts
+```ts title="__tests__/order-fulfillment-saga-startup.test.ts"
 const result = await testSaga(OrderFulfillmentSaga)
   .when({
     name: "OrderPlaced",
@@ -78,7 +78,7 @@ expect(result.commands).toEqual([
 
 Some saga handlers update state without dispatching commands:
 
-```ts
+```ts title="__tests__/order-fulfillment-saga-state-only.test.ts"
 const result = await testSaga(OrderFulfillmentSaga)
   .givenState({ status: "fulfilled", orderId: "o-1" })
   .when({
@@ -101,7 +101,7 @@ Most saga handlers return commands in the reaction rather than dispatching throu
 
 When saga handlers use domain-specific infrastructure (notification services, APIs, etc.), provide it via `.withInfrastructure()`:
 
-```ts
+```ts title="__tests__/notification-saga.test.ts"
 const mockNotifier = { send: vi.fn().mockResolvedValue(undefined) };
 
 const result = await testSaga(NotificationSaga)
@@ -121,7 +121,7 @@ expect(mockNotifier.send).toHaveBeenCalledWith(
 
 In rare cases where a saga handler calls `commandBus.dispatch` directly (instead of returning commands in the reaction), override the CQRS buses:
 
-```ts
+```ts title="__tests__/special-saga.test.ts"
 const mockDispatch = vi.fn().mockResolvedValue(undefined);
 
 const result = await testSaga(SpecialSaga)
@@ -138,7 +138,7 @@ expect(mockDispatch).toHaveBeenCalled();
 
 If a saga handler throws, the error is captured:
 
-```ts
+```ts title="__tests__/strict-saga.test.ts"
 const result = await testSaga(StrictSaga)
   .givenState({ validated: false })
   .when({ name: "InvalidEvent", payload: { bad: true } })
@@ -152,7 +152,7 @@ expect(result.commands).toEqual([]);
 
 Each on-entry bundles an `id` function that extracts the saga instance ID from an event. Since on-entries are extracted to standalone files, import them directly:
 
-```ts
+```ts title="__tests__/saga-id-extraction.test.ts"
 import { onOrderPlaced } from "./on-entries/on-order-placed";
 
 const sagaId = onOrderPlaced.id({
@@ -165,7 +165,7 @@ expect(sagaId).toBe("o-1");
 
 Each bounded context may name the correlation field differently (`orderId`, `referenceId`, `customerReference`), so verify that each on-entry's `id` function resolves to the same saga ID:
 
-```ts
+```ts title="__tests__/saga-id-multi-event.test.ts"
 import { onOrderPlaced } from "./on-entries/on-order-placed";
 import { onPaymentCompleted } from "./on-entries/on-payment-completed";
 
@@ -203,7 +203,7 @@ describe("on entry id extraction", () => {
 
 Replay a sequence of events through the saga to verify the complete lifecycle. Import the extracted on-entries and call their `handle` function directly:
 
-```ts
+```ts title="__tests__/order-fulfillment-saga-workflow.test.ts"
 import { onOrderPlaced } from "./on-entries/on-order-placed";
 import { onPaymentCompleted } from "./on-entries/on-payment-completed";
 import { onShipmentDispatched } from "./on-entries/on-shipment-dispatched";

--- a/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/docs/src/app/docs/[[...slug]]/page.tsx
@@ -8,6 +8,7 @@ import {
 import { notFound } from "next/navigation";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import { File, Folder, Files } from "fumadocs-ui/components/files";
+import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Mermaid } from "@/components/mermaid";
 import { PreWithTitle } from "@/components/code-block";
 import type { Metadata } from "next";
@@ -35,6 +36,8 @@ export default async function Page(props: {
             Files,
             File,
             Folder,
+            Steps,
+            Step,
             Mermaid,
           }}
         />


### PR DESCRIPTION
## Summary

Two presentation improvements to the docs site:

- **Code-block titles** — Replaced the lazy language-name headers (`typescript`, `ts`) on ~480 code blocks with realistic file paths drawn from the canonical project structure (`samples/sample-auction/src/`). Examples: `event-model/index.ts`, `bank-account/deciders/decide-create-bank-account.ts`, `auction/auction.ts`, `__tests__/booking-saga.test.ts`.
- **Vertical stepper** — Registered Fumadocs' `<Steps>`/`<Step>` components and wrapped the five step-by-step guides:
  - `modeling/defining-aggregates` (6 steps)
  - `modeling/routing-and-dispatch` (7 steps)
  - `persistence/custom-adapters` (4 steps)
  - `getting-started/quick-start` (7-step Walkthrough section)
  - `running/observability` (3-step Setup section)

  Headings drop the `"Step N:"` prefix since the stepper's CSS counter auto-numbers each step in a circle next to the heading.

## What didn't change

- Non-ts code blocks (bash, json, mermaid, sql, prisma, yaml) keep the language-only header per direction.
- Already-titled blocks (e.g. existing `title="projection.ts"` entries in `read-model/projections.mdx`) were left as-is.
- `read-model/projection-rebuild.mdx` has a "For Adapter Authors" section with 2 numbered items — that reads as a requirements checklist, not a sequential walkthrough, so no stepper there.

## Convention applied

Drawn from `samples/sample-auction/src/`:

| Block content | Title |
|---|---|
| Aggregate def + types bundle | `<aggregate>/<aggregate>.ts` |
| Aggregate state | `<aggregate>/state.ts` |
| `DefineCommands` union | `<aggregate>/commands/index.ts` |
| Per-command payload | `<aggregate>/commands/<name>.ts` |
| Decide / evolve handlers | `<aggregate>/deciders/decide-X.ts`, `evolvers/evolve-X.ts` |
| `DefineEvents` union | `event-model/index.ts` |
| Per-event payload | `event-model/<event-name>.ts` |
| Projection def | `<projection>/<projection>.ts` + `on-entries/`, `query-handlers/`, `queries/` |
| Saga def | `<saga>/saga.ts` + `state.ts` + `on-entries/` |
| Domain wiring / entry / infra | `domain.ts`, `main.ts`, `infrastructure/...` |
| Tests | `__tests__/<name>.test.ts` |
| Framework source refs | full path, e.g. `packages/core/src/ddd/aggregate-root.ts` |
| Counter-examples (OOP version, "Hypothetical", anti-pattern) | descriptive name, e.g. `bank-account-aggregate.ts`, `define-aggregate.ts`, `anti-pattern-mutation.ts` |

## Heads-up

Stepper conversion shifts anchor links on affected headings from `#step-N-title` to `#title`. No inbound references to those specific anchors were found in this repo; external links would need updating.

## Test plan

- [x] `npx prettier --check "docs/content/docs/**/*.mdx"` clean
- [x] `grep -nE '^\`\`\`(ts|typescript)\s*$' docs/content/docs/**/*.mdx` returns empty (no untitled ts blocks remain)
- [x] DOM check on `/docs/modeling/defining-aggregates` shows 6 `.fd-step` elements with auto-numbered CSS counters and the vertical rail
- [ ] Eyeball the 5 stepper pages in the preview to confirm visual fit

🤖 Generated with [Claude Code](https://claude.com/claude-code)