### PR TITLE
fix(engine): commit saga state before dispatching commands to prevent event loss

### DIFF
--- a/packages/engine/src/__tests__/engine/executors/saga-executor.test.ts
+++ b/packages/engine/src/__tests__/engine/executors/saga-executor.test.ts
@@ -368,9 +368,10 @@ describe("SagaExecutor", () => {
       }),
     ).rejects.toThrow("Command failed");
 
-    // Saga state should NOT be persisted due to rollback
+    // Saga state IS persisted even when a command fails — state commits
+    // before commands, so a downstream command failure does not roll it back.
     const state = await sagaPersistence.load("RbSaga", "rb1");
-    expect(state).toBeUndefined();
+    expect(state).toEqual({ ran: true });
   });
 
   // ============================================================

--- a/packages/engine/src/executors/saga-executor.ts
+++ b/packages/engine/src/executors/saga-executor.ts
@@ -124,10 +124,14 @@ export class SagaExecutor {
           userId: event.metadata?.userId,
         };
 
-        // Step 7: Create UoW for saga reaction (spans state + commands)
+        // Step 7: Create UoW for saga state persistence
         const uow = this.unitOfWorkFactory();
         const sagaPersistence = this.sagaPersistence;
+        let events: Event[] = [];
 
+        // Step 8: Commit saga state FIRST, before dispatching commands.
+        // This ensures the saga executor finds persisted state when command
+        // handlers dispatch events synchronously through the event bus.
         await this.uowStorage.run(uow, async () => {
           await this.metadataStorage.run(sagaCtx, async () => {
             try {
@@ -136,19 +140,9 @@ export class SagaExecutor {
                 sagaPersistence.save(sagaName, sagaId, reaction.state),
               );
 
-              // Step 8: Dispatch commands (within the saga's UoW + metadata context)
-              if (reaction.commands) {
-                const commands = Array.isArray(reaction.commands)
-                  ? reaction.commands
-                  : [reaction.commands];
-                for (const command of commands) {
-                  await this.infrastructure.commandBus.dispatch(command);
-                }
-              }
-
-              // Step 9: Commit saga state + all aggregate changes atomically
+              // Commit saga state + any deferred changes
               const commitFn = () => uow.commit();
-              const events = this.instrumentation
+              events = this.instrumentation
                 ? await this.instrumentation.withSpan(
                     "noddde.uow.commit",
                     { "noddde.saga.name": sagaName },
@@ -156,7 +150,7 @@ export class SagaExecutor {
                   )
                 : await commitFn();
 
-              // Step 10: Publish all deferred events sequentially
+              // Step 9: Publish all deferred events sequentially
               for (const e of events) {
                 await this.infrastructure.eventBus.dispatch(e);
               }
@@ -185,6 +179,21 @@ export class SagaExecutor {
             }
           });
         });
+
+        // Step 10: Dispatch commands outside UoW context (inside metadata context).
+        // Saga state is already persisted, so events dispatched by command handlers
+        // will find the saga state when processed by the saga executor.
+        // Each command creates its own UoW via CommandLifecycleExecutor.
+        if (reaction.commands) {
+          const commands = Array.isArray(reaction.commands)
+            ? reaction.commands
+            : [reaction.commands];
+          await this.metadataStorage.run(sagaCtx, async () => {
+            for (const command of commands) {
+              await this.infrastructure.commandBus.dispatch(command);
+            }
+          });
+        }
       };
 
       if (this.instrumentation) {


### PR DESCRIPTION
## Summary

Fixes #119

When a saga handler dispatches a command whose handler synchronously dispatches an event through the event bus, the saga executor received that event before the saga state was committed. The executor would find no persisted state and silently ignore the event.

## Change

Commit the saga UoW (persisting saga state) before dispatching commands. Commands run outside the UoW context so each creates its own UoW, but still inside the metadata context for correlation propagation.

## Trade-off

Saga state is now persisted independently of command success. A failed command no longer rolls back saga state (atomicity was untested and structurally broken when commands dispatched events — see issue #119 for detailed analysis).

## Verification

- All 384 engine tests pass (39 test files)
- All 106 sample tests pass (20 test files)
- Reproduction test confirms the bug is fixed
- No new TypeScript errors