### PR TITLE
feat(saga): per-saga atomicity option (stacked on #120)

### DIFF
--- a/.changeset/saga-atomicity-core.md
+++ b/.changeset/saga-atomicity-core.md
@@ -1,0 +1,7 @@
+---
+"@noddde/core": minor
+---
+
+Add an optional per-saga `atomicity` field and the `SagaAtomicity` type (`"atomic" | "best-effort"`) to saga definitions.
+
+`atomicity` is a declarative field on `defineSaga` / the `Saga` interface; `defineSaga` remains a pure identity function and does not read, validate, or default it. The engine's `SagaExecutor` consumes the field, treating an absent value as `"atomic"` (today's behavior), so existing sagas are unaffected.

--- a/.changeset/saga-atomicity-engine.md
+++ b/.changeset/saga-atomicity-engine.md
@@ -1,0 +1,10 @@
+---
+"@noddde/engine": minor
+---
+
+`SagaExecutor` now honors a per-saga `atomicity` mode (`saga.atomicity ?? "atomic"`):
+
+- **`atomic`** (default) — unchanged: the saga's unit of work spans the saga-state save and all reaction commands, so they commit or roll back together.
+- **`best-effort`** — commits the saga state first, then dispatches reaction commands outside that unit of work (each command obtains its own UoW via `CommandLifecycleExecutor`). Command handlers that publish events directly through the event bus — and the re-entrant saga executions they trigger — therefore observe the committed saga state, fixing the silent event loss in issue #119. Trade-off: a reaction-command failure no longer rolls back the saga-state transition.
+
+Sagas that do not set `atomicity` keep their current transactional behavior.

--- a/docs/content/docs/design-decisions/why-sagas-return-commands.mdx
+++ b/docs/content/docs/design-decisions/why-sagas-return-commands.mdx
@@ -61,6 +61,8 @@ With imperative dispatch, you'd need to mock the `CommandBus`, capture calls, an
 
 The framework can persist the new saga state and dispatch commands as a single logical operation. If the handler dispatched commands imperatively, a failure between dispatches would leave the saga in an inconsistent state — commands partially dispatched but state not updated.
 
+By default (`atomicity: "atomic"`) the saga-state save and all returned commands share one unit of work, so they commit or roll back together. A saga can opt into `atomicity: "best-effort"` to commit its state before dispatching commands — see [Atomicity](/docs/process-managers/sagas#atomicity) for when that trade-off is worthwhile.
+
 ### Deterministic Replay
 
 If saga event streams are replayed (for rebuilding state or debugging), declarative reactions can be inspected without executing side effects. Imperative dispatches would re-trigger commands during replay.
@@ -70,6 +72,26 @@ If saga event streams are replayed (for rebuilding state or debugging), declarat
 Handlers still receive `CQRSInfrastructure` (including `QueryBus`), so they _can_ read data before deciding which commands to return. The constraint is on outputs, not inputs: you can read from the query bus, but you return commands rather than dispatching them.
 
 For truly imperative side effects (notifications, logging), handlers can call infrastructure methods directly — only command dispatch is declarative.
+
+## The Golden Path: Return Events, Don't Dispatch Them
+
+The same principle applies one layer down, to the **aggregates** a saga's commands target. On the golden path, aggregate deciders **return** events; the engine defers them and publishes them only **after** the unit of work commits. This is what makes the saga's atomicity guarantee hold — the saga state and the events its commands produce become visible together, in order.
+
+Dispatching an event manually with `eventBus.dispatch()` from inside a command handler (or decider) is **off the golden path**: the event is published immediately, before the surrounding unit of work commits, so it loses the engine's ordering and atomicity guarantees.
+
+<Callout type="warn">
+  Under the default `atomic` saga mode, an event a command handler dispatches
+  directly is delivered **before** the saga's unit of work commits. If that
+  event is meant to advance the same saga instance, the re-entrant handler loads
+  uncommitted (`null`) state and the event is silently dropped — the saga never
+  advances ([issue #119](https://github.com/dogganidhal/noddde/issues/119)).
+  Prefer returning events from your deciders. If a handler genuinely must
+  dispatch directly (e.g. a [standalone command
+  handler](/docs/process-managers/standalone-commands), which has no return
+  channel), set the consuming saga to [`atomicity:
+  "best-effort"`](/docs/process-managers/sagas#atomicity) so it commits its
+  state before dispatching.
+</Callout>
 
 ## See Also
 

--- a/docs/content/docs/process-managers/sagas.mdx
+++ b/docs/content/docs/process-managers/sagas.mdx
@@ -424,6 +424,45 @@ const domain = await wireDomain(ecommerceDomain, {
 
 The `processModel` section is separate because sagas are neither pure write-model (they subscribe to events) nor pure read-model (they dispatch commands). They bridge both sides.
 
+## Atomicity
+
+By default, a saga's state transition and the commands it returns are **atomic**: the saga state save and every reaction command share a single unit of work, so they commit or roll back together. If any reaction command fails, the saga-state transition is rolled back too.
+
+You can change this per-saga with the optional `atomicity` field on the definition:
+
+```ts title="saga.ts"
+export const OrderFulfillmentSaga = defineSaga<OrderFulfillmentSagaDef>({
+  atomicity: "atomic", // (default) or "best-effort"
+  initialState: {
+    /* ... */
+  },
+  startedBy: ["OrderPlaced"],
+  on: {
+    /* ... */
+  },
+});
+```
+
+| Mode                   | Coupling                                                                                                          | On reaction-command failure                                                                                                      |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `"atomic"` _(default)_ | Saga-state save and all reaction commands share one unit of work.                                                 | The whole reaction rolls back — saga state is **not** persisted.                                                                 |
+| `"best-effort"`        | Saga state is committed **first**, then reaction commands are dispatched afterward, each in its own unit of work. | The (already committed) saga state **stays persisted**; the failing command's own changes roll back. The error still propagates. |
+
+<Callout type="info">
+  `atomicity` is purely declarative on the definition — `defineSaga` does not
+  read, validate, or default it. The engine's saga executor consumes it, and
+  treats an absent field as `"atomic"`, so existing sagas keep their current
+  behavior.
+</Callout>
+
+### When to use `best-effort`
+
+Choose `best-effort` when a reaction command's handler publishes a follow-up event **directly** through the event bus (the off-path pattern that [standalone command handlers](/docs/process-managers/standalone-commands) must use, since they have no "return events" channel) and that event needs to advance the **same** saga instance.
+
+Under `atomic`, reaction commands run inside the saga's still-uncommitted unit of work, so a re-entrant event dispatched by a command handler loads `null` saga state and is silently dropped — the saga never advances. Committing the saga state first (`best-effort`) makes that re-entrant event observe the persisted state and resume the saga. This is the fix for the silent event loss in [issue #119](https://github.com/dogganidhal/noddde/issues/119).
+
+If your aggregates follow the **golden path** — deciders **return** events rather than dispatching them, and the engine publishes those events only after the unit of work commits — `atomic` is correct and you do not need `best-effort`.
+
 ## Type Inference Helpers
 
 Like aggregates and projections, sagas have `Infer*` helpers. The most commonly used is `InferSagaOnEntry`, which types an extracted on-entry in its own file:

--- a/docs/content/docs/running/persistence.mdx
+++ b/docs/content/docs/running/persistence.mdx
@@ -570,7 +570,7 @@ const accountId = await domain.withUnitOfWork(async () => {
 
 ### Saga Unit of Work
 
-Saga reactions are automatically wrapped in a unit of work. When a saga handler dispatches commands, the saga state persistence and all dispatched command operations share a single unit of work:
+Saga reactions are automatically wrapped in a unit of work. By default (`atomicity: "atomic"`), the saga state persistence and all dispatched command operations share a single unit of work:
 
 ```
 Event arrives --> saga handler executes
@@ -581,6 +581,8 @@ Event arrives --> saga handler executes
 ```
 
 This ensures that saga state transitions and the commands they trigger are always consistent.
+
+A saga declared with [`atomicity: "best-effort"`](/docs/process-managers/sagas#atomicity) inverts this: its state is committed in its own unit of work **first**, and the reaction commands are then dispatched afterward, each obtaining its own unit of work. A reaction-command failure no longer rolls back the (already committed) saga-state transition.
 
 ### The UnitOfWork Interface
 

--- a/docs/content/docs/testing/testing-sagas.mdx
+++ b/docs/content/docs/testing/testing-sagas.mdx
@@ -265,6 +265,12 @@ it("should complete the full happy path", async () => {
 });
 ```
 
+## Atomicity Mode and testSaga
+
+`testSaga` exercises a saga handler in isolation — event in, reaction out — without the engine's unit of work, persistence, or command dispatch. A saga's [`atomicity`](/docs/process-managers/sagas#atomicity) setting (`"atomic"` vs `"best-effort"`) only governs how the **engine** couples the state commit with reaction-command dispatch at runtime, so it has no effect on a `testSaga` result: the returned `state` and `commands` are identical in either mode.
+
+To verify mode-dependent behavior — for example, that a `best-effort` saga commits its state before dispatching commands, or resumes when a command handler publishes a consumed event — drive the saga through the engine with [`testDomain`](/docs/testing/testing-domains) instead.
+
 ## Next Steps
 
 - [Testing Domains](/docs/testing/testing-domains) -- `testDomain` for full saga orchestration tests across aggregates and projections

--- a/packages/cli/src/templates/saga/saga.ts
+++ b/packages/cli/src/templates/saga/saga.ts
@@ -23,6 +23,11 @@ type ${ctx.name}SagaDef = {
 // ── Saga definition ─────────────────────────────────────────────
 
 export const ${ctx.name}Saga = defineSaga<${ctx.name}SagaDef>({
+  // atomicity defaults to "atomic" (state + reaction commands commit together).
+  // Set "best-effort" to commit saga state before dispatching commands — needed
+  // when a command handler publishes a consumed event directly via the event bus.
+  // atomicity: "best-effort",
+
   initialState: initial${ctx.name}SagaState,
 
   startedBy: [

--- a/packages/core/src/__tests__/ddd/saga.test.ts
+++ b/packages/core/src/__tests__/ddd/saga.test.ts
@@ -15,6 +15,7 @@ import type {
   InferSagaState,
   Infrastructure,
   Saga,
+  SagaAtomicity,
   SagaEventHandler,
   SagaReaction,
 } from "@noddde/core";
@@ -463,5 +464,89 @@ describe("InferSagaOnEntry", () => {
     });
 
     expectTypeOf(saga.on.OrderPlaced).not.toBeUndefined();
+  });
+});
+
+describe("Saga atomicity field", () => {
+  it("should type SagaAtomicity as the atomic | best-effort union", () => {
+    expectTypeOf<SagaAtomicity>().toEqualTypeOf<"atomic" | "best-effort">();
+  });
+
+  it("should expose atomicity as an optional SagaAtomicity on Saga", () => {
+    expectTypeOf<Saga["atomicity"]>().toEqualTypeOf<
+      SagaAtomicity | undefined
+    >();
+  });
+});
+
+describe("defineSaga atomicity", () => {
+  type E = DefineEvents<{ Started: { id: string } }>;
+  type C = Command & { name: "Noop" };
+  type T = {
+    state: { started: boolean };
+    events: E;
+    commands: C;
+    infrastructure: Infrastructure;
+  };
+
+  it("should preserve an explicit best-effort atomicity", () => {
+    const saga = defineSaga<T>({
+      atomicity: "best-effort",
+      initialState: { started: false },
+      startedBy: ["Started"],
+      on: {
+        Started: {
+          id: (event) => event.payload.id,
+          handle: () => ({ state: { started: true } }),
+        },
+      },
+    });
+    expect(saga.atomicity).toBe("best-effort");
+    expectTypeOf(saga.atomicity).toEqualTypeOf<SagaAtomicity | undefined>();
+  });
+
+  it("should preserve an explicit atomic atomicity", () => {
+    const saga = defineSaga<T>({
+      atomicity: "atomic",
+      initialState: { started: false },
+      startedBy: ["Started"],
+      on: {
+        Started: {
+          id: (event) => event.payload.id,
+          handle: () => ({ state: { started: true } }),
+        },
+      },
+    });
+    expect(saga.atomicity).toBe("atomic");
+  });
+});
+
+describe("defineSaga atomicity default", () => {
+  type E = DefineEvents<{ Started: { id: string } }>;
+  type C = Command & { name: "Noop" };
+  type T = {
+    state: {};
+    events: E;
+    commands: C;
+    infrastructure: Infrastructure;
+  };
+
+  it("should not inject a default — an omitted atomicity stays undefined", () => {
+    const config = {
+      initialState: {},
+      startedBy: ["Started" as const],
+      on: {
+        Started: {
+          id: (e: any) => String(e.payload.id),
+          handle: (_e: any, s: any) => ({ state: s }),
+        },
+      },
+    };
+    const saga = defineSaga<T>(config as any);
+
+    // Engine, not core, supplies the "atomic" default — core leaves it absent.
+    expect(saga.atomicity).toBeUndefined();
+    // Identity is preserved exactly (the new field does not change this).
+    expect(saga).toBe(config);
   });
 });

--- a/packages/core/src/ddd/saga.ts
+++ b/packages/core/src/ddd/saga.ts
@@ -43,6 +43,32 @@ export type SagaTypes = {
   infrastructure: Infrastructure;
 };
 
+// ---- Atomicity mode ----
+
+/**
+ * Selects the transactional coupling between a saga instance's state
+ * persistence and the commands it dispatches in reaction to an event.
+ *
+ * - **`"atomic"`** — Saga-state save and all reaction commands share one unit
+ *   of work; they commit or roll back together. A reaction-command failure
+ *   rolls back the saga-state transition. This is the default: the engine
+ *   treats an absent `atomicity` field as `"atomic"`.
+ *
+ * - **`"best-effort"`** — The saga state is committed first, then reaction
+ *   commands are dispatched outside that unit of work; a reaction-command
+ *   failure does **not** roll back the (already committed) saga state.
+ *   Use this mode when reaction commands may dispatch events directly via
+ *   `eventBus.dispatch()` (off-path/standalone handlers) to ensure the
+ *   re-entrant event observes committed saga state (issue #119 fix).
+ *
+ * Consumed by the engine's `SagaExecutor`; see
+ * `engine/executors/saga-executor` for the runtime semantics.
+ * **When omitted, the engine treats the saga as `"atomic"`.**
+ *
+ * @see {@link Saga.atomicity}
+ */
+export type SagaAtomicity = "atomic" | "best-effort";
+
 // ---- Reaction return type ----
 
 /**
@@ -191,6 +217,25 @@ export interface Saga<
    * this map is partial over the event union.
    */
   on: SagaOnMap<T, TSagaId>;
+
+  /**
+   * **Optional.** Selects how saga-state persistence and reaction-command
+   * dispatch are coupled (`"atomic" | "best-effort"`). When omitted, the
+   * engine treats the saga as `"atomic"`.
+   *
+   * - `"atomic"` (default) — state save and all reaction commands share one
+   *   unit of work; they commit or roll back together.
+   * - `"best-effort"` — state is committed first; reaction commands are
+   *   dispatched afterward, each in its own unit of work. Safer for sagas
+   *   whose command handlers publish events directly via `eventBus.dispatch()`
+   *   (the off-path pattern; fixes issue #119).
+   *
+   * This is a **declarative** field only — `defineSaga` does not read,
+   * validate, or default it. The engine's `SagaExecutor` consumes it.
+   *
+   * @see {@link SagaAtomicity}
+   */
+  atomicity?: SagaAtomicity;
 }
 
 /**

--- a/packages/engine/src/__tests__/engine/executors/saga-executor.test.ts
+++ b/packages/engine/src/__tests__/engine/executors/saga-executor.test.ts
@@ -5,6 +5,7 @@ import { defineSaga } from "@noddde/core";
 import type {
   SagaTypes,
   DefineEvents,
+  Event,
   Infrastructure,
   CQRSInfrastructure,
   UnitOfWork,
@@ -368,10 +369,9 @@ describe("SagaExecutor", () => {
       }),
     ).rejects.toThrow("Command failed");
 
-    // Saga state IS persisted even when a command fails — state commits
-    // before commands, so a downstream command failure does not roll it back.
+    // Saga state should NOT be persisted due to rollback
     const state = await sagaPersistence.load("RbSaga", "rb1");
-    expect(state).toEqual({ ran: true });
+    expect(state).toBeUndefined();
   });
 
   // ============================================================
@@ -468,5 +468,296 @@ describe("SagaExecutor", () => {
 
     const state = await sagaPersistence.load("FlowSaga", "flow-1");
     expect(state).toEqual({ steps: ["started", "continued"] });
+  });
+});
+
+type BeRbState = { ran: boolean };
+type BeRbEvent = DefineEvents<{ BeRbTrigger: { id: string } }>;
+type BeRbTypes = SagaTypes & {
+  state: BeRbState;
+  events: BeRbEvent;
+  commands: never;
+  infrastructure: Infrastructure & CQRSInfrastructure;
+};
+
+const BeRbSaga = defineSaga<BeRbTypes>({
+  atomicity: "best-effort",
+  initialState: { ran: false },
+  startedBy: ["BeRbTrigger"],
+  on: {
+    BeRbTrigger: {
+      id: (event) => event.payload.id,
+      handle: () => ({
+        state: { ran: true },
+        commands: {
+          name: "FailingCmd",
+          payload: {},
+          targetAggregateId: "fail-be",
+        },
+      }),
+    },
+  },
+});
+
+describe("SagaExecutor best-effort", () => {
+  it("should persist saga state even when a command throws", async () => {
+    const sagaPersistence = new InMemorySagaPersistence();
+    const commandBus = new InMemoryCommandBus();
+    commandBus.register("FailingCmd", async () => {
+      throw new Error("Command failed");
+    });
+    const infrastructure: Infrastructure & CQRSInfrastructure = {
+      commandBus,
+      eventBus: new EventEmitterEventBus(),
+      queryBus: new InMemoryQueryBus(),
+    };
+    const uowStorage = new AsyncLocalStorage<UnitOfWork>();
+    const metadataStorage = new AsyncLocalStorage<MetadataContext>();
+
+    const executor = new SagaExecutor(
+      infrastructure,
+      sagaPersistence,
+      createInMemoryUnitOfWork,
+      uowStorage,
+      metadataStorage,
+    );
+
+    await expect(
+      executor.execute("BeRbSaga", BeRbSaga, {
+        name: "BeRbTrigger",
+        payload: { id: "be1" },
+      }),
+    ).rejects.toThrow("Command failed");
+
+    // Saga state IS persisted — committed before the command ran.
+    const state = await sagaPersistence.load("BeRbSaga", "be1");
+    expect(state).toEqual({ ran: true });
+  });
+});
+
+type OrderingState = { phase: string };
+type OrderingEvent = DefineEvents<{ Begin: { id: string } }>;
+type OrderingTypes = SagaTypes & {
+  state: OrderingState;
+  events: OrderingEvent;
+  commands: never;
+  infrastructure: Infrastructure & CQRSInfrastructure;
+};
+
+const OrderingSaga = defineSaga<OrderingTypes>({
+  atomicity: "best-effort",
+  initialState: { phase: "init" },
+  startedBy: ["Begin"],
+  on: {
+    Begin: {
+      id: (event) => event.payload.id,
+      handle: () => ({
+        state: { phase: "committed" },
+        commands: { name: "Probe", payload: {}, targetAggregateId: "p1" },
+      }),
+    },
+  },
+});
+
+describe("SagaExecutor best-effort (commit ordering)", () => {
+  it("should have committed saga state by the time the command handler runs", async () => {
+    const sagaPersistence = new InMemorySagaPersistence();
+    const commandBus = new InMemoryCommandBus();
+    const uowStorage = new AsyncLocalStorage<UnitOfWork>();
+    const metadataStorage = new AsyncLocalStorage<MetadataContext>();
+
+    let stateSeenByCommand: unknown;
+    commandBus.register("Probe", async () => {
+      stateSeenByCommand = await sagaPersistence.load("OrderingSaga", "o1");
+    });
+
+    const infrastructure: Infrastructure & CQRSInfrastructure = {
+      commandBus,
+      eventBus: new EventEmitterEventBus(),
+      queryBus: new InMemoryQueryBus(),
+    };
+
+    const executor = new SagaExecutor(
+      infrastructure,
+      sagaPersistence,
+      createInMemoryUnitOfWork,
+      uowStorage,
+      metadataStorage,
+    );
+
+    await executor.execute("OrderingSaga", OrderingSaga, {
+      name: "Begin",
+      payload: { id: "o1" },
+    });
+
+    // The command handler observed the already-committed saga state.
+    expect(stateSeenByCommand).toEqual({ phase: "committed" });
+  });
+});
+
+type TaskState = { step: "initial" | "processing" | "done" };
+type TaskEvent = DefineEvents<{
+  StartTask: { taskId: string };
+  ProcessCompleted: { taskId: string };
+}>;
+type TaskTypes = SagaTypes & {
+  state: TaskState;
+  events: TaskEvent;
+  commands: never;
+  infrastructure: Infrastructure & CQRSInfrastructure;
+};
+
+const BestEffortTaskSaga = defineSaga<TaskTypes>({
+  atomicity: "best-effort",
+  initialState: { step: "initial" },
+  startedBy: ["StartTask"],
+  on: {
+    StartTask: {
+      id: (event) => event.payload.taskId,
+      handle: (event) => ({
+        state: { step: "processing" },
+        commands: {
+          name: "ProcessTask",
+          payload: { taskId: event.payload.taskId },
+          targetAggregateId: event.payload.taskId,
+        },
+      }),
+    },
+    ProcessCompleted: {
+      id: (event) => event.payload.taskId,
+      handle: (_event, state) => ({
+        state: { ...state, step: "done" },
+      }),
+    },
+  },
+});
+
+describe("SagaExecutor best-effort (issue #119)", () => {
+  it("should resume the saga when a command handler dispatches a consumed event", async () => {
+    const sagaPersistence = new InMemorySagaPersistence();
+    const commandBus = new InMemoryCommandBus();
+    const eventBus = new EventEmitterEventBus();
+    const uowStorage = new AsyncLocalStorage<UnitOfWork>();
+    const metadataStorage = new AsyncLocalStorage<MetadataContext>();
+
+    const infrastructure: Infrastructure & CQRSInfrastructure = {
+      commandBus,
+      eventBus,
+      queryBus: new InMemoryQueryBus(),
+    };
+
+    const executor = new SagaExecutor(
+      infrastructure,
+      sagaPersistence,
+      createInMemoryUnitOfWork,
+      uowStorage,
+      metadataStorage,
+    );
+
+    // Wire the executor to the event bus exactly as Domain does (eventBus.on).
+    for (const eventName of Object.keys(BestEffortTaskSaga.on)) {
+      eventBus.on(eventName, (event: Event) =>
+        executor.execute("TaskSaga", BestEffortTaskSaga, event),
+      );
+    }
+
+    // Standalone-style command handler: publishes an event directly (off-path).
+    commandBus.register("ProcessTask", async (command) => {
+      await eventBus.dispatch({
+        name: "ProcessCompleted",
+        payload: { taskId: (command.payload as { taskId: string }).taskId },
+      });
+    });
+
+    await executor.execute("TaskSaga", BestEffortTaskSaga, {
+      name: "StartTask",
+      payload: { taskId: "t-1" },
+    });
+
+    const state = await sagaPersistence.load("TaskSaga", "t-1");
+    expect(state).toEqual({ step: "done" });
+  });
+});
+
+type AtomicTaskState = { step: "initial" | "processing" | "done" };
+type AtomicTaskEvent = DefineEvents<{
+  StartTask: { taskId: string };
+  ProcessCompleted: { taskId: string };
+}>;
+type AtomicTaskTypes = SagaTypes & {
+  state: AtomicTaskState;
+  events: AtomicTaskEvent;
+  commands: never;
+  infrastructure: Infrastructure & CQRSInfrastructure;
+};
+
+const AtomicTaskSaga = defineSaga<AtomicTaskTypes>({
+  atomicity: "atomic",
+  initialState: { step: "initial" },
+  startedBy: ["StartTask"],
+  on: {
+    StartTask: {
+      id: (event) => event.payload.taskId,
+      handle: (event) => ({
+        state: { step: "processing" },
+        commands: {
+          name: "ProcessTask",
+          payload: { taskId: event.payload.taskId },
+          targetAggregateId: event.payload.taskId,
+        },
+      }),
+    },
+    ProcessCompleted: {
+      id: (event) => event.payload.taskId,
+      handle: (_event, state) => ({
+        state: { ...state, step: "done" },
+      }),
+    },
+  },
+});
+
+describe("SagaExecutor atomic (issue #119 limitation)", () => {
+  it("should drop a command-handler-dispatched event (saga stays at processing)", async () => {
+    const sagaPersistence = new InMemorySagaPersistence();
+    const commandBus = new InMemoryCommandBus();
+    const eventBus = new EventEmitterEventBus();
+    const uowStorage = new AsyncLocalStorage<UnitOfWork>();
+    const metadataStorage = new AsyncLocalStorage<MetadataContext>();
+
+    const infrastructure: Infrastructure & CQRSInfrastructure = {
+      commandBus,
+      eventBus,
+      queryBus: new InMemoryQueryBus(),
+    };
+
+    const executor = new SagaExecutor(
+      infrastructure,
+      sagaPersistence,
+      createInMemoryUnitOfWork,
+      uowStorage,
+      metadataStorage,
+    );
+
+    for (const eventName of Object.keys(AtomicTaskSaga.on)) {
+      eventBus.on(eventName, (event: Event) =>
+        executor.execute("AtomicTaskSaga", AtomicTaskSaga, event),
+      );
+    }
+
+    commandBus.register("ProcessTask", async (command) => {
+      await eventBus.dispatch({
+        name: "ProcessCompleted",
+        payload: { taskId: (command.payload as { taskId: string }).taskId },
+      });
+    });
+
+    await executor.execute("AtomicTaskSaga", AtomicTaskSaga, {
+      name: "StartTask",
+      payload: { taskId: "t-2" },
+    });
+
+    // The re-entrant ProcessCompleted arrived before commit → dropped.
+    const state = await sagaPersistence.load("AtomicTaskSaga", "t-2");
+    expect(state).toEqual({ step: "processing" });
   });
 });

--- a/packages/engine/src/executors/saga-executor.ts
+++ b/packages/engine/src/executors/saga-executor.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars */
 import { AsyncLocalStorage } from "node:async_hooks";
 import type {
+  Command,
   CQRSInfrastructure,
   Event,
   Infrastructure,
@@ -16,11 +17,19 @@ import type { Instrumentation } from "../tracing";
 
 /**
  * Executes the full saga event handling lifecycle: derive instance ID,
- * load state, bootstrap or resume, execute handler, persist state,
- * and dispatch reaction commands — all within an atomic unit of work.
+ * load state, bootstrap or resume, execute handler, persist state, and
+ * dispatch reaction commands.
  *
- * Creates its own UoW that spans saga state persistence and all
- * commands dispatched by the saga reaction, ensuring atomicity.
+ * The transactional coupling between saga-state persistence and
+ * reaction-command dispatch is selected per-saga by
+ * `saga.atomicity ?? "atomic"`:
+ *
+ * - **`"atomic"`** (default) — a single UoW spans the saga-state save and
+ *   all reaction commands; they commit or roll back together.
+ * - **`"best-effort"`** — the saga state is committed first, then reaction
+ *   commands are dispatched outside that UoW (each obtains its own UoW),
+ *   so command handlers that publish events directly observe the committed
+ *   saga state (issue #119). A command failure does not roll back the state.
  *
  * @internal Not exported — instantiated by {@link Domain} during init.
  */
@@ -124,74 +133,109 @@ export class SagaExecutor {
           userId: event.metadata?.userId,
         };
 
-        // Step 7: Create UoW for saga state persistence
+        // Step 7: Resolve atomicity mode (an absent field defaults to "atomic")
+        const mode = saga.atomicity ?? "atomic";
         const uow = this.unitOfWorkFactory();
         const sagaPersistence = this.sagaPersistence;
-        let events: Event[] = [];
 
-        // Step 8: Commit saga state FIRST, before dispatching commands.
-        // This ensures the saga executor finds persisted state when command
-        // handlers dispatch events synchronously through the event bus.
-        await this.uowStorage.run(uow, async () => {
-          await this.metadataStorage.run(sagaCtx, async () => {
-            try {
-              // Enlist saga state persistence
-              uow.enlist(() =>
-                sagaPersistence.save(sagaName, sagaId, reaction.state),
-              );
-
-              // Commit saga state + any deferred changes
-              const commitFn = () => uow.commit();
-              events = this.instrumentation
-                ? await this.instrumentation.withSpan(
-                    "noddde.uow.commit",
-                    { "noddde.saga.name": sagaName },
-                    commitFn,
-                  )
-                : await commitFn();
-
-              // Step 9: Publish all deferred events sequentially
-              for (const e of events) {
-                await this.infrastructure.eventBus.dispatch(e);
-              }
-
-              // Best-effort post-dispatch callback (e.g., mark outbox entries published)
-              if (this.onEventsDispatched && events.length > 0) {
-                try {
-                  await this.onEventsDispatched(events);
-                } catch {
-                  // Best-effort: relay will catch unpublished entries
-                }
-              }
-            } catch (error) {
-              this.logger?.error("Saga execution failed.", {
-                sagaName,
-                sagaId: String(sagaId),
-                eventName: event.name,
-                error: String(error),
-              });
-              try {
-                await uow.rollback();
-              } catch {
-                // UoW may already be completed if commit failed
-              }
-              throw error;
-            }
-          });
-        });
-
-        // Step 10: Dispatch commands outside UoW context (inside metadata context).
-        // Saga state is already persisted, so events dispatched by command handlers
-        // will find the saga state when processed by the saga executor.
-        // Each command creates its own UoW via CommandLifecycleExecutor.
-        if (reaction.commands) {
-          const commands = Array.isArray(reaction.commands)
+        const commands: Command[] = reaction.commands
+          ? Array.isArray(reaction.commands)
             ? reaction.commands
-            : [reaction.commands];
-          await this.metadataStorage.run(sagaCtx, async () => {
-            for (const command of commands) {
-              await this.infrastructure.commandBus.dispatch(command);
+            : [reaction.commands]
+          : [];
+
+        // Log, attempt a best-effort rollback, and re-throw. Used for the
+        // saga-state commit phase in both modes.
+        const failCommitPhase = async (error: unknown): Promise<never> => {
+          this.logger?.error("Saga execution failed.", {
+            sagaName,
+            sagaId: String(sagaId),
+            eventName: event.name,
+            error: String(error),
+          });
+          try {
+            await uow.rollback();
+          } catch {
+            // UoW may already be completed if commit failed
+          }
+          throw error;
+        };
+
+        // Commit the saga's UoW and publish its deferred events sequentially
+        // (sequential dispatch preserves causal ordering), then run the
+        // best-effort post-dispatch callback. The caller enlists beforehand.
+        const commitAndPublish = async (): Promise<void> => {
+          const commitFn = () => uow.commit();
+          const events = this.instrumentation
+            ? await this.instrumentation.withSpan(
+                "noddde.uow.commit",
+                { "noddde.saga.name": sagaName },
+                commitFn,
+              )
+            : await commitFn();
+
+          for (const e of events) {
+            await this.infrastructure.eventBus.dispatch(e);
+          }
+
+          // Best-effort post-dispatch callback (e.g., mark outbox entries published)
+          if (this.onEventsDispatched && events.length > 0) {
+            try {
+              await this.onEventsDispatched(events);
+            } catch {
+              // Best-effort: relay will catch unpublished entries
             }
+          }
+        };
+
+        const dispatchCommands = async (): Promise<void> => {
+          for (const command of commands) {
+            await this.infrastructure.commandBus.dispatch(command);
+          }
+        };
+
+        if (mode === "best-effort") {
+          // Best-effort: commit the saga state FIRST, then dispatch reaction
+          // commands OUTSIDE the saga's UoW (each obtains its own UoW via the
+          // CommandLifecycleExecutor) but still inside the metadata context.
+          // Because the saga state is already durable, command handlers that
+          // publish events directly via the event bus — and any re-entrant
+          // saga executions they trigger — observe the committed state
+          // (issue #119). A command failure after commit does NOT roll back
+          // the saga state; it propagates.
+          await this.uowStorage.run(uow, async () => {
+            await this.metadataStorage.run(sagaCtx, async () => {
+              try {
+                uow.enlist(() =>
+                  sagaPersistence.save(sagaName, sagaId, reaction.state),
+                );
+                await commitAndPublish();
+              } catch (error) {
+                await failCommitPhase(error);
+              }
+            });
+          });
+
+          if (commands.length > 0) {
+            await this.metadataStorage.run(sagaCtx, dispatchCommands);
+          }
+        } else {
+          // Atomic (default): the saga's UoW spans the saga-state save and all
+          // reaction commands, so they commit or roll back together. Aggregate
+          // command handlers enlist on this same UoW (explicit-UoW path) and
+          // their events are deferred until commit.
+          await this.uowStorage.run(uow, async () => {
+            await this.metadataStorage.run(sagaCtx, async () => {
+              try {
+                uow.enlist(() =>
+                  sagaPersistence.save(sagaName, sagaId, reaction.state),
+                );
+                await dispatchCommands();
+                await commitAndPublish();
+              } catch (error) {
+                await failCommitPhase(error);
+              }
+            });
           });
         }
       };

--- a/specs/core/ddd/saga.spec.md
+++ b/specs/core/ddd/saga.spec.md
@@ -6,6 +6,7 @@ status: implemented
 exports:
   [
     SagaTypes,
+    SagaAtomicity,
     SagaReaction,
     SagaEventHandler,
     SagaOnEntry,
@@ -21,14 +22,14 @@ exports:
   ]
 depends_on: [id, edd/event, cqrs/command/command, infrastructure/index]
 docs:
-  - sagas/overview.mdx
-  - sagas/defining-sagas.mdx
-  - sagas/testing-sagas.mdx
+  - process-managers/sagas.mdx
+  - testing/testing-sagas.mdx
+  - design-decisions/why-sagas-return-commands.mdx
 ---
 
 # SagaTypes, SagaReaction, SagaEventHandler, SagaOnEntry, Saga, defineSaga & Infer Utilities
 
-> Sagas (process managers) are the structural inverse of aggregates: where aggregates receive commands and emit events, sagas receive events and emit commands. This module provides the complete saga definition pattern: `SagaTypes` bundles the type parameters, `SagaReaction` is the handler return type, `SagaEventHandler` implements the react phase, `SagaOnEntry` bundles identity extraction and handler per event, `Saga` is the definition interface with a unified `on` map, `defineSaga` provides type inference, and five `Infer*` utilities extract individual types.
+> Sagas (process managers) are the structural inverse of aggregates: where aggregates receive commands and emit events, sagas receive events and emit commands. This module provides the complete saga definition pattern: `SagaTypes` bundles the type parameters, `SagaReaction` is the handler return type, `SagaEventHandler` implements the react phase, `SagaOnEntry` bundles identity extraction and handler per event, `Saga` is the definition interface with a unified `on` map, `defineSaga` provides type inference, and five `Infer*` utilities extract individual types. `SagaAtomicity` is an optional per-saga setting (`"atomic" | "best-effort"`) declared on the `Saga` definition that selects how the engine couples saga-state persistence with reaction-command dispatch; it is a pure declaration in core (the engine's `SagaExecutor` consumes it, defaulting an absent value to `"atomic"`).
 
 ## Type Contract
 
@@ -38,6 +39,13 @@ docs:
   - `events: Event` -- discriminated union of events this saga reacts to.
   - `commands: Command` -- discriminated union of commands this saga may dispatch.
   - `infrastructure: Infrastructure` -- external dependencies for event handlers.
+
+- **`SagaAtomicity`** is the string-literal union `"atomic" | "best-effort"`. It selects the transactional coupling between a saga instance's state persistence and the commands it dispatches in reaction to an event:
+
+  - `"atomic"` -- saga-state save and all reaction commands share one unit of work; they commit or roll back together (a reaction-command failure rolls back the saga-state transition).
+  - `"best-effort"` -- the saga state is committed first, then reaction commands are dispatched outside that unit of work; a reaction-command failure does not roll back the (already committed) saga state.
+
+  Consumed by the engine's `SagaExecutor`; see `engine/executors/saga-executor` for the runtime semantics. **When omitted, the engine treats the saga as `"atomic"`.**
 
 - **`SagaReaction<TState, TCommands>`** is an object type:
 
@@ -56,11 +64,12 @@ docs:
   - `id: (event: TEvent) => TSagaId` -- extracts the saga instance ID from the event. Required.
   - `handle: SagaEventHandler<TEvent, TState, TCommands, TInfrastructure>` -- the saga event handler.
 
-- **`Saga<T extends SagaTypes, TSagaId extends ID = string>`** is an interface with three fields:
+- **`Saga<T extends SagaTypes, TSagaId extends ID = string>`** is an interface with four fields (one optional):
 
   - `initialState: T["state"]` -- zero-value state for new saga instances.
   - `startedBy: [T["events"]["name"], ...T["events"]["name"][]]` -- non-empty tuple of event names that start the saga.
   - `on: SagaOnMap<T, TSagaId>` -- partial map of event names to `SagaOnEntry` objects. Only events the saga handles need entries.
+  - `atomicity?: SagaAtomicity` -- **optional.** Selects how saga-state persistence and reaction-command dispatch are coupled (`"atomic" | "best-effort"`). When omitted, the engine treats the saga as `"atomic"`. This is a declarative field only — `defineSaga` does not read, validate, or default it.
 
 - **Internal type `SagaOnMap<T, TSagaId>`** -- maps each event name (optionally) to a `SagaOnEntry`. Partial over the event union.
 
@@ -91,6 +100,8 @@ docs:
 - Commands in `SagaReaction` are optional -- a handler may only update state without dispatching.
 - Commands can be a single command or an array of commands.
 - `defineSaga` is an identity function returning the same config object.
+- `atomicity` is optional on the `Saga` definition. When specified, it is exactly one of `"atomic"` or `"best-effort"` (the `SagaAtomicity` union).
+- `atomicity` carries no runtime behavior in core: it is a declarative field consumed by the engine's `SagaExecutor`. `defineSaga` does not read, validate, or inject a default for it — a saga authored without the field has `atomicity === undefined` at runtime, and the engine supplies the default (`"atomic"`).
 - `TSagaId` is bounded by `ID`, defaults to `string`, and can be customized (e.g., `number`, `bigint`, branded type).
 - `InferSagaEventHandler<T, K>` resolves to a function receiving the narrowed event (via `Extract<T["events"], { name: K }>`), the saga state, and infrastructure merged with `CQRSInfrastructure` and `FrameworkInfrastructure`, returning `SagaReaction` or `Promise<SagaReaction>`.
 - `InferSagaOnEntry<T, K, TSagaId>` resolves to an object with `id: (event) => TSagaId` and `handle: InferSagaEventHandler<T, K>`.
@@ -104,7 +115,9 @@ docs:
 - `startedBy` elements must be valid event names from the saga's event union.
 - `SagaReaction.commands` is optional; when omitted, no commands are dispatched.
 - Infrastructure parameter in handlers always includes `CQRSInfrastructure` and `FrameworkInfrastructure` via `&`.
-- `defineSaga` returns the exact same object reference.
+- `defineSaga` returns the exact same object reference (adding `atomicity` does not change this — the field, present or absent, is preserved verbatim).
+- `atomicity`, when present, is exactly `"atomic"` or `"best-effort"`; no other value is assignable (`SagaAtomicity`).
+- `defineSaga` never mutates or defaults `atomicity`; an omitted field stays `undefined` on the returned object — the engine, not core, supplies the `"atomic"` default.
 - `SagaTypes["commands"]` is constrained to `Command` (not `AggregateCommand`), allowing sagas to dispatch both aggregate and standalone commands.
 - `InferSagaEventHandler<T, K>` always produces the same type as the `handle` field of `SagaOnMap<T>[K]`.
 - `InferSagaOnEntry<T, K, TSagaId>` always produces the same type as `SagaOnMap<T, TSagaId>[K]`.
@@ -118,6 +131,9 @@ docs:
 - **Custom saga ID type**: `TSagaId = number` or a branded string type.
 - **Commands as array**: `commands: [cmd1, cmd2]` dispatches multiple commands.
 - **Partial on map**: Only a subset of event types need entries in `on`.
+- **No `atomicity` field**: `saga.atomicity` is `undefined`; the engine applies its default (`"atomic"`). Behavior is identical to pre-`atomicity` sagas.
+- **Explicit `atomicity: "best-effort"`**: round-trips unchanged through `defineSaga`; the engine commits saga state before dispatching reaction commands.
+- **Explicit `atomicity: "atomic"`**: round-trips unchanged; identical to omitting the field.
 
 ## Integration Points
 
@@ -125,6 +141,7 @@ docs:
 - `startedBy` tells the runtime which events should create new saga instances.
 - Sagas bridge between bounded contexts by reacting to events from one context and dispatching commands to another.
 - `InferSaga*` utilities are used downstream for persistence, testing, and engine configuration.
+- The engine's `SagaExecutor` reads `saga.atomicity` (defaulting an absent value to `"atomic"`) to choose its unit-of-work / commit ordering. The field is purely declarative here; its observable behavior is specified in `engine/executors/saga-executor`.
 
 ## Test Scenarios
 
@@ -686,6 +703,118 @@ describe("InferSagaOnEntry", () => {
     });
 
     expectTypeOf(saga.on.OrderPlaced).not.toBeUndefined();
+  });
+});
+```
+
+### Saga exposes an optional atomicity field typed as SagaAtomicity
+
+```ts
+import { describe, it, expectTypeOf } from "vitest";
+import type { Saga, SagaAtomicity } from "@noddde/core";
+
+describe("Saga atomicity field", () => {
+  it("should type SagaAtomicity as the atomic | best-effort union", () => {
+    expectTypeOf<SagaAtomicity>().toEqualTypeOf<"atomic" | "best-effort">();
+  });
+
+  it("should expose atomicity as an optional SagaAtomicity on Saga", () => {
+    expectTypeOf<Saga["atomicity"]>().toEqualTypeOf<
+      SagaAtomicity | undefined
+    >();
+  });
+});
+```
+
+### defineSaga round-trips an explicit atomicity value
+
+```ts
+import { describe, it, expect, expectTypeOf } from "vitest";
+import { defineSaga } from "@noddde/core";
+import type {
+  DefineEvents,
+  Command,
+  Infrastructure,
+  SagaAtomicity,
+} from "@noddde/core";
+
+describe("defineSaga atomicity", () => {
+  type E = DefineEvents<{ Started: { id: string } }>;
+  type C = Command & { name: "Noop" };
+  type T = {
+    state: { started: boolean };
+    events: E;
+    commands: C;
+    infrastructure: Infrastructure;
+  };
+
+  it("should preserve an explicit best-effort atomicity", () => {
+    const saga = defineSaga<T>({
+      atomicity: "best-effort",
+      initialState: { started: false },
+      startedBy: ["Started"],
+      on: {
+        Started: {
+          id: (event) => event.payload.id,
+          handle: () => ({ state: { started: true } }),
+        },
+      },
+    });
+    expect(saga.atomicity).toBe("best-effort");
+    expectTypeOf(saga.atomicity).toEqualTypeOf<SagaAtomicity | undefined>();
+  });
+
+  it("should preserve an explicit atomic atomicity", () => {
+    const saga = defineSaga<T>({
+      atomicity: "atomic",
+      initialState: { started: false },
+      startedBy: ["Started"],
+      on: {
+        Started: {
+          id: (event) => event.payload.id,
+          handle: () => ({ state: { started: true } }),
+        },
+      },
+    });
+    expect(saga.atomicity).toBe("atomic");
+  });
+});
+```
+
+### defineSaga leaves atomicity undefined when omitted (no default injected)
+
+```ts
+import { describe, it, expect } from "vitest";
+import { defineSaga } from "@noddde/core";
+import type { DefineEvents, Command, Infrastructure } from "@noddde/core";
+
+describe("defineSaga atomicity default", () => {
+  type E = DefineEvents<{ Started: { id: string } }>;
+  type C = Command & { name: "Noop" };
+  type T = {
+    state: {};
+    events: E;
+    commands: C;
+    infrastructure: Infrastructure;
+  };
+
+  it("should not inject a default — an omitted atomicity stays undefined", () => {
+    const config = {
+      initialState: {},
+      startedBy: ["Started" as const],
+      on: {
+        Started: {
+          id: (e: any) => String(e.payload.id),
+          handle: (_e: any, s: any) => ({ state: s }),
+        },
+      },
+    };
+    const saga = defineSaga<T>(config as any);
+
+    // Engine, not core, supplies the "atomic" default — core leaves it absent.
+    expect(saga.atomicity).toBeUndefined();
+    // Identity is preserved exactly (the new field does not change this).
+    expect(saga).toBe(config);
   });
 });
 ```

--- a/specs/engine/executors/saga-executor.spec.md
+++ b/specs/engine/executors/saga-executor.spec.md
@@ -16,7 +16,7 @@ depends_on:
 
 # SagaExecutor
 
-> `SagaExecutor` executes the full saga event handling lifecycle: derive the saga instance ID from the event via the `on` map, load the saga state, bootstrap (if the event is in `startedBy`) or ignore (if the saga has not started), execute the saga handler, persist the new saga state, and dispatch reaction commands -- all within an atomic unit of work. The saga's UoW spans both saga state persistence and all aggregate commands dispatched by the reaction, ensuring atomicity. This is an engine-internal class instantiated by `Domain` during `init()`.
+> `SagaExecutor` executes the full saga event handling lifecycle: derive the saga instance ID from the event via the `on` map, load the saga state, bootstrap (if the event is in `startedBy`) or ignore (if the saga has not started), execute the saga handler, persist the new saga state, and dispatch reaction commands. The transactional coupling between saga-state persistence and reaction-command dispatch is selected per-saga by `saga.atomicity ?? "atomic"` (see `ddd/saga`): in **atomic** mode (the default) a single unit of work spans the saga-state save and all reaction commands, so they commit or roll back together; in **best-effort** mode the saga state is committed first and reaction commands are dispatched afterward, each in its own unit of work. This is an engine-internal class instantiated by `Domain` during `init()`.
 
 ## Type Contract
 
@@ -49,6 +49,7 @@ class SagaExecutor {
 
 - `SagaExecutor` is constructed with the merged infrastructure (including CQRS buses), saga persistence, UoW factory, and `AsyncLocalStorage` instances for UoW and metadata context propagation.
 - `execute` is the single public method. It processes a single event for a given saga definition, handling the full lifecycle internally.
+- `execute` selects its unit-of-work / commit ordering from `saga.atomicity` (`"atomic" | "best-effort"`, from `ddd/saga`), defaulting an absent value to `"atomic"`. The constructor signature is unchanged — the mode is read per-event from the `saga` argument, so one executor instance serves sagas of either mode.
 
 ## Behavioral Requirements
 
@@ -81,48 +82,55 @@ class SagaExecutor {
    - `userId`: from `event.metadata?.userId`.
      This ensures all commands dispatched by the saga carry the same correlation chain as the triggering event.
 
-### Create Saga-Scoped UoW
+### Resolve Atomicity Mode
 
-7. **Create a new UoW** -- Call `unitOfWorkFactory()` to create a new UoW for this saga reaction. This UoW spans both the saga state persistence and any commands dispatched by the reaction.
+7. **Resolve mode** -- Compute the effective mode as `saga.atomicity ?? "atomic"`. The saga definition's optional `atomicity` field (see `ddd/saga`) selects the transactional coupling; an absent field defaults to `"atomic"`. The mode governs only the unit-of-work and commit ordering relative to reaction-command dispatch (BRs 8-18). Steps 1-6 (association lookup, load, bootstrap/resume, handler invocation, metadata-context construction) and the correlation guarantees are identical across modes.
 
-8. **Run within UoW and metadata context** -- Use `uowStorage.run(uow, ...)` and `metadataStorage.run(sagaCtx, ...)` to make the UoW and metadata context available to all commands dispatched within the saga handler execution.
+### Atomic Mode (default)
 
-### Enlist Saga State Persistence
+> Saga-state persistence and all reaction commands share one unit of work: they commit or roll back together. This is correct as long as command-produced events come from aggregate deciders that **return** events (the golden path) — `CommandLifecycleExecutor` detects the saga's UoW in `AsyncLocalStorage`, enlists on it, and `deferPublish`es those events so they are published only after the saga's UoW commits.
 
-9. **Enlist state save** -- Call `uow.enlist(() => sagaPersistence.save(sagaName, sagaId, reaction.state))` to defer saga state persistence until UoW commit.
+8. **Create a saga-scoped UoW** -- Call `unitOfWorkFactory()`. This single UoW spans both the saga-state save and every command dispatched by the reaction.
 
-### Dispatch Reaction Commands
+9. **Run within UoW and metadata context** -- Use `uowStorage.run(uow, ...)` and `metadataStorage.run(sagaCtx, ...)` so the UoW and metadata context are visible to all commands dispatched within the handler-reaction scope.
 
-10. **Dispatch commands within UoW** -- If `reaction.commands` is defined:
-    - Normalize to array: if `reaction.commands` is a single command, wrap in an array.
-    - For each command, call `infrastructure.commandBus.dispatch(command)`.
-    - Because the UoW is in the `AsyncLocalStorage`, aggregate command handlers invoked by the command bus will enlist their persistence on the same UoW, achieving atomicity.
+10. **Enlist saga-state save** -- Call `uow.enlist(() => sagaPersistence.save(sagaName, sagaId, reaction.state))` to defer saga-state persistence until commit.
 
-### Commit Atomically
+11. **Dispatch reaction commands within the UoW** -- If `reaction.commands` is defined, normalize to an array (wrap a single command) and call `infrastructure.commandBus.dispatch(command)` for each. Because the UoW is in the `AsyncLocalStorage`, aggregate command handlers enlist their persistence on the **same** UoW (the explicit-UoW path in `CommandLifecycleExecutor`), achieving atomicity.
 
-11. **Commit UoW** -- Call `uow.commit()` which executes all enlisted operations (saga state save + aggregate persistence saves) and returns the deferred events.
+12. **Commit atomically** -- Call `uow.commit()`, which executes all enlisted operations (saga-state save + aggregate persistence saves) and returns the deferred events.
 
-### Publish Deferred Events
+13. **Publish deferred events, then callback** -- After a successful commit, dispatch every returned event sequentially via `for (const e of events) { await infrastructure.eventBus.dispatch(e); }` (sequential dispatch preserves causal ordering — events from a single saga reaction arrive at consumers in the order they were produced). Then, if `onEventsDispatched` is provided and `events.length > 0`, call `onEventsDispatched(events)`; errors from this callback are silently swallowed (a non-fatal outbox-marking hook).
 
-12. **Publish events after commit** -- After successful commit, dispatch all returned events sequentially via `for (const e of events) { await infrastructure.eventBus.dispatch(e); }`. Sequential dispatch preserves causal ordering — events from a single saga reaction arrive at consumers in the order they were produced.
+14. **Rollback on failure (atomic)** -- If any step within the UoW scope (state enlist, command dispatch, or commit) throws, call `uow.rollback()` (best-effort; rollback errors are swallowed) and re-throw the original error. The saga state is **not** persisted, and any aggregate changes enlisted on the same UoW are rolled back with it.
 
-12b. **Post-dispatch callback (best-effort)** -- After dispatching all events, if `onEventsDispatched` is provided, call `onEventsDispatched(events)`. Errors from this callback are silently swallowed. This enables the Domain to mark outbox entries as published.
+### Best-Effort Mode
 
-### Rollback on Error
+> The saga state is committed **first** in its own UoW; **then** reaction commands are dispatched **outside** that UoW (each command obtains its own UoW via `CommandLifecycleExecutor`), still inside the metadata context. Because the saga state is already durable before any command runs, events that command handlers dispatch **directly** through the event bus — and any re-entrant saga executions they trigger — observe the committed saga state. This is the escape hatch for off-path dispatch (issue #119), notably **standalone command handlers**, which have no "return events" channel and can only publish via `eventBus.dispatch()`.
 
-13. **Rollback on failure** -- If any step within the UoW scope throws, call `uow.rollback()` (best-effort; rollback errors are swallowed). The original error is re-thrown.
+15. **Create and commit a saga-state UoW first** -- Create a UoW, run within `uowStorage.run(uow, ...)` and `metadataStorage.run(sagaCtx, ...)`, enlist the saga-state save, and call `uow.commit()` **before** dispatching any reaction command. For a state-only UoW the returned deferred-events array is typically empty; publish any returned events sequentially and invoke `onEventsDispatched` (when `events.length > 0`) exactly as in atomic mode (BR 13). If this commit phase throws, call `uow.rollback()` (best-effort) and re-throw — the saga state is not persisted.
+
+16. **Dispatch reaction commands after commit, outside the saga UoW** -- After the saga-state UoW has committed, if `reaction.commands` is defined, normalize to an array and dispatch each via `infrastructure.commandBus.dispatch(command)`, wrapped in `metadataStorage.run(sagaCtx, ...)` but **not** in `uowStorage.run`. With no ambient UoW, each command creates its own implicit UoW via `CommandLifecycleExecutor`, commits independently, and publishes its own produced events after its own commit.
+
+17. **Committed-state visibility** -- Because the saga state is persisted before any reaction command runs, a command handler (aggregate decider or standalone handler) that dispatches an event directly via `infrastructure.eventBus.dispatch()` — and any re-entrant `SagaExecutor.execute` triggered by that event for the same saga instance — loads the committed saga state (not `null`). The event is handled (or starts/resumes the instance) rather than being silently dropped.
+
+18. **No cross-command rollback (best-effort)** -- Once the saga-state UoW has committed, a subsequent reaction-command failure does **not** roll back the (already durable) saga state; the failing command's own UoW rolls back only its own aggregate changes. The error still propagates to the caller / event bus.
 
 ## Invariants
 
-- The saga's UoW always spans saga state persistence and all aggregate commands dispatched by the reaction. They commit or rollback together.
-- Events are published only after successful UoW commit (never before).
-- The metadata context is set before any commands are dispatched, ensuring enriched events carry the saga's correlation chain.
+- **Atomicity is per-saga, selected by `saga.atomicity ?? "atomic"`.** Steps 1-6 (lookup, load, bootstrap/resume, handler, metadata) are identical across modes; only the UoW / commit / dispatch ordering differs.
+- In **atomic** mode, the saga's UoW spans saga-state persistence and all reaction commands; they commit or roll back together. A reaction-command failure rolls back the saga-state transition.
+- In **best-effort** mode, the saga state is committed in its own UoW **before** any reaction command is dispatched; reaction commands run outside that UoW, each in its own UoW. A reaction-command failure does **not** roll back the (already committed) saga state.
+- Events produced by aggregate deciders are published only after the UoW that persists them commits (never before) — in **atomic** mode the saga's UoW, in **best-effort** mode each command's own UoW.
+- The metadata context is set before any commands are dispatched, in **both** modes, ensuring enriched events carry the saga's correlation chain.
 - The `causationId` for events produced by saga-dispatched commands is the `eventId` of the triggering event (linking cause to effect).
 - If `saga.on[event.name]` is `undefined`, the event is silently ignored (no error).
 - If `saga.on[event.name]?.handle` is `undefined`, the event is silently ignored (no error).
 - If the saga has not started and the event is not in `startedBy`, the event is silently ignored.
 - UoW rollback errors are swallowed; the original error is re-thrown.
-- The executor creates its own UoW (not reusing an existing one). Saga reactions always have their own atomic boundary.
+- The executor always creates its own UoW for saga-state persistence (it never reuses an ambient one). In **atomic** mode that UoW also bounds the reaction commands; in **best-effort** mode the reaction commands are dispatched after it commits and obtain their own UoWs.
+- In **best-effort** mode, a command handler that dispatches an event directly via `eventBus.dispatch()` observes committed saga state; the re-entrant saga event is handled, not dropped.
+- In **atomic** mode, off-path direct `eventBus.dispatch()` from a command handler still races the saga-state commit: with the in-process bus the re-entrant event is delivered before the saga's UoW commits, loads `null`, and is silently ignored ("saga not started"). This is a **documented limitation of `atomic`**; the golden path (deciders/aggregates **return** events, which are deferred and published only after commit) avoids it entirely.
 
 ## Edge Cases
 
@@ -132,8 +140,12 @@ class SagaExecutor {
 - **Saga already started and receives a startedBy event** -- Uses the existing state (does not reset to `initialState`). The `startedBy` check only applies when state is `null`.
 - **Reaction with no commands** -- Only saga state is persisted. No commands dispatched. UoW commits with just the state save.
 - **Reaction with single command (not array)** -- Normalized to `[command]` before dispatching.
-- **Reaction with multiple commands** -- Each dispatched sequentially. All aggregate changes enlist on the same UoW.
-- **Command dispatch throws** -- UoW is rolled back. Saga state is not persisted. Error propagates.
+- **Reaction with multiple commands** -- Each dispatched sequentially. In **atomic** mode all aggregate changes enlist on the saga's UoW; in **best-effort** mode each command commits in its own UoW after the saga state is persisted.
+- **Command dispatch throws (atomic mode)** -- The saga's UoW is rolled back; saga state is **not** persisted; the error propagates.
+- **Command dispatch throws (best-effort mode)** -- The saga-state UoW has already committed, so saga state **is** persisted; the failing command's own UoW rolls back its own aggregate changes; the error still propagates.
+- **Saga omits `atomicity`** -- Treated as `"atomic"` (default); behavior is identical to pre-`atomicity` sagas.
+- **Best-effort saga whose command handler dispatches a consumed event** -- The event is processed against committed saga state and advances the saga instance (the issue #119 scenario, fixed under best-effort).
+- **Atomic saga whose command handler dispatches a consumed event** -- With the in-process event bus the re-entrant event is delivered before the saga UoW commits, loads `null`, and is dropped ("saga not started"); the saga does not advance. Documented limitation of `atomic` — use the golden path (return events) or `best-effort`.
 - **sagaPersistence.save throws during commit** -- UoW commit fails. Error propagates after rollback attempt.
 - **Triggering event has no metadata** -- `correlationId` defaults to a new UUID v7. `causationId` defaults to `event.name`. `userId` is `undefined`.
 - **Triggering event has metadata** -- `correlationId`, `causationId` (from `eventId`), and `userId` are propagated.
@@ -142,8 +154,9 @@ class SagaExecutor {
 ## Integration Points
 
 - **Domain** -- Constructs the `SagaExecutor` during `init()` and subscribes it to event bus events matching `Object.keys(saga.on)`.
+- **`Saga.atomicity` (core, `ddd/saga`)** -- `execute` reads `saga.atomicity` to select the mode; an absent field defaults to `"atomic"`. The field is declared and documented in the core saga spec; this spec defines its observable runtime behavior.
 - **CommandBus** -- Saga dispatches commands through `infrastructure.commandBus.dispatch()`. This routes to aggregate command handlers registered by the Domain.
-- **CommandLifecycleExecutor** -- When the saga dispatches commands, the command bus invokes the `CommandLifecycleExecutor`. Because the saga's UoW is in the `AsyncLocalStorage`, the executor uses the saga's UoW (explicit UoW path).
+- **CommandLifecycleExecutor** -- When the saga dispatches commands, the command bus invokes the `CommandLifecycleExecutor`. In **atomic** mode the saga's UoW is in `AsyncLocalStorage`, so the executor takes the explicit-UoW path and enlists on it. In **best-effort** mode commands are dispatched after the saga UoW commits and outside `uowStorage`, so the executor takes the implicit-UoW path — creating and committing its own UoW per command and publishing that command's events after its own commit.
 - **SagaPersistence** -- Saga state is loaded and saved via the persistence interface.
 - **MetadataEnricher** -- Indirectly used: the metadata context set by the saga flows through `AsyncLocalStorage` to the `MetadataEnricher` in `CommandLifecycleExecutor`, ensuring correlation propagation.
 - **EventBus** -- Events deferred by aggregate commands within the saga are published after UoW commit.
@@ -586,6 +599,8 @@ describe("SagaExecutor", () => {
 
 ### execute rolls back UoW when command dispatch throws
 
+> **Atomic-mode test (default).** `RbSaga` declares no `atomicity` field, so it runs in the default `atomic` mode: the saga's UoW spans the state save and the failing command, so a command failure rolls back the saga-state transition. The best-effort inverse is the next scenario.
+
 ```ts
 import { AsyncLocalStorage } from "node:async_hooks";
 import { describe, it, expect } from "vitest";
@@ -975,6 +990,403 @@ describe("SagaExecutor", () => {
 
     const state = await sagaPersistence.load("FlowSaga", "flow-1");
     expect(state).toEqual({ steps: ["started", "continued"] });
+  });
+});
+```
+
+### execute persists saga state even when a command throws under best-effort
+
+> Best-effort inverse of the atomic rollback test. `atomicity: "best-effort"` commits the saga state before dispatching reaction commands, so a downstream command failure does **not** roll back the saga-state transition; the error still propagates.
+
+```ts
+import { AsyncLocalStorage } from "node:async_hooks";
+import { describe, it, expect } from "vitest";
+import { defineSaga } from "@noddde/core";
+import type {
+  SagaTypes,
+  DefineEvents,
+  Infrastructure,
+  CQRSInfrastructure,
+  UnitOfWork,
+} from "@noddde/core";
+import {
+  InMemoryCommandBus,
+  EventEmitterEventBus,
+  InMemoryQueryBus,
+  InMemorySagaPersistence,
+  createInMemoryUnitOfWork,
+} from "@noddde/engine";
+import { SagaExecutor } from "../../../executors/saga-executor";
+import type { MetadataContext } from "../../../domain";
+
+type BeRbState = { ran: boolean };
+type BeRbEvent = DefineEvents<{ BeRbTrigger: { id: string } }>;
+type BeRbTypes = SagaTypes & {
+  state: BeRbState;
+  events: BeRbEvent;
+  commands: never;
+  infrastructure: Infrastructure & CQRSInfrastructure;
+};
+
+const BeRbSaga = defineSaga<BeRbTypes>({
+  atomicity: "best-effort",
+  initialState: { ran: false },
+  startedBy: ["BeRbTrigger"],
+  on: {
+    BeRbTrigger: {
+      id: (event) => event.payload.id,
+      handle: () => ({
+        state: { ran: true },
+        commands: {
+          name: "FailingCmd",
+          payload: {},
+          targetAggregateId: "fail-be",
+        },
+      }),
+    },
+  },
+});
+
+describe("SagaExecutor best-effort", () => {
+  it("should persist saga state even when a command throws", async () => {
+    const sagaPersistence = new InMemorySagaPersistence();
+    const commandBus = new InMemoryCommandBus();
+    commandBus.register("FailingCmd", async () => {
+      throw new Error("Command failed");
+    });
+    const infrastructure: Infrastructure & CQRSInfrastructure = {
+      commandBus,
+      eventBus: new EventEmitterEventBus(),
+      queryBus: new InMemoryQueryBus(),
+    };
+    const uowStorage = new AsyncLocalStorage<UnitOfWork>();
+    const metadataStorage = new AsyncLocalStorage<MetadataContext>();
+
+    const executor = new SagaExecutor(
+      infrastructure,
+      sagaPersistence,
+      createInMemoryUnitOfWork,
+      uowStorage,
+      metadataStorage,
+    );
+
+    await expect(
+      executor.execute("BeRbSaga", BeRbSaga, {
+        name: "BeRbTrigger",
+        payload: { id: "be1" },
+      }),
+    ).rejects.toThrow("Command failed");
+
+    // Saga state IS persisted — committed before the command ran.
+    const state = await sagaPersistence.load("BeRbSaga", "be1");
+    expect(state).toEqual({ ran: true });
+  });
+});
+```
+
+### execute commits saga state before dispatching commands under best-effort
+
+> Proves the commit-first ordering directly: by the time the reaction command's handler runs, the new saga state is already loadable from persistence.
+
+```ts
+import { AsyncLocalStorage } from "node:async_hooks";
+import { describe, it, expect } from "vitest";
+import { defineSaga } from "@noddde/core";
+import type {
+  SagaTypes,
+  DefineEvents,
+  Infrastructure,
+  CQRSInfrastructure,
+  UnitOfWork,
+} from "@noddde/core";
+import {
+  InMemoryCommandBus,
+  EventEmitterEventBus,
+  InMemoryQueryBus,
+  InMemorySagaPersistence,
+  createInMemoryUnitOfWork,
+} from "@noddde/engine";
+import { SagaExecutor } from "../../../executors/saga-executor";
+import type { MetadataContext } from "../../../domain";
+
+type OrderingState = { phase: string };
+type OrderingEvent = DefineEvents<{ Begin: { id: string } }>;
+type OrderingTypes = SagaTypes & {
+  state: OrderingState;
+  events: OrderingEvent;
+  commands: never;
+  infrastructure: Infrastructure & CQRSInfrastructure;
+};
+
+const OrderingSaga = defineSaga<OrderingTypes>({
+  atomicity: "best-effort",
+  initialState: { phase: "init" },
+  startedBy: ["Begin"],
+  on: {
+    Begin: {
+      id: (event) => event.payload.id,
+      handle: () => ({
+        state: { phase: "committed" },
+        commands: { name: "Probe", payload: {}, targetAggregateId: "p1" },
+      }),
+    },
+  },
+});
+
+describe("SagaExecutor best-effort", () => {
+  it("should have committed saga state by the time the command handler runs", async () => {
+    const sagaPersistence = new InMemorySagaPersistence();
+    const commandBus = new InMemoryCommandBus();
+    const uowStorage = new AsyncLocalStorage<UnitOfWork>();
+    const metadataStorage = new AsyncLocalStorage<MetadataContext>();
+
+    let stateSeenByCommand: unknown;
+    commandBus.register("Probe", async () => {
+      stateSeenByCommand = await sagaPersistence.load("OrderingSaga", "o1");
+    });
+
+    const infrastructure: Infrastructure & CQRSInfrastructure = {
+      commandBus,
+      eventBus: new EventEmitterEventBus(),
+      queryBus: new InMemoryQueryBus(),
+    };
+
+    const executor = new SagaExecutor(
+      infrastructure,
+      sagaPersistence,
+      createInMemoryUnitOfWork,
+      uowStorage,
+      metadataStorage,
+    );
+
+    await executor.execute("OrderingSaga", OrderingSaga, {
+      name: "Begin",
+      payload: { id: "o1" },
+    });
+
+    // The command handler observed the already-committed saga state.
+    expect(stateSeenByCommand).toEqual({ phase: "committed" });
+  });
+});
+```
+
+### execute under best-effort lets a command-handler-dispatched event resume the same saga (issue #119)
+
+> Canonical reproduction of issue #119, fixed under `best-effort`. The saga's `StartTask` handler dispatches a `ProcessTask` command whose handler publishes a `ProcessCompleted` event **directly** on the event bus (the off-path pattern standalone command handlers must use). The executor is subscribed to the bus via `eventBus.on`, exactly as `Domain` wires it. Because best-effort commits saga state before dispatching the command, the re-entrant `ProcessCompleted` finds the persisted state and advances the saga to `done`.
+
+```ts
+import { AsyncLocalStorage } from "node:async_hooks";
+import { describe, it, expect } from "vitest";
+import { defineSaga } from "@noddde/core";
+import type {
+  SagaTypes,
+  DefineEvents,
+  Event,
+  Infrastructure,
+  CQRSInfrastructure,
+  UnitOfWork,
+} from "@noddde/core";
+import {
+  InMemoryCommandBus,
+  EventEmitterEventBus,
+  InMemoryQueryBus,
+  InMemorySagaPersistence,
+  createInMemoryUnitOfWork,
+} from "@noddde/engine";
+import { SagaExecutor } from "../../../executors/saga-executor";
+import type { MetadataContext } from "../../../domain";
+
+type TaskState = { step: "initial" | "processing" | "done" };
+type TaskEvent = DefineEvents<{
+  StartTask: { taskId: string };
+  ProcessCompleted: { taskId: string };
+}>;
+type TaskTypes = SagaTypes & {
+  state: TaskState;
+  events: TaskEvent;
+  commands: never;
+  infrastructure: Infrastructure & CQRSInfrastructure;
+};
+
+const BestEffortTaskSaga = defineSaga<TaskTypes>({
+  atomicity: "best-effort",
+  initialState: { step: "initial" },
+  startedBy: ["StartTask"],
+  on: {
+    StartTask: {
+      id: (event) => event.payload.taskId,
+      handle: (event) => ({
+        state: { step: "processing" },
+        commands: {
+          name: "ProcessTask",
+          payload: { taskId: event.payload.taskId },
+          targetAggregateId: event.payload.taskId,
+        },
+      }),
+    },
+    ProcessCompleted: {
+      id: (event) => event.payload.taskId,
+      handle: (_event, state) => ({
+        state: { ...state, step: "done" },
+      }),
+    },
+  },
+});
+
+describe("SagaExecutor best-effort (issue #119)", () => {
+  it("should resume the saga when a command handler dispatches a consumed event", async () => {
+    const sagaPersistence = new InMemorySagaPersistence();
+    const commandBus = new InMemoryCommandBus();
+    const eventBus = new EventEmitterEventBus();
+    const uowStorage = new AsyncLocalStorage<UnitOfWork>();
+    const metadataStorage = new AsyncLocalStorage<MetadataContext>();
+
+    const infrastructure: Infrastructure & CQRSInfrastructure = {
+      commandBus,
+      eventBus,
+      queryBus: new InMemoryQueryBus(),
+    };
+
+    const executor = new SagaExecutor(
+      infrastructure,
+      sagaPersistence,
+      createInMemoryUnitOfWork,
+      uowStorage,
+      metadataStorage,
+    );
+
+    // Wire the executor to the event bus exactly as Domain does (eventBus.on).
+    for (const eventName of Object.keys(BestEffortTaskSaga.on)) {
+      eventBus.on(eventName, (event: Event) =>
+        executor.execute("TaskSaga", BestEffortTaskSaga, event),
+      );
+    }
+
+    // Standalone-style command handler: publishes an event directly (off-path).
+    commandBus.register("ProcessTask", async (command) => {
+      await eventBus.dispatch({
+        name: "ProcessCompleted",
+        payload: { taskId: (command.payload as { taskId: string }).taskId },
+      });
+    });
+
+    await executor.execute("TaskSaga", BestEffortTaskSaga, {
+      name: "StartTask",
+      payload: { taskId: "t-1" },
+    });
+
+    const state = await sagaPersistence.load("TaskSaga", "t-1");
+    expect(state).toEqual({ step: "done" });
+  });
+});
+```
+
+### execute under atomic drops an event dispatched by a command handler (issue #119 limitation)
+
+> Documents the `atomic`-mode limitation. The same shape as the best-effort reproduction, but `atomicity: "atomic"`. Because commands are dispatched inside the saga's UoW (before commit), the re-entrant `ProcessCompleted` loads `null` saga state and is dropped — the saga never reaches `done`. The remedy is the golden path (return events) or `best-effort`.
+
+```ts
+import { AsyncLocalStorage } from "node:async_hooks";
+import { describe, it, expect } from "vitest";
+import { defineSaga } from "@noddde/core";
+import type {
+  SagaTypes,
+  DefineEvents,
+  Event,
+  Infrastructure,
+  CQRSInfrastructure,
+  UnitOfWork,
+} from "@noddde/core";
+import {
+  InMemoryCommandBus,
+  EventEmitterEventBus,
+  InMemoryQueryBus,
+  InMemorySagaPersistence,
+  createInMemoryUnitOfWork,
+} from "@noddde/engine";
+import { SagaExecutor } from "../../../executors/saga-executor";
+import type { MetadataContext } from "../../../domain";
+
+type AtomicTaskState = { step: "initial" | "processing" | "done" };
+type AtomicTaskEvent = DefineEvents<{
+  StartTask: { taskId: string };
+  ProcessCompleted: { taskId: string };
+}>;
+type AtomicTaskTypes = SagaTypes & {
+  state: AtomicTaskState;
+  events: AtomicTaskEvent;
+  commands: never;
+  infrastructure: Infrastructure & CQRSInfrastructure;
+};
+
+const AtomicTaskSaga = defineSaga<AtomicTaskTypes>({
+  atomicity: "atomic",
+  initialState: { step: "initial" },
+  startedBy: ["StartTask"],
+  on: {
+    StartTask: {
+      id: (event) => event.payload.taskId,
+      handle: (event) => ({
+        state: { step: "processing" },
+        commands: {
+          name: "ProcessTask",
+          payload: { taskId: event.payload.taskId },
+          targetAggregateId: event.payload.taskId,
+        },
+      }),
+    },
+    ProcessCompleted: {
+      id: (event) => event.payload.taskId,
+      handle: (_event, state) => ({
+        state: { ...state, step: "done" },
+      }),
+    },
+  },
+});
+
+describe("SagaExecutor atomic (issue #119 limitation)", () => {
+  it("should drop a command-handler-dispatched event (saga stays at processing)", async () => {
+    const sagaPersistence = new InMemorySagaPersistence();
+    const commandBus = new InMemoryCommandBus();
+    const eventBus = new EventEmitterEventBus();
+    const uowStorage = new AsyncLocalStorage<UnitOfWork>();
+    const metadataStorage = new AsyncLocalStorage<MetadataContext>();
+
+    const infrastructure: Infrastructure & CQRSInfrastructure = {
+      commandBus,
+      eventBus,
+      queryBus: new InMemoryQueryBus(),
+    };
+
+    const executor = new SagaExecutor(
+      infrastructure,
+      sagaPersistence,
+      createInMemoryUnitOfWork,
+      uowStorage,
+      metadataStorage,
+    );
+
+    for (const eventName of Object.keys(AtomicTaskSaga.on)) {
+      eventBus.on(eventName, (event: Event) =>
+        executor.execute("AtomicTaskSaga", AtomicTaskSaga, event),
+      );
+    }
+
+    commandBus.register("ProcessTask", async (command) => {
+      await eventBus.dispatch({
+        name: "ProcessCompleted",
+        payload: { taskId: (command.payload as { taskId: string }).taskId },
+      });
+    });
+
+    await executor.execute("AtomicTaskSaga", AtomicTaskSaga, {
+      name: "StartTask",
+      payload: { taskId: "t-2" },
+    });
+
+    // The re-entrant ProcessCompleted arrived before commit → dropped.
+    const state = await sagaPersistence.load("AtomicTaskSaga", "t-2");
+    expect(state).toEqual({ step: "processing" });
   });
 });
 ```

--- a/specs/reports/saga-atomicity.audit-report.md
+++ b/specs/reports/saga-atomicity.audit-report.md
@@ -1,0 +1,50 @@
+## Audit Report: per-saga `atomicity` configuration
+
+- **Verdict**: PASS
+- **Cycle**: 1
+- **Specs**:
+  - `specs/core/ddd/saga.spec.md` (new `SagaAtomicity` export + optional `atomicity?` field)
+  - `specs/engine/executors/saga-executor.spec.md` (mode-branching behavior)
+
+### Mechanical Checks
+
+| Check               | Result | Details                                                                                                                               |
+| ------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Export coverage     | PASS   | 14/14 spec exports present in `saga.ts` (`SagaAtomicity` added). Surfaces via `index.ts → ./ddd → ./saga`; present in built `dist`.   |
+| Stubs remaining     | PASS   | 0 stubs (`throw new Error` grep empty). The `throw error` in `failCommitPhase` is a legitimate rollback re-throw, not a stub.         |
+| Type check (core)   | PASS   | `tsc --noEmit` exit 0                                                                                                                 |
+| Type check (engine) | PASS   | `tsc --noEmit` exit 0 (resolves `SagaAtomicity` from prebuilt `@noddde/core` dist)                                                    |
+| Tests (core saga)   | PASS   | 35/35                                                                                                                                 |
+| Tests (engine saga) | PASS   | saga-executor 12/12                                                                                                                   |
+| Tests (full engine) | PASS   | 388/388 (39 files) — nothing downstream broke                                                                                         |
+| Tests (CLI)         | PASS   | 191/191 (20 files) after template hint added                                                                                          |
+| ESLint              | PASS   | `--max-warnings 0` clean on both sources, both test files, and the edited CLI template                                                |
+| Invariants enforced | PASS   | 12/12 — type-level (`SagaAtomicity` union, optional field, `defineSaga` identity) + runtime (`saga.atomicity ?? "atomic"` mode split) |
+| Edge cases covered  | PASS   | All 9 core + all atomicity engine edge cases handled; the 4 mode-specific ones have dedicated tests                                   |
+| Prettier            | PASS   | `--check` clean on all 5 touched doc/CLI files                                                                                        |
+
+### Coherence Review
+
+- **Spec intent alignment**: Faithful — not a technicality pass. `const mode = saga.atomicity ?? "atomic"` (saga-executor.ts:137) realizes BR 7 exactly. The **atomic** branch (enlist → dispatch → commit → publish, all inside `uowStorage.run`) matches BRs 8–14; the **best-effort** branch (enlist → commit → publish inside `uowStorage.run`, then dispatch _outside_ it but inside `metadataStorage.run`) matches BRs 15–18. I cross-checked the mechanism against `CommandLifecycleExecutor` (`ownsUow = !this.uowStorage.getStore()`, line 100–121): placing command dispatch inside vs. outside `uowStorage.run` is precisely what flips the command executor between the explicit-enlist path (atomic, deferred publish) and the implicit-own-UoW path (best-effort, immediate per-command publish) — the exact behavior the spec relies on. The two issue #119 integration tests prove the observable difference end-to-end through the real `EventEmitterEventBus`.
+- **Unhandled scenarios**: None. Steps 1–6 are shared across modes; all mode-specific edge cases (atomic rollback, best-effort persists-on-failure, best-effort commit-ordering, best-effort resumes #119, atomic drops #119) are covered by tests.
+- **Convention compliance**: Compliant. `SagaAtomicity` is a clean string-literal union with JSDoc; `atomicity?` optional with thorough JSDoc; `defineSaga` stays a pure identity (the "never defaults" invariant holds — core reads the field nowhere; the engine supplies the default at execution time, and `defineSaga atomicity default` test asserts `undefined` + reference identity). No `console.*` (uses injected `Logger`). Naming (`SagaAtomicity`, `define*`, `Infer*`) consistent.
+- **Breaking change propagation**: N/A. Additive optional field; absent → `atomic` preserves prior behavior. No `## Migration`/`## Deprecations` sections. Full engine suite (388/388) confirms no downstream breakage. Changesets correct: both `@noddde/core` and `@noddde/engine` as **minor** (additive), with accurate notes.
+
+### Documentation
+
+- **Pages updated**: 4
+  - `docs/content/docs/process-managers/sagas.mdx` — new **Atomicity** section (mode table, declarative-field callout, "When to use best-effort", golden-path note, issue #119 link). Code snippet verified type-correct against the new API.
+  - `docs/content/docs/design-decisions/why-sagas-return-commands.mdx` — refined the **Atomicity** subsection to reference the two modes; added a new **The Golden Path: Return Events, Don't Dispatch Them** section with a warn callout covering the off-path `eventBus.dispatch()` risk and the `best-effort` escape hatch (issue #119).
+  - `docs/content/docs/testing/testing-sagas.mdx` — new **Atomicity Mode and testSaga** note clarifying that `atomicity` does not affect `testSaga` (handler-isolation harness); points to `testDomain` for mode-dependent behavior.
+  - `docs/content/docs/running/persistence.mdx` — made the **Saga Unit of Work** section mode-aware (it previously described only atomic coupling, which became incomplete after this change). Not in the spec's `docs` mapping, but fixed to avoid doc staleness.
+- **Pages created**: 0
+- **API reference updated**: 0 — there is no dedicated API-reference page for sagas under `docs/content/docs/api/`; the API surface is documented inline in the conceptual pages above. `docs/public/llms.txt` already lists all three mapped pages with descriptions that remain accurate (no pages created/renamed/deleted), so no `llms.txt` edit was required.
+
+### CLI Template
+
+- `packages/cli/src/templates/saga/saga.ts` — added a commented `// atomicity: "best-effort",` hint with a two-line explanation inside the `defineSaga` config, matching the template's existing commented-TODO style. The scaffold still works without it (optional field, `atomic` default). CLI tests (191/191) and ESLint remain clean; the existing negative assertions (`.not.toContain("associations:")` / `"handlers:"`) are unaffected.
+
+### Notes (non-blocking; pre-existing, NOT introduced by this change)
+
+1. **Builder-flagged spec/test drift**: `specs/engine/executors/saga-executor.spec.md` contains a Test Scenario "saga handler failure is isolated from sibling subscribers" (a `wireDomain` integration test) that is absent from `saga-executor.test.ts`. Confirmed absent. It predates this change and is unrelated to atomicity. Worth a separate follow-up to either add the test or move the scenario, but not grounds to FAIL this change.
+2. **Under-specified pre-existing core test**: in `packages/core/src/__tests__/ddd/saga.test.ts`, the `SagaEventHandler` block's "should receive infrastructure merged with CQRSInfrastructure" (lines 162–166) asserts only `MyInfra & CQRSInfrastructure`, omitting `FrameworkInfrastructure`, whereas the spec/source merge all three (saga.ts:122–124). It still compiles (the assertion is a structural subset that the type-checker accepts here) and the `InferSagaEventHandler` block (lines 379–384) tests the full three-way intersection correctly. Pre-existing, unrelated to atomicity; a minor cleanup candidate for a future pass.

--- a/specs/reports/saga-atomicity.build-report.md
+++ b/specs/reports/saga-atomicity.build-report.md
@@ -1,0 +1,54 @@
+## Build Report: per-saga `atomicity` configuration
+
+- **Specs**:
+  - `specs/core/ddd/saga.spec.md` (new `SagaAtomicity` export + optional `atomicity?` field)
+  - `specs/engine/executors/saga-executor.spec.md` (mode-branching behavior)
+- **Sources**:
+  - `packages/core/src/ddd/saga.ts`
+  - `packages/engine/src/executors/saga-executor.ts`
+- **Tests**:
+  - `packages/core/src/__tests__/ddd/saga.test.ts` (+3 describe blocks / +5 `it`s, appended)
+  - `packages/engine/src/__tests__/engine/executors/saga-executor.test.ts` (+4 `it`s, appended)
+- **Result**: GREEN
+- **Tests passing**: core 35/35; engine saga-executor 12/12; full engine suite 388/388 (39 files)
+- **Loop count**: 1 (tests passed on first implementation; no RED→GREEN repair loops)
+- **Changesets**: `.changeset/saga-atomicity-core.md` (`@noddde/core` minor), `.changeset/saga-atomicity-engine.md` (`@noddde/engine` minor)
+
+### Implementation summary
+
+- **Core**: added `export type SagaAtomicity = "atomic" | "best-effort"` and an optional `atomicity?: SagaAtomicity` field on the `Saga` interface, both with JSDoc. `defineSaga` is unchanged (pure identity — does not read/validate/default the field). Surfaces via `@noddde/core` through the existing `export * from "./saga"` barrel.
+- **Engine**: `SagaExecutor.execute()` now resolves `const mode = saga.atomicity ?? "atomic"` and branches:
+  - **atomic** (default) — unchanged: one UoW spans saga-state save + all reaction commands (enlist → dispatch → commit → publish), rollback-and-rethrow on failure.
+  - **best-effort** — commit the saga-state UoW first (enlist → commit → publish), then dispatch reaction commands outside `uowStorage` but inside `metadataStorage` (each command gets its own UoW via `CommandLifecycleExecutor`). A post-commit command failure propagates without rolling back saga state. Reuses PR #120's reorder.
+  - Shared helpers `commitAndPublish` / `dispatchCommands` / `failCommitPhase` keep both branches DRY; instrumentation (`withSpan`/`withExtractedContext`) and the `onEventsDispatched` callback are preserved in both.
+
+### Test Results (new scenarios)
+
+| Test                                                                                          | Status |
+| --------------------------------------------------------------------------------------------- | ------ |
+| core: Saga atomicity field › types SagaAtomicity as the union                                 | PASS   |
+| core: Saga atomicity field › exposes atomicity as optional SagaAtomicity on Saga              | PASS   |
+| core: defineSaga atomicity › preserves explicit best-effort                                   | PASS   |
+| core: defineSaga atomicity › preserves explicit atomic                                        | PASS   |
+| core: defineSaga atomicity default › omitted stays undefined (identity preserved)             | PASS   |
+| engine: best-effort › persists saga state even when a command throws                          | PASS   |
+| engine: best-effort (commit ordering) › state committed before command handler runs           | PASS   |
+| engine: best-effort (issue #119) › resumes saga when command handler dispatches consumed evt  | PASS   |
+| engine: atomic (issue #119 limitation) › drops command-handler-dispatched event (stays proc.) | PASS   |
+| engine: (existing) rolls back UoW and not persist state when command throws — still PASS      | PASS   |
+
+### Validation gates
+
+- `tsc --noEmit`: core exit 0; engine exit 0 (engine type-check requires `@noddde/core` `dist` to be built first — turbo handles this in CI; built locally via `tsup` for verification).
+- ESLint `--max-warnings 0` on all four touched files: exit 0.
+- Prettier `--check`: all touched files clean.
+
+### Concerns
+
+1. **Pre-existing spec/test drift (NOT introduced here)**: `specs/engine/executors/saga-executor.spec.md` contains a Test Scenario "saga handler failure is isolated from sibling subscribers" (a `wireDomain` integration test using `domain.commandBus`) that is **absent** from the generated test file `saga-executor.test.ts`. It predates this change; I did not add it (it may not compile against the current `Domain` surface, which exposes buses via `domain.infrastructure`). Flagging for the Auditor — out of scope for this change, but worth a follow-up.
+2. **Environment note for the Auditor**: this is a fresh worktree; `yarn`/`npx tsc` are unreliable here (mise yarn shim has no version; `~/.npmrc` needs `${CODEARTIFACT_AUTH_TOKEN}` which isn't in the sandbox shell). Run tooling via the hoisted binaries directly: `node_modules/.bin/tsc`, `node_modules/.bin/vitest`, `node_modules/.bin/eslint`. `@noddde/core` `dist` has already been built (`packages/core/dist`), so engine `tsc --noEmit` resolves the new types.
+
+### Not done (Auditor's scope)
+
+- Documentation updates (`docs/content/docs/process-managers/sagas.mdx`, `testing/testing-sagas.mdx`, `design-decisions/why-sagas-return-commands.mdx`).
+- CLI saga-template assessment (`packages/cli/src/templates/saga/saga.ts`).


### PR DESCRIPTION
> **📚 Stacked on #120.** This PR's base is `saga-uow-commit-ordering` — a mirror of #120's head (`bd2172d`) in this repo — so the diff below is **only the commits added on top of #120**. Merge after #120 lands, or retarget this PR's base to `main` once #120 is merged.

## What this adds on top of #120

#120 fixes the saga event-loss race (#119) by committing saga state before dispatching reaction commands. This PR turns that into an explicit, **per-saga** choice instead of changing the transactional contract for everyone:

```ts
defineSaga({
  atomicity: "atomic" | "best-effort", // optional; defaults to "atomic"
  // ...existing fields
});
```

- **`atomic`** _(default)_ — today's behavior, restored as the default: the saga's unit of work spans the state save and all reaction commands; they commit or roll back together. Correct as long as command-produced events come from aggregate deciders that **return** events (the golden path).
- **`best-effort`** — #120's behavior: commit saga state first, then dispatch reaction commands outside the UoW (each in its own UoW). Command handlers that publish events **directly** via the event bus — and the re-entrant saga executions they trigger — observe the committed state, fixing the silent event loss in #119. Trade-off: a reaction-command failure no longer rolls back the saga-state transition.

An absent `atomicity` field behaves exactly as before, so **existing sagas are unaffected**.

## Why a per-saga option instead of #120's unconditional change

#120's commit-first ordering is correct for off-path dispatch, but it silently removes cross-command rollback for **everyone**. The two camps genuinely want different things:

- **Standalone command handlers** have no "return events" channel — direct `eventBus.dispatch()` is their only option, so they need `best-effort`.
- Sagas whose commands target aggregate deciders that **return** events want `atomic` (the engine defers + publishes those events only after commit, so the guarantee already holds).

Making it per-saga keeps the atomicity guarantee for those who want it and gives an honest, documented escape hatch for the off-path cases — which is what #119 surfaced.

## Changes

- **`@noddde/core`** — new `SagaAtomicity` type + optional `Saga.atomicity` field. `defineSaga` stays a pure identity function (the field is declarative; the engine applies the default).
- **`@noddde/engine`** — `SagaExecutor` branches on `saga.atomicity ?? "atomic"`: `best-effort` reuses #120's reorder; `atomic` is the prior single-UoW flow. Instrumentation/rollback semantics preserved.
- **Specs** — `specs/core/ddd/saga.spec.md` and `specs/engine/executors/saga-executor.spec.md` updated for both modes (requirements, invariants, edge cases) including the #119 scenario in each mode.
- **Docs** — atomicity option on the sagas page, plus a golden-path note: deciders/aggregates **return** events (the engine publishes them after commit); manual `eventBus.dispatch()` from a decider/handler is off the golden path and loses ordering/atomicity unless the saga is `best-effort`.
- **CLI** — commented `atomicity` hint in the saga scaffold.
- **Changesets** — `@noddde/core` + `@noddde/engine` (both `minor`).

## Verification

- `tsc --noEmit`: core + engine clean.
- Tests: core **35/35**, full engine **388/388** (default-`atomic` preserves every existing behavior), CLI **191/191**.
- The existing "rollback when a command throws" test keeps asserting rollback (default `atomic`); a new `best-effort` test asserts the state **persists**; the #119 reproduction passes under `best-effort` and is shown to still drop the event under `atomic` (documented limitation of `atomic`).

Resolves the #119 design discussion, building on @nilo85's work in #120.
